### PR TITLE
Route address enrichment through pf-query

### DIFF
--- a/crates/pf-query/src/dto.rs
+++ b/crates/pf-query/src/dto.rs
@@ -796,6 +796,9 @@ impl TransactionV3 {
     pub fn tx_type(&self) -> &'static str {
         self.variant.tx_type()
     }
+    pub fn calldata(&self) -> &[MinimalFelt] {
+        self.variant.calldata()
+    }
 }
 
 impl From<TransactionVariantV2> for TransactionVariantV3 {
@@ -900,6 +903,30 @@ impl TransactionVariantV3 {
             Self::InvokeV4(_) => "INVOKE_V4",
             Self::InvokeV5(_) => "INVOKE_V5",
             Self::L1HandlerV0(_) => "L1_HANDLER",
+        }
+    }
+
+    /// The calldata payload for this tx. Invoke txs carry the multicall
+    /// calldata; L1Handler and DeployAccount carry their constructor/entry
+    /// calldata. Declare/Deploy have no calldata payload → empty slice.
+    pub fn calldata(&self) -> &[MinimalFelt] {
+        match self {
+            Self::InvokeV0(tx) => &tx.calldata,
+            Self::InvokeV1(tx) => &tx.calldata,
+            Self::InvokeV3(tx) => &tx.calldata,
+            Self::InvokeV4(tx) => &tx.calldata,
+            Self::InvokeV5(tx) => &tx.calldata,
+            Self::L1HandlerV0(tx) => &tx.calldata,
+            Self::DeployV0(tx) => &tx.constructor_calldata,
+            Self::DeployV1(tx) => &tx.constructor_calldata,
+            Self::DeployAccountV1(tx) => &tx.constructor_calldata,
+            Self::DeployAccountV3(tx) => &tx.constructor_calldata,
+            Self::DeployAccountV4(tx) => &tx.constructor_calldata,
+            Self::DeclareV0(_)
+            | Self::DeclareV1(_)
+            | Self::DeclareV2(_)
+            | Self::DeclareV3(_)
+            | Self::DeclareV4(_) => &[],
         }
     }
 }

--- a/crates/pf-query/src/main.rs
+++ b/crates/pf-query/src/main.rs
@@ -150,11 +150,21 @@ struct SenderTxEntry {
 struct ContractEvent {
     tx_index: usize,
     event_index: usize,
+    tx_hash: String,
     from_address: String,
     keys: Vec<String>,
     data: Vec<String>,
     block_number: u64,
     timestamp: u64,
+}
+
+/// Paginated response for /contract-events.
+#[derive(Serialize)]
+struct ContractEventsResponse {
+    events: Vec<ContractEvent>,
+    /// If set, the caller should pass this as `to_block` (inclusive upper bound)
+    /// on the next request to continue newest-first pagination.
+    continuation_token: Option<u64>,
 }
 
 // =========================================================================
@@ -173,8 +183,20 @@ struct SenderTxParams {
 
 #[derive(Deserialize)]
 struct ContractEventsParams {
+    /// Inclusive lower block bound. Default 0 (scan whole chain).
     from_block: Option<u64>,
+    /// Inclusive upper block bound. Default = latest block.
+    to_block: Option<u64>,
+    /// Key filter: positional groups separated by `;`, OR-keys within a group by `,`.
+    /// An empty group is a wildcard for that position. Example:
+    /// `keys=0x3db...,0x0af...;;0xc2f...` means
+    ///   (key[0] IN {0x3db, 0x0af}) AND (key[2] == 0xc2f).
+    keys: Option<String>,
+    /// Max events per page. Clamped to 5000.
     limit: Option<u32>,
+    /// Pagination: inclusive upper bound for the next page (newest-first).
+    /// Takes precedence over `to_block`.
+    continuation_token: Option<u64>,
 }
 
 // =========================================================================
@@ -550,16 +572,81 @@ async fn handler_sender_txs(
     Ok(Json(results))
 }
 
+/// Parse the `keys` query-param into positional filter groups.
+///
+/// Format: groups separated by `;`, OR-keys within a group by `,`.
+/// An empty group means "no filter" for that position.
+/// Each key is a hex string (0x-prefixed optional). Returns an error for
+/// malformed hex; silently tolerates extra whitespace.
+fn parse_keys_filter(raw: &str) -> Result<Vec<Vec<[u8; 32]>>, String> {
+    let mut groups = Vec::new();
+    for group_str in raw.split(';') {
+        let group_str = group_str.trim();
+        let mut group = Vec::new();
+        if !group_str.is_empty() {
+            for key_str in group_str.split(',') {
+                let key_str = key_str.trim();
+                if key_str.is_empty() {
+                    continue;
+                }
+                let bytes = parse_address(key_str)
+                    .map_err(|e| format!("Invalid key in filter: {e}"))?;
+                let arr: [u8; 32] = bytes
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| "key must decode to 32 bytes".to_string())?;
+                group.push(arr);
+            }
+        }
+        groups.push(group);
+    }
+    Ok(groups)
+}
+
+/// Check an event's keys against a positional filter.
+///
+/// Each group in `filter` constrains the key at that position:
+/// - empty group = no constraint
+/// - non-empty group = event.keys[i] must be one of the listed values
+///
+/// Groups beyond the event's key count fail the match (can't satisfy a
+/// required position that doesn't exist).
+fn event_keys_match(event_keys: &[dto::MinimalFelt], filter: &[Vec<[u8; 32]>]) -> bool {
+    for (i, group) in filter.iter().enumerate() {
+        if group.is_empty() {
+            continue;
+        }
+        let ek = match event_keys.get(i) {
+            Some(k) => &k.0,
+            None => return false,
+        };
+        if !group.iter().any(|g| g == ek) {
+            return false;
+        }
+    }
+    true
+}
+
 /// GET /contract-events/{address} — events emitted by a contract, accelerated by bloom filters.
 ///
-/// Uses the `event_filters` bloom filter table to identify candidate blocks,
-/// then decodes only those blocks' event blobs (instead of scanning every block).
+/// Pagination: newest-first. When more events may exist below the oldest returned
+/// block, the response includes `continuation_token = Some(next_to_block)`; the
+/// caller passes that back on the next request to continue.
+///
+/// Key filter: see `ContractEventsParams::keys`.
 async fn handler_contract_events(
     Path(address): Path<String>,
     Query(params): Query<ContractEventsParams>,
     State(state): State<AppState>,
-) -> ApiResult<Vec<ContractEvent>> {
-    let limit = params.limit.unwrap_or(200).min(1000) as usize;
+) -> ApiResult<ContractEventsResponse> {
+    // Cap per-page events. Bigger than before since pagination handles the rest.
+    let limit = params.limit.unwrap_or(500).min(5000) as usize;
+
+    // Per-request safety cap on candidate blocks, to bound latency on
+    // very dense contracts. If the bloom-filter candidate set exceeds this,
+    // we process the newest MAX_CANDIDATES and return a continuation token.
+    const MAX_CANDIDATES: usize = 10_000;
+
     let addr_bytes = parse_address(&address)
         .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid address: {e}")))?;
 
@@ -568,9 +655,14 @@ async fn handler_contract_events(
         .try_into()
         .map_err(|_| (StatusCode::BAD_REQUEST, "Address must be 32 bytes".into()))?;
 
+    let keys_filter: Vec<Vec<[u8; 32]>> = match params.keys.as_deref() {
+        Some(raw) => parse_keys_filter(raw).map_err(|e| (StatusCode::BAD_REQUEST, e))?,
+        None => Vec::new(),
+    };
+
     let conn = open_db(&state.db_path).map_err(db_err)?;
 
-    // Get latest block
+    // Resolve block range.
     let latest_block: u64 = conn
         .query_row(
             "SELECT number FROM block_headers ORDER BY number DESC LIMIT 1",
@@ -579,11 +671,22 @@ async fn handler_contract_events(
         )
         .map_err(db_err)?;
 
-    let from_block = params
-        .from_block
-        .unwrap_or(latest_block.saturating_sub(100_000));
+    let from_block = params.from_block.unwrap_or(0);
+    // continuation_token takes precedence over to_block.
+    let requested_to = params
+        .continuation_token
+        .or(params.to_block)
+        .unwrap_or(latest_block);
+    let effective_to = requested_to.min(latest_block);
 
-    // Step 1: Load bloom filter chunks that overlap our block range
+    if from_block > effective_to {
+        return Ok(Json(ContractEventsResponse {
+            events: Vec::new(),
+            continuation_token: None,
+        }));
+    }
+
+    // Step 1: Bloom-accelerated candidate-block discovery.
     let mut bloom_stmt = conn
         .prepare(
             "SELECT from_block, to_block, bitmap \
@@ -594,9 +697,10 @@ async fn handler_contract_events(
         .map_err(db_err)?;
 
     let mut candidate_blocks: Vec<u64> = Vec::new();
+    let mut max_bloom_covered: Option<u64> = None;
 
     let mut bloom_rows = bloom_stmt
-        .query(rusqlite::params![from_block, latest_block])
+        .query(rusqlite::params![from_block, effective_to])
         .map_err(db_err)?;
 
     while let Some(row) = bloom_rows.next().map_err(db_err)? {
@@ -604,105 +708,139 @@ async fn handler_contract_events(
         let bf_to: u64 = row.get(1).map_err(db_err)?;
         let compressed: Vec<u8> = row.get(2).map_err(db_err)?;
 
+        max_bloom_covered = Some(max_bloom_covered.map_or(bf_to, |m| m.max(bf_to)));
+
         let agg = bloom::AggregateBloom::from_compressed(bf_from, bf_to, &compressed);
         let mut blocks = agg.blocks_for_address(&addr_array);
 
-        // Filter to our requested range
-        blocks.retain(|&b| b >= from_block && b <= latest_block);
+        blocks.retain(|&b| b >= from_block && b <= effective_to);
         candidate_blocks.extend(blocks);
     }
 
-    // Also scan the most recent blocks not yet covered by event_filters
-    // (the "running" filter may not be flushed yet)
-    let max_bloom_block = candidate_blocks.iter().copied().max().unwrap_or(from_block);
-    if max_bloom_block < latest_block {
-        // Add all blocks from max_bloom_block+1 to latest_block (brute scan for recent)
-        let recent_start = max_bloom_block + 1;
-        for b in recent_start..=latest_block {
+    // Blocks above the highest bloom-covered block may exist in the
+    // `running_event_filter` but aren't persisted to `event_filters` yet;
+    // brute-scan them to avoid missing recent events.
+    let brute_scan_start = max_bloom_covered
+        .map(|m| m.saturating_add(1).max(from_block))
+        .unwrap_or(from_block);
+    if brute_scan_start <= effective_to {
+        for b in brute_scan_start..=effective_to {
             candidate_blocks.push(b);
         }
     }
 
-    // Sort descending (most recent first) and deduplicate
+    // Sort desc + dedup so we process newest-first.
     candidate_blocks.sort_unstable_by(|a, b| b.cmp(a));
     candidate_blocks.dedup();
 
-    // Cap candidate blocks to avoid runaway scans on very popular contracts.
-    // Process most recent first; caller can paginate with from_block.
-    const MAX_CANDIDATES: usize = 5000;
+    // Truncate to per-request cap; remember if we truncated.
+    let truncated = candidate_blocks.len() > MAX_CANDIDATES;
     candidate_blocks.truncate(MAX_CANDIDATES);
 
-    // Step 2: Decode event blobs for candidate blocks in batches
-    let mut results = Vec::new();
+    // Step 2: Walk candidates newest-first, decoding events AND transactions
+    // per block (transactions give us tx_hash per tx_index).
+    let mut events_stmt = conn
+        .prepare("SELECT events FROM transactions WHERE block_number = ?1")
+        .map_err(db_err)?;
+    let mut txs_stmt = conn
+        .prepare("SELECT transactions FROM transactions WHERE block_number = ?1")
+        .map_err(db_err)?;
+    let mut ts_stmt = conn
+        .prepare("SELECT timestamp FROM block_headers WHERE number = ?1")
+        .map_err(db_err)?;
 
-    // Process in batches of 500 blocks using an IN clause for efficient DB access
-    for chunk in candidate_blocks.chunks(500) {
-        if results.len() >= limit {
-            break;
+    let mut results: Vec<ContractEvent> = Vec::new();
+    let mut last_processed: Option<u64> = None;
+    let mut hit_limit = false;
+
+    for block_number in &candidate_blocks {
+        let block_number = *block_number;
+        last_processed = Some(block_number);
+
+        let events_blob: Option<Vec<u8>> = events_stmt
+            .query_row(rusqlite::params![block_number], |row| row.get(0))
+            .ok();
+        let Some(events_blob) = events_blob else {
+            continue;
+        };
+
+        let tx_events = match decode::decode_events(&events_blob) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        // Quick address match scan to skip blocks that definitely don't
+        // contain our address (bloom filters have false positives).
+        let any_match = tx_events.iter().any(|evs| {
+            evs.iter().any(|e| {
+                e.from_address.0 == addr_bytes.as_slice()
+                    && event_keys_match(&e.keys, &keys_filter)
+            })
+        });
+        if !any_match {
+            continue;
         }
 
-        let placeholders: String = (0..chunk.len())
-            .map(|i| format!("?{}", i + 1))
-            .collect::<Vec<_>>()
-            .join(",");
-        let sql = format!(
-            "SELECT t.block_number, t.events, bh.timestamp \
-             FROM transactions t \
-             JOIN block_headers bh ON t.block_number = bh.number \
-             WHERE t.block_number IN ({placeholders}) AND t.events IS NOT NULL \
-             ORDER BY t.block_number DESC"
-        );
+        // Need tx hashes for this block.
+        let txs_blob: Option<Vec<u8>> = txs_stmt
+            .query_row(rusqlite::params![block_number], |row| row.get(0))
+            .ok();
+        let tx_hashes: Vec<String> = txs_blob
+            .and_then(|b| decode::decode_transactions(&b).ok())
+            .map(|txs| txs.iter().map(|t| t.transaction.hash.to_hex()).collect())
+            .unwrap_or_default();
 
-        let mut stmt = conn.prepare(&sql).map_err(db_err)?;
-        let params: Vec<Box<dyn rusqlite::types::ToSql>> = chunk
-            .iter()
-            .map(|b| Box::new(*b as i64) as Box<dyn rusqlite::types::ToSql>)
-            .collect();
-        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-            params.iter().map(|b| b.as_ref()).collect();
+        let timestamp: u64 = ts_stmt
+            .query_row(rusqlite::params![block_number], |row| row.get(0))
+            .unwrap_or(0);
 
-        let mut rows = stmt.query(param_refs.as_slice()).map_err(db_err)?;
-
-        while let Some(row) = rows.next().map_err(db_err)? {
-            if results.len() >= limit {
-                break;
-            }
-
-            let block_number: u64 = row.get(0).map_err(db_err)?;
-            let events_blob: Vec<u8> = row.get(1).map_err(db_err)?;
-            let timestamp: u64 = row.get(2).map_err(db_err)?;
-
-            let tx_events = match decode::decode_events(&events_blob) {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
-
-            for (tx_idx, events) in tx_events.iter().enumerate() {
-                for (ev_idx, event) in events.iter().enumerate() {
-                    if event.from_address.0 == addr_bytes.as_slice() {
-                        results.push(ContractEvent {
-                            tx_index: tx_idx,
-                            event_index: ev_idx,
-                            from_address: event.from_address.to_hex(),
-                            keys: event.keys.iter().map(|k| k.to_hex()).collect(),
-                            data: event.data.iter().map(|d| d.to_hex()).collect(),
-                            block_number,
-                            timestamp,
-                        });
-
-                        if results.len() >= limit {
-                            break;
-                        }
-                    }
+        // Collect ALL matching events in this block before checking the limit,
+        // so pagination boundaries land cleanly on block boundaries.
+        for (tx_idx, events) in tx_events.iter().enumerate() {
+            for (ev_idx, event) in events.iter().enumerate() {
+                if event.from_address.0 != addr_bytes.as_slice() {
+                    continue;
                 }
-                if results.len() >= limit {
-                    break;
+                if !event_keys_match(&event.keys, &keys_filter) {
+                    continue;
                 }
+                let tx_hash = tx_hashes
+                    .get(tx_idx)
+                    .cloned()
+                    .unwrap_or_else(|| "0x0".to_string());
+                results.push(ContractEvent {
+                    tx_index: tx_idx,
+                    event_index: ev_idx,
+                    tx_hash,
+                    from_address: event.from_address.to_hex(),
+                    keys: event.keys.iter().map(|k| k.to_hex()).collect(),
+                    data: event.data.iter().map(|d| d.to_hex()).collect(),
+                    block_number,
+                    timestamp,
+                });
             }
+        }
+
+        if results.len() >= limit {
+            hit_limit = true;
+            break;
         }
     }
 
-    Ok(Json(results))
+    // Compute continuation token.
+    let continuation_token = if hit_limit || truncated {
+        // More to scan: next page should start at (last_processed - 1).
+        last_processed
+            .and_then(|b| b.checked_sub(1))
+            .filter(|&b| b >= from_block)
+    } else {
+        None
+    };
+
+    Ok(Json(ContractEventsResponse {
+        events: results,
+        continuation_token,
+    }))
 }
 
 // =========================================================================

--- a/crates/pf-query/src/main.rs
+++ b/crates/pf-query/src/main.rs
@@ -3,7 +3,7 @@ use axum::{
     Json, Router,
     extract::{Path, Query, State},
     http::StatusCode,
-    routing::get,
+    routing::{get, post},
 };
 use clap::Parser;
 use rusqlite::{Connection, OpenFlags};
@@ -130,6 +130,32 @@ struct DecodedTx {
     revert_reason: Option<String>,
 }
 
+/// Per-tx response for `/txs-by-hash` — includes calldata so the client can
+/// decode multicalls/endpoint names without a separate RPC round trip.
+#[derive(Serialize)]
+struct TxByHashEntry {
+    hash: String,
+    block_number: u64,
+    block_timestamp: u64,
+    tx_index: u64,
+    sender: String,
+    nonce: Option<u64>,
+    tx_type: String,
+    /// Calldata as `0x`-prefixed hex felts, matching RPC `InvokeTransaction.calldata`.
+    calldata: Vec<String>,
+    actual_fee: String,
+    tip: u64,
+    status: String,
+    revert_reason: Option<String>,
+}
+
+/// Entry for `/block-timestamps`.
+#[derive(Serialize)]
+struct BlockTimestampEntry {
+    block_number: u64,
+    timestamp: u64,
+}
+
 /// Full transaction summary combining nonce_updates + blob decode.
 #[derive(Serialize)]
 struct SenderTxEntry {
@@ -180,6 +206,27 @@ struct NonceHistoryParams {
 struct SenderTxParams {
     limit: Option<u32>,
 }
+
+#[derive(Deserialize)]
+struct TxsByHashRequest {
+    hashes: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct BlockTimestampsParams {
+    from: u64,
+    to: u64,
+}
+
+/// Server-side cap on how many hashes a single /txs-by-hash POST may include.
+/// Generous enough that one enrichment run of ~1000 missing endpoints is a
+/// single request, while bounding memory and decode CPU per request.
+const TXS_BY_HASH_MAX: usize = 10_000;
+
+/// Server-side cap on how many blocks a single /block-timestamps request may
+/// span. 50_000 ≈ ~3 days at 5s block time; the underlying SQL is a single
+/// indexed range scan so this is cheap.
+const BLOCK_TIMESTAMPS_MAX_SPAN: u64 = 50_000;
 
 #[derive(Deserialize)]
 struct ContractEventsParams {
@@ -446,6 +493,197 @@ async fn handler_block_txs(
     Ok(Json(results))
 }
 
+/// POST /txs-by-hash — bulk lookup of tx + receipt data by hash.
+///
+/// Groups input hashes by block_number (single SELECT on `transaction_hashes`),
+/// decompresses each block's `transactions` blob at most once, and returns
+/// calldata + sender + nonce + fee + status + timestamp per tx. This offloads
+/// the address-view enrichment path from Starknet RPC.
+///
+/// Missing hashes are silently omitted from the response. Caller should
+/// diff requested vs returned hashes to decide fallback behavior.
+async fn handler_txs_by_hash(
+    State(state): State<AppState>,
+    Json(req): Json<TxsByHashRequest>,
+) -> ApiResult<Vec<TxByHashEntry>> {
+    if req.hashes.is_empty() {
+        return Ok(Json(vec![]));
+    }
+    if req.hashes.len() > TXS_BY_HASH_MAX {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Too many hashes: {} (max {})",
+                req.hashes.len(),
+                TXS_BY_HASH_MAX
+            ),
+        ));
+    }
+
+    // Parse all hashes up front; reject the whole request on a bad one.
+    let mut wanted: Vec<(Vec<u8>, String)> = Vec::with_capacity(req.hashes.len());
+    for h in &req.hashes {
+        let bytes = parse_address(h)
+            .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid hash {h}: {e}")))?;
+        wanted.push((bytes, h.clone()));
+    }
+
+    let conn = open_db(&state.db_path).map_err(db_err)?;
+
+    // Step 1: map each hash → (block_number, idx). One SELECT per hash (fast,
+    // indexed lookup). The transaction_hashes table is keyed on hash so these
+    // are O(log N) B-tree lookups — no wildcard scan.
+    let mut lookup_stmt = conn
+        .prepare("SELECT block_number, idx FROM transaction_hashes WHERE hash = ?1")
+        .map_err(db_err)?;
+
+    // (block_number, tx_idx_in_block, original_hash_hex)
+    let mut locations: Vec<(u64, u64, String)> = Vec::with_capacity(wanted.len());
+    for (hash_bytes, hash_hex) in &wanted {
+        match lookup_stmt.query_row(rusqlite::params![hash_bytes.as_slice()], |row| {
+            Ok((row.get::<_, u64>(0)?, row.get::<_, u64>(1)?))
+        }) {
+            Ok((block_number, idx)) => locations.push((block_number, idx, hash_hex.clone())),
+            Err(rusqlite::Error::QueryReturnedNoRows) => continue,
+            Err(e) => return Err(db_err(e)),
+        }
+    }
+
+    if locations.is_empty() {
+        return Ok(Json(vec![]));
+    }
+
+    // Step 2: fetch block timestamps and decode each distinct block blob once.
+    // We decode lazily so blocks with no requested txs are skipped (they won't
+    // appear in `locations`).
+    let mut tx_blob_stmt = conn
+        .prepare("SELECT transactions FROM transactions WHERE block_number = ?1")
+        .map_err(db_err)?;
+    let mut timestamp_stmt = conn
+        .prepare("SELECT timestamp FROM block_headers WHERE number = ?1")
+        .map_err(db_err)?;
+
+    let mut decoded_cache: std::collections::HashMap<u64, Vec<dto::TransactionWithReceiptV4>> =
+        std::collections::HashMap::new();
+    let mut timestamp_cache: std::collections::HashMap<u64, u64> = std::collections::HashMap::new();
+
+    let mut results: Vec<TxByHashEntry> = Vec::with_capacity(locations.len());
+    for (block_number, tx_idx, hash_hex) in &locations {
+        // Decode the block blob on first touch.
+        if !decoded_cache.contains_key(block_number) {
+            let blob: Vec<u8> =
+                match tx_blob_stmt.query_row(rusqlite::params![block_number], |row| row.get(0)) {
+                    Ok(b) => b,
+                    Err(_) => continue,
+                };
+            let decoded = match decode::decode_transactions(&blob) {
+                Ok(d) => d,
+                Err(e) => {
+                    tracing::warn!(block = block_number, error = %e, "Failed to decode tx blob");
+                    continue;
+                }
+            };
+            decoded_cache.insert(*block_number, decoded);
+        }
+        if !timestamp_cache.contains_key(block_number) {
+            let ts: u64 =
+                match timestamp_stmt.query_row(rusqlite::params![block_number], |row| row.get(0)) {
+                    Ok(t) => t,
+                    Err(_) => continue,
+                };
+            timestamp_cache.insert(*block_number, ts);
+        }
+
+        let txs = &decoded_cache[block_number];
+        let timestamp = timestamp_cache[block_number];
+
+        let tr = match txs.get(*tx_idx as usize) {
+            Some(t) => t,
+            None => continue,
+        };
+
+        let (status, revert_reason) = match &tr.receipt.execution_status {
+            dto::ExecutionStatus::Succeeded => ("OK".to_string(), None),
+            dto::ExecutionStatus::Reverted { reason } => ("REV".to_string(), Some(reason.clone())),
+        };
+
+        let calldata: Vec<String> = tr
+            .transaction
+            .calldata()
+            .iter()
+            .map(|f| f.to_hex())
+            .collect();
+
+        results.push(TxByHashEntry {
+            hash: hash_hex.clone(),
+            block_number: *block_number,
+            block_timestamp: timestamp,
+            tx_index: *tx_idx,
+            sender: tr
+                .transaction
+                .variant
+                .sender_address()
+                .map(|a| a.to_hex())
+                .unwrap_or_default(),
+            nonce: tr.transaction.nonce(),
+            tx_type: tr.transaction.tx_type().to_string(),
+            calldata,
+            actual_fee: tr.receipt.actual_fee.to_hex(),
+            tip: tr.transaction.tip(),
+            status,
+            revert_reason,
+        });
+    }
+
+    Ok(Json(results))
+}
+
+/// GET /block-timestamps?from=N&to=M — bulk fetch block timestamps in range.
+///
+/// Single indexed range scan on `block_headers.number`. Replaces the per-block
+/// RPC round trip in snbeat's `backfill_timestamps`.
+async fn handler_block_timestamps(
+    Query(params): Query<BlockTimestampsParams>,
+    State(state): State<AppState>,
+) -> ApiResult<Vec<BlockTimestampEntry>> {
+    if params.to < params.from {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("to ({}) must be >= from ({})", params.to, params.from),
+        ));
+    }
+    let span = params.to - params.from + 1;
+    if span > BLOCK_TIMESTAMPS_MAX_SPAN {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Range too large: {} blocks (max {})",
+                span, BLOCK_TIMESTAMPS_MAX_SPAN
+            ),
+        ));
+    }
+
+    let conn = open_db(&state.db_path).map_err(db_err)?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT number, timestamp FROM block_headers \
+             WHERE number BETWEEN ?1 AND ?2 ORDER BY number",
+        )
+        .map_err(db_err)?;
+    let entries: Vec<BlockTimestampEntry> = stmt
+        .query_map(rusqlite::params![params.from, params.to], |row| {
+            Ok(BlockTimestampEntry {
+                block_number: row.get(0)?,
+                timestamp: row.get(1)?,
+            })
+        })
+        .map_err(db_err)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(db_err)?;
+
+    Ok(Json(entries))
+}
+
 /// GET /sender-txs/{address} — full tx history for an account via nonce_updates + blob decode.
 ///
 /// Combines nonce_updates (to find blocks) with transaction blob decoding
@@ -589,8 +827,8 @@ fn parse_keys_filter(raw: &str) -> Result<Vec<Vec<[u8; 32]>>, String> {
                 if key_str.is_empty() {
                     continue;
                 }
-                let bytes = parse_address(key_str)
-                    .map_err(|e| format!("Invalid key in filter: {e}"))?;
+                let bytes =
+                    parse_address(key_str).map_err(|e| format!("Invalid key in filter: {e}"))?;
                 let arr: [u8; 32] = bytes
                     .as_slice()
                     .try_into()
@@ -656,9 +894,8 @@ fn process_candidate_block(
     // Fast rejection scan: bloom filters have false positives, so most
     // candidate blocks will have no match.
     let any_match = tx_events.iter().any(|evs| {
-        evs.iter().any(|e| {
-            e.from_address.0 == addr_bytes && event_keys_match(&e.keys, keys_filter)
-        })
+        evs.iter()
+            .any(|e| e.from_address.0 == addr_bytes && event_keys_match(&e.keys, keys_filter))
     });
     if !any_match {
         return;
@@ -962,7 +1199,9 @@ async fn main() -> Result<()> {
             get(handler_class_declaration),
         )
         .route("/tx-by-hash/{hash}", get(handler_tx_by_hash))
+        .route("/txs-by-hash", post(handler_txs_by_hash))
         .route("/block-txs/{block_number}", get(handler_block_txs))
+        .route("/block-timestamps", get(handler_block_timestamps))
         .route("/sender-txs/{address}", get(handler_sender_txs))
         .route("/contract-events/{address}", get(handler_contract_events))
         .with_state(state)
@@ -974,4 +1213,112 @@ async fn main() -> Result<()> {
     axum::serve(listener, app).await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dto::MinimalFelt;
+
+    fn felt(hex_last_byte: u8) -> [u8; 32] {
+        let mut out = [0u8; 32];
+        out[31] = hex_last_byte;
+        out
+    }
+
+    fn mfelt(hex_last_byte: u8) -> MinimalFelt {
+        MinimalFelt(felt(hex_last_byte))
+    }
+
+    // ----- parse_keys_filter --------------------------------------------------
+
+    #[test]
+    fn parse_keys_filter_single_group_single_key() {
+        let parsed = parse_keys_filter("0x1").unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0], vec![felt(1)]);
+    }
+
+    #[test]
+    fn parse_keys_filter_or_within_group() {
+        let parsed = parse_keys_filter("0x1,0x2").unwrap();
+        assert_eq!(parsed, vec![vec![felt(1), felt(2)]]);
+    }
+
+    #[test]
+    fn parse_keys_filter_positional_groups() {
+        let parsed = parse_keys_filter("0x1;;0x3").unwrap();
+        assert_eq!(parsed.len(), 3);
+        assert_eq!(parsed[0], vec![felt(1)]);
+        assert!(parsed[1].is_empty(), "empty group is a wildcard");
+        assert_eq!(parsed[2], vec![felt(3)]);
+    }
+
+    #[test]
+    fn parse_keys_filter_tolerates_whitespace_and_empty_tail() {
+        // Trailing comma / empty slot is tolerated rather than producing a
+        // phantom zero key — caller typos shouldn't silently match 0x0.
+        let parsed = parse_keys_filter(" 0x1 , 0x2 ;0x3, ").unwrap();
+        assert_eq!(parsed, vec![vec![felt(1), felt(2)], vec![felt(3)]]);
+    }
+
+    #[test]
+    fn parse_keys_filter_rejects_bad_hex() {
+        let err = parse_keys_filter("0xZZZ").unwrap_err();
+        assert!(err.contains("Invalid key"), "err was: {err}");
+    }
+
+    // ----- event_keys_match ---------------------------------------------------
+
+    #[test]
+    fn event_keys_match_empty_filter_matches_anything() {
+        let keys = vec![mfelt(1), mfelt(2)];
+        assert!(event_keys_match(&keys, &[]));
+    }
+
+    #[test]
+    fn event_keys_match_empty_group_is_wildcard() {
+        let keys = vec![mfelt(1), mfelt(2), mfelt(3)];
+        // [*, *, 0x3]
+        let filter = vec![vec![], vec![], vec![felt(3)]];
+        assert!(event_keys_match(&keys, &filter));
+    }
+
+    #[test]
+    fn event_keys_match_exact_positional() {
+        let keys = vec![mfelt(0xAA), mfelt(0xBB)];
+        let filter = vec![vec![felt(0xAA)], vec![felt(0xBB)]];
+        assert!(event_keys_match(&keys, &filter));
+    }
+
+    #[test]
+    fn event_keys_match_or_within_group() {
+        let keys = vec![mfelt(0xBB)];
+        let filter = vec![vec![felt(0xAA), felt(0xBB), felt(0xCC)]];
+        assert!(event_keys_match(&keys, &filter));
+    }
+
+    #[test]
+    fn event_keys_match_mismatch_rejects() {
+        let keys = vec![mfelt(0xAA), mfelt(0xBB)];
+        let filter = vec![vec![felt(0xAA)], vec![felt(0xCC)]];
+        assert!(!event_keys_match(&keys, &filter));
+    }
+
+    #[test]
+    fn event_keys_match_longer_filter_than_event_is_reject() {
+        // Filter requires a key at position 2, event only has 2 keys → no match.
+        let keys = vec![mfelt(0xAA), mfelt(0xBB)];
+        let filter = vec![vec![felt(0xAA)], vec![felt(0xBB)], vec![felt(0xCC)]];
+        assert!(!event_keys_match(&keys, &filter));
+    }
+
+    #[test]
+    fn event_keys_match_trailing_wildcard_ignored() {
+        // Wildcard (empty) groups don't look at event_keys, so a trailing
+        // wildcard beyond the event's key count is harmless.
+        let keys = vec![mfelt(0xAA)];
+        let filter = vec![vec![felt(0xAA)], vec![]];
+        assert!(event_keys_match(&keys, &filter));
+    }
 }

--- a/crates/pf-query/src/main.rs
+++ b/crates/pf-query/src/main.rs
@@ -627,6 +627,82 @@ fn event_keys_match(event_keys: &[dto::MinimalFelt], filter: &[Vec<[u8; 32]>]) -
     true
 }
 
+/// Decode events for a single block and append matching ones to `results`.
+///
+/// Shared between the brute-scan phase and the bloom-walk phase. Silently
+/// skips blocks with no blob or with decode errors — bloom filters have
+/// false positives, so "no match in this block" is normal.
+fn process_candidate_block(
+    block_number: u64,
+    addr_bytes: &[u8],
+    keys_filter: &[Vec<[u8; 32]>],
+    events_stmt: &mut rusqlite::Statement<'_>,
+    txs_stmt: &mut rusqlite::Statement<'_>,
+    ts_stmt: &mut rusqlite::Statement<'_>,
+    results: &mut Vec<ContractEvent>,
+) {
+    let events_blob: Option<Vec<u8>> = events_stmt
+        .query_row(rusqlite::params![block_number], |row| row.get(0))
+        .ok();
+    let Some(events_blob) = events_blob else {
+        return;
+    };
+
+    let tx_events = match decode::decode_events(&events_blob) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    // Fast rejection scan: bloom filters have false positives, so most
+    // candidate blocks will have no match.
+    let any_match = tx_events.iter().any(|evs| {
+        evs.iter().any(|e| {
+            e.from_address.0 == addr_bytes && event_keys_match(&e.keys, keys_filter)
+        })
+    });
+    if !any_match {
+        return;
+    }
+
+    // Need tx hashes for this block.
+    let txs_blob: Option<Vec<u8>> = txs_stmt
+        .query_row(rusqlite::params![block_number], |row| row.get(0))
+        .ok();
+    let tx_hashes: Vec<String> = txs_blob
+        .and_then(|b| decode::decode_transactions(&b).ok())
+        .map(|txs| txs.iter().map(|t| t.transaction.hash.to_hex()).collect())
+        .unwrap_or_default();
+
+    let timestamp: u64 = ts_stmt
+        .query_row(rusqlite::params![block_number], |row| row.get(0))
+        .unwrap_or(0);
+
+    for (tx_idx, events) in tx_events.iter().enumerate() {
+        for (ev_idx, event) in events.iter().enumerate() {
+            if event.from_address.0 != addr_bytes {
+                continue;
+            }
+            if !event_keys_match(&event.keys, keys_filter) {
+                continue;
+            }
+            let tx_hash = tx_hashes
+                .get(tx_idx)
+                .cloned()
+                .unwrap_or_else(|| "0x0".to_string());
+            results.push(ContractEvent {
+                tx_index: tx_idx,
+                event_index: ev_idx,
+                tx_hash,
+                from_address: event.from_address.to_hex(),
+                keys: event.keys.iter().map(|k| k.to_hex()).collect(),
+                data: event.data.iter().map(|d| d.to_hex()).collect(),
+                block_number,
+                timestamp,
+            });
+        }
+    }
+}
+
 /// GET /contract-events/{address} — events emitted by a contract, accelerated by bloom filters.
 ///
 /// Pagination: newest-first. When more events may exist below the oldest returned
@@ -686,59 +762,22 @@ async fn handler_contract_events(
         }));
     }
 
-    // Step 1: Bloom-accelerated candidate-block discovery.
-    let mut bloom_stmt = conn
-        .prepare(
-            "SELECT from_block, to_block, bitmap \
-             FROM event_filters \
-             WHERE to_block >= ?1 AND from_block <= ?2 \
-             ORDER BY from_block DESC",
+    // Step 1: Discover max bloom coverage so we know where to brute-scan.
+    // Blocks above `max_bloom_covered` are in `running_event_filter` (not yet
+    // persisted into an `event_filters` row) and must be scanned directly.
+    let max_bloom_covered: Option<u64> = conn
+        .query_row(
+            "SELECT MAX(to_block) FROM event_filters WHERE from_block <= ?1",
+            rusqlite::params![effective_to],
+            |row| row.get::<_, Option<u64>>(0),
         )
-        .map_err(db_err)?;
+        .unwrap_or(None);
 
-    let mut candidate_blocks: Vec<u64> = Vec::new();
-    let mut max_bloom_covered: Option<u64> = None;
-
-    let mut bloom_rows = bloom_stmt
-        .query(rusqlite::params![from_block, effective_to])
-        .map_err(db_err)?;
-
-    while let Some(row) = bloom_rows.next().map_err(db_err)? {
-        let bf_from: u64 = row.get(0).map_err(db_err)?;
-        let bf_to: u64 = row.get(1).map_err(db_err)?;
-        let compressed: Vec<u8> = row.get(2).map_err(db_err)?;
-
-        max_bloom_covered = Some(max_bloom_covered.map_or(bf_to, |m| m.max(bf_to)));
-
-        let agg = bloom::AggregateBloom::from_compressed(bf_from, bf_to, &compressed);
-        let mut blocks = agg.blocks_for_address(&addr_array);
-
-        blocks.retain(|&b| b >= from_block && b <= effective_to);
-        candidate_blocks.extend(blocks);
-    }
-
-    // Blocks above the highest bloom-covered block may exist in the
-    // `running_event_filter` but aren't persisted to `event_filters` yet;
-    // brute-scan them to avoid missing recent events.
     let brute_scan_start = max_bloom_covered
         .map(|m| m.saturating_add(1).max(from_block))
         .unwrap_or(from_block);
-    if brute_scan_start <= effective_to {
-        for b in brute_scan_start..=effective_to {
-            candidate_blocks.push(b);
-        }
-    }
 
-    // Sort desc + dedup so we process newest-first.
-    candidate_blocks.sort_unstable_by(|a, b| b.cmp(a));
-    candidate_blocks.dedup();
-
-    // Truncate to per-request cap; remember if we truncated.
-    let truncated = candidate_blocks.len() > MAX_CANDIDATES;
-    candidate_blocks.truncate(MAX_CANDIDATES);
-
-    // Step 2: Walk candidates newest-first, decoding events AND transactions
-    // per block (transactions give us tx_hash per tx_index).
+    // Statements used during per-block processing.
     let mut events_stmt = conn
         .prepare("SELECT events FROM transactions WHERE block_number = ?1")
         .map_err(db_err)?;
@@ -749,86 +788,111 @@ async fn handler_contract_events(
         .prepare("SELECT timestamp FROM block_headers WHERE number = ?1")
         .map_err(db_err)?;
 
+    // Inline closure-like helper: given a block number, decode events and push
+    // any matching ones into `results`. Returns true if the block contained at
+    // least one match (for telemetry; not used directly).
+    //
+    // We expand it as a macro-style block below since it borrows `results`,
+    // the addr bytes, the filter, and multiple prepared statements — inlining
+    // avoids lifetime gymnastics.
     let mut results: Vec<ContractEvent> = Vec::new();
     let mut last_processed: Option<u64> = None;
+    let mut candidates_processed: usize = 0;
     let mut hit_limit = false;
+    let mut hit_candidate_cap = false;
 
-    for block_number in &candidate_blocks {
-        let block_number = *block_number;
-        last_processed = Some(block_number);
-
-        let events_blob: Option<Vec<u8>> = events_stmt
-            .query_row(rusqlite::params![block_number], |row| row.get(0))
-            .ok();
-        let Some(events_blob) = events_blob else {
-            continue;
-        };
-
-        let tx_events = match decode::decode_events(&events_blob) {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-
-        // Quick address match scan to skip blocks that definitely don't
-        // contain our address (bloom filters have false positives).
-        let any_match = tx_events.iter().any(|evs| {
-            evs.iter().any(|e| {
-                e.from_address.0 == addr_bytes.as_slice()
-                    && event_keys_match(&e.keys, &keys_filter)
-            })
-        });
-        if !any_match {
-            continue;
-        }
-
-        // Need tx hashes for this block.
-        let txs_blob: Option<Vec<u8>> = txs_stmt
-            .query_row(rusqlite::params![block_number], |row| row.get(0))
-            .ok();
-        let tx_hashes: Vec<String> = txs_blob
-            .and_then(|b| decode::decode_transactions(&b).ok())
-            .map(|txs| txs.iter().map(|t| t.transaction.hash.to_hex()).collect())
-            .unwrap_or_default();
-
-        let timestamp: u64 = ts_stmt
-            .query_row(rusqlite::params![block_number], |row| row.get(0))
-            .unwrap_or(0);
-
-        // Collect ALL matching events in this block before checking the limit,
-        // so pagination boundaries land cleanly on block boundaries.
-        for (tx_idx, events) in tx_events.iter().enumerate() {
-            for (ev_idx, event) in events.iter().enumerate() {
-                if event.from_address.0 != addr_bytes.as_slice() {
-                    continue;
-                }
-                if !event_keys_match(&event.keys, &keys_filter) {
-                    continue;
-                }
-                let tx_hash = tx_hashes
-                    .get(tx_idx)
-                    .cloned()
-                    .unwrap_or_else(|| "0x0".to_string());
-                results.push(ContractEvent {
-                    tx_index: tx_idx,
-                    event_index: ev_idx,
-                    tx_hash,
-                    from_address: event.from_address.to_hex(),
-                    keys: event.keys.iter().map(|k| k.to_hex()).collect(),
-                    data: event.data.iter().map(|d| d.to_hex()).collect(),
-                    block_number,
-                    timestamp,
-                });
+    // Step 2a: Brute-scan blocks above the persisted bloom filter, newest-first.
+    if brute_scan_start <= effective_to {
+        let mut b = effective_to;
+        loop {
+            if b < brute_scan_start {
+                break;
             }
-        }
+            last_processed = Some(b);
+            candidates_processed += 1;
 
-        if results.len() >= limit {
-            hit_limit = true;
-            break;
+            process_candidate_block(
+                b,
+                &addr_bytes,
+                &keys_filter,
+                &mut events_stmt,
+                &mut txs_stmt,
+                &mut ts_stmt,
+                &mut results,
+            );
+
+            if results.len() >= limit {
+                hit_limit = true;
+                break;
+            }
+            if candidates_processed >= MAX_CANDIDATES {
+                hit_candidate_cap = true;
+                break;
+            }
+            if b == 0 {
+                break;
+            }
+            b -= 1;
+        }
+    }
+
+    // Step 2b: Walk bloom chunks newest-first, decompressing one at a time.
+    // As soon as `limit` is reached we stop — the continuation token resumes
+    // the scan from (last_processed - 1) on the next call.
+    if !hit_limit && !hit_candidate_cap {
+        let mut bloom_stmt = conn
+            .prepare(
+                "SELECT from_block, to_block, bitmap \
+                 FROM event_filters \
+                 WHERE to_block >= ?1 AND from_block <= ?2 \
+                 ORDER BY from_block DESC",
+            )
+            .map_err(db_err)?;
+
+        let mut bloom_rows = bloom_stmt
+            .query(rusqlite::params![from_block, effective_to])
+            .map_err(db_err)?;
+
+        'chunks: while let Some(row) = bloom_rows.next().map_err(db_err)? {
+            let bf_from: u64 = row.get(0).map_err(db_err)?;
+            let bf_to: u64 = row.get(1).map_err(db_err)?;
+            let compressed: Vec<u8> = row.get(2).map_err(db_err)?;
+
+            let agg = bloom::AggregateBloom::from_compressed(bf_from, bf_to, &compressed);
+            let mut blocks = agg.blocks_for_address(&addr_array);
+            blocks.retain(|&b| b >= from_block && b <= effective_to);
+            // Process within-chunk candidates newest-first.
+            blocks.sort_unstable_by(|a, b| b.cmp(a));
+            blocks.dedup();
+
+            for block_number in blocks {
+                last_processed = Some(block_number);
+                candidates_processed += 1;
+
+                process_candidate_block(
+                    block_number,
+                    &addr_bytes,
+                    &keys_filter,
+                    &mut events_stmt,
+                    &mut txs_stmt,
+                    &mut ts_stmt,
+                    &mut results,
+                );
+
+                if results.len() >= limit {
+                    hit_limit = true;
+                    break 'chunks;
+                }
+                if candidates_processed >= MAX_CANDIDATES {
+                    hit_candidate_cap = true;
+                    break 'chunks;
+                }
+            }
         }
     }
 
     // Compute continuation token.
-    let continuation_token = if hit_limit || truncated {
+    let continuation_token = if hit_limit || hit_candidate_cap {
         // More to scan: next page should start at (last_processed - 1).
         last_processed
             .and_then(|b| b.checked_sub(1))

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1,6 +1,7 @@
 use starknet::core::types::Felt;
 
 use crate::app::state::SourceStatus;
+use crate::app::views::address_info::UnfilledGap;
 use crate::data::pathfinder::ClassHashEntry;
 use crate::data::types::{
     AddressTxSummary, ClassContractEntry, ClassDeclareInfo, ContractCallSummary, SnAddressInfo,
@@ -35,11 +36,19 @@ pub enum Action {
     },
     /// Enrich visible address txs that are missing endpoint/timestamp data.
     EnrichAddressTxs { address: Felt, hashes: Vec<Felt> },
-    /// Post-load sanity check: fill nonce gaps + enrich all empty endpoints.
-    SanityCheckAddress {
+    /// Post-load enrichment: fill small nonce gaps + enrich missing endpoint names.
+    /// Fires automatically once initial sources settle. Large gaps are handled by
+    /// `FillAddressNonceGaps` instead (on-demand, issue #10).
+    EnrichAddressEndpoints {
         address: Felt,
         current_nonce: u64,
         known_txs: Vec<AddressTxSummary>,
+    },
+    /// On-demand large-gap fill: triggered when the user scrolls toward the gap.
+    FillAddressNonceGaps {
+        address: Felt,
+        known_txs: Vec<AddressTxSummary>,
+        gap: UnfilledGap,
     },
     /// Enrich WS-streamed call stubs (missing sender/function/fee/timestamp).
     EnrichAddressCalls {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -496,6 +496,19 @@ fn handle_cycle(app: &mut App, direction: i64) -> Option<Action> {
             app.clear_tx_detail();
             Some(Action::FetchTransaction { hash })
         }
+        View::AddressInfo => {
+            // Half-page-ish scroll inside the active address tab.
+            // direction: +1 = Ctrl+U / PageUp (up), -1 = Ctrl+D / PageDown (down).
+            // Address lists are newest-first, so "up" means lower index.
+            const CHUNK: i64 = 20;
+            let delta = -direction * CHUNK;
+            match app.address.tab {
+                crate::app::AddressTab::Transactions => app.address.txs.scroll_by(delta),
+                crate::app::AddressTab::Calls => app.address.calls.scroll_by(delta),
+                _ => {}
+            }
+            None
+        }
         _ => None,
     }
 }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -502,11 +502,7 @@ fn handle_cycle(app: &mut App, direction: i64) -> Option<Action> {
             // Address lists are newest-first, so "up" means lower index.
             const CHUNK: i64 = 20;
             let delta = -direction * CHUNK;
-            match app.address.tab {
-                crate::app::AddressTab::Transactions => app.address.txs.scroll_by(delta),
-                crate::app::AddressTab::Calls => app.address.calls.scroll_by(delta),
-                _ => {}
-            }
+            app.address_list_scroll_by(delta);
             None
         }
         _ => None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -288,6 +288,53 @@ impl App {
         }
     }
 
+    /// Send an `EnrichAddressTxs` for the rows currently visible in the
+    /// address Transactions tab that are missing endpoint names or timestamps.
+    ///
+    /// Idempotent: the cache layer dedups in-flight requests and
+    /// `enrich_address_txs` itself drops hashes that already have data.
+    /// Safe to call on every scroll keystroke.
+    pub fn maybe_enrich_visible_address_txs(&self) {
+        if self.current_view() != View::AddressInfo {
+            return;
+        }
+        if !matches!(self.address.tab, AddressTab::Transactions) {
+            return;
+        }
+        let Some(address) = self.address.context else {
+            return;
+        };
+        let offset = self.address.txs.state.offset();
+        let hashes: Vec<_> = self
+            .address
+            .txs
+            .items
+            .iter()
+            .skip(offset)
+            .take(50)
+            .filter(|t| t.endpoint_names.is_empty() || t.timestamp == 0)
+            .map(|t| t.hash)
+            .collect();
+        if !hashes.is_empty() {
+            let _ = self
+                .action_tx
+                .send(Action::EnrichAddressTxs { address, hashes });
+        }
+    }
+
+    /// Scroll the active address list by a delta and trigger viewport
+    /// enrichment for any rows newly exposed.
+    pub fn address_list_scroll_by(&mut self, delta: i64) {
+        match self.address.tab {
+            AddressTab::Transactions => {
+                self.address.txs.scroll_by(delta);
+                self.maybe_enrich_visible_address_txs();
+            }
+            AddressTab::Calls => self.address.calls.scroll_by(delta),
+            _ => {}
+        }
+    }
+
     pub fn select_next(&mut self) {
         match self.current_view() {
             View::Blocks => {
@@ -305,6 +352,7 @@ impl App {
                 AddressTab::Transactions => {
                     self.address.txs.next();
                     self.maybe_fetch_more_address_txs();
+                    self.maybe_enrich_visible_address_txs();
                 }
                 AddressTab::Calls => {
                     self.address.calls.next();
@@ -338,7 +386,10 @@ impl App {
                 self.class.scroll = self.class.scroll.saturating_sub(1);
             }
             View::AddressInfo => match self.address.tab {
-                AddressTab::Transactions => self.address.txs.previous(),
+                AddressTab::Transactions => {
+                    self.address.txs.previous();
+                    self.maybe_enrich_visible_address_txs();
+                }
                 AddressTab::Calls => self.address.calls.previous(),
                 AddressTab::Events => {
                     self.address.event_scroll = self.address.event_scroll.saturating_sub(1);
@@ -363,7 +414,10 @@ impl App {
                 self.class.scroll = 0;
             }
             View::AddressInfo => match self.address.tab {
-                AddressTab::Transactions => self.address.txs.select_first(),
+                AddressTab::Transactions => {
+                    self.address.txs.select_first();
+                    self.maybe_enrich_visible_address_txs();
+                }
                 AddressTab::Calls => self.address.calls.select_first(),
                 AddressTab::Events => self.address.event_scroll = 0,
                 AddressTab::ClassHistory => {
@@ -391,6 +445,7 @@ impl App {
                 AddressTab::Transactions => {
                     self.address.txs.select_last();
                     self.maybe_fetch_more_address_txs();
+                    self.maybe_enrich_visible_address_txs();
                 }
                 AddressTab::Calls => {
                     self.address.calls.select_last();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -840,8 +840,7 @@ impl App {
                         if let Some(info) = &self.address.info {
                             let current_nonce = crate::utils::felt_to_u64(&info.nonce);
                             if current_nonce > 0 {
-                                self.address.unfilled_gap =
-                                    self.address.detect_unfilled_gap();
+                                self.address.unfilled_gap = self.address.detect_unfilled_gap();
                                 self.address.sanity_check_dispatched = true;
                                 let _ = self.action_tx.send(Action::EnrichAddressEndpoints {
                                     address,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -432,29 +432,52 @@ impl App {
         if self.address.fetching_more_txs {
             return;
         }
-        // Don't fetch if no source thinks there's more data
+        let near_bottom = match self.address.tab {
+            AddressTab::Transactions => self.address.txs.is_near_bottom(5),
+            AddressTab::Calls => self.address.calls.is_near_bottom(5),
+            _ => false,
+        };
+        if !near_bottom {
+            return;
+        }
+
+        // Priority 1: on-demand fill of a deferred large nonce gap (issue #10).
+        // Only fires once per gap; the handler clears `unfilled_gap` on completion.
+        if let Some(gap) = self.address.unfilled_gap.as_ref() {
+            if !gap.fill_dispatched {
+                if let Some(address) = self.address.context {
+                    let gap_clone = gap.clone();
+                    if let Some(g) = self.address.unfilled_gap.as_mut() {
+                        g.fill_dispatched = true;
+                    }
+                    self.address.fetching_more_txs = true;
+                    let _ = self.action_tx.send(Action::FillAddressNonceGaps {
+                        address,
+                        known_txs: self.address.txs.items.clone(),
+                        gap: gap_clone,
+                    });
+                    return;
+                }
+            }
+        }
+
+        // Priority 2: chronological pagination (older than oldest known block).
+        // Don't fetch if no source thinks there's more data.
         if !self.address.has_more_data()
             && self.address.oldest_event_block.is_some()
             && self.address.sources_pending.is_empty()
         {
             return;
         }
-        let near_bottom = match self.address.tab {
-            AddressTab::Transactions => self.address.txs.is_near_bottom(5),
-            AddressTab::Calls => self.address.calls.is_near_bottom(5),
-            _ => false,
-        };
-        if near_bottom {
-            let cursor = self.address.pagination_cursor();
-            if let (Some(address), Some(before_block)) = (self.address.context, cursor) {
-                if before_block > 0 {
-                    self.address.fetching_more_txs = true;
-                    let _ = self.action_tx.send(Action::FetchMoreAddressTxs {
-                        address,
-                        before_block,
-                        is_contract: self.address.is_contract,
-                    });
-                }
+        let cursor = self.address.pagination_cursor();
+        if let (Some(address), Some(before_block)) = (self.address.context, cursor) {
+            if before_block > 0 {
+                self.address.fetching_more_txs = true;
+                let _ = self.action_tx.send(Action::FetchMoreAddressTxs {
+                    address,
+                    before_block,
+                    is_contract: self.address.is_contract,
+                });
             }
         }
     }
@@ -807,8 +830,9 @@ impl App {
                             .send(Action::EnrichAddressTxs { address, hashes });
                     }
 
-                    // Sanity check cached data: fill nonce gaps + enrich endpoints
-                    // from what we already have in the cache, even before sources complete.
+                    // Detect any large nonce gap in cached data and defer it to
+                    // on-demand fill (issue #10). Endpoint enrichment + small gap
+                    // fill still run immediately from cache.
                     if !self.address.is_contract
                         && !self.address.txs.items.is_empty()
                         && !self.address.sanity_check_dispatched
@@ -816,8 +840,10 @@ impl App {
                         if let Some(info) = &self.address.info {
                             let current_nonce = crate::utils::felt_to_u64(&info.nonce);
                             if current_nonce > 0 {
+                                self.address.unfilled_gap =
+                                    self.address.detect_unfilled_gap();
                                 self.address.sanity_check_dispatched = true;
-                                let _ = self.action_tx.send(Action::SanityCheckAddress {
+                                let _ = self.action_tx.send(Action::EnrichAddressEndpoints {
                                     address,
                                     current_nonce,
                                     known_txs: self.address.txs.items.clone(),
@@ -892,8 +918,26 @@ impl App {
                 if self.address.context != Some(address) {
                     return;
                 }
+                // If a deferred gap-fill was in-flight, unblock the pagination
+                // trigger now that results have landed.
+                let was_gap_fill = self
+                    .address
+                    .unfilled_gap
+                    .as_ref()
+                    .is_some_and(|g| g.fill_dispatched);
                 // Merge enrichment data (upgrades existing entries)
                 self.address.merge_tx_summaries(updates);
+                // If a gap fill was in flight, re-run detection so we either
+                // clear the gap (filled) or update it to the residual gap.
+                if was_gap_fill {
+                    self.address.unfilled_gap = self.address.detect_unfilled_gap().map(|mut g| {
+                        // Preserve dispatched state so we don't re-fire for the
+                        // same (or similar) gap; require refresh ('r') to retry.
+                        g.fill_dispatched = true;
+                        g
+                    });
+                    self.address.fetching_more_txs = false;
+                }
                 // Persist enriched txs to cache so they survive restarts
                 if !self.address.txs.items.is_empty() {
                     let _ = self.action_tx.send(Action::PersistAddressTxs {
@@ -982,13 +1026,15 @@ impl App {
                         self.is_loading = false;
                         self.loading_detail = None;
 
-                        // Post-display sanity check: fill nonce gaps + enrich all endpoints.
-                        // Reset the flag so we run again with the full merged dataset.
+                        // Post-display: detect any large nonce gap and defer it for
+                        // on-demand fill (issue #10). Small gaps + endpoint
+                        // enrichment still run automatically.
                         if !self.address.is_contract {
                             if let Some(info) = &self.address.info {
                                 let current_nonce = crate::utils::felt_to_u64(&info.nonce);
+                                self.address.unfilled_gap = self.address.detect_unfilled_gap();
                                 self.address.sanity_check_dispatched = true;
-                                let _ = self.action_tx.send(Action::SanityCheckAddress {
+                                let _ = self.action_tx.send(Action::EnrichAddressEndpoints {
                                     address,
                                     current_nonce,
                                     known_txs: self.address.txs.items.clone(),

--- a/src/app/views/address_info.rs
+++ b/src/app/views/address_info.rs
@@ -12,6 +12,26 @@ use crate::decode::events::DecodedEvent;
 use crate::network::dune::AddressActivityProbe;
 use crate::ui::widgets::stateful_list::StatefulList;
 
+/// A detected, unfilled nonce gap in the tx list that has been deferred
+/// for on-demand filling (issue #10). We do NOT auto-fill large gaps on
+/// address load; instead we wait until the user scrolls toward the gap
+/// boundary before burning RPC/Dune budget on it.
+#[derive(Clone, Debug)]
+pub struct UnfilledGap {
+    /// Last known nonce below the gap.
+    pub lo_nonce: u64,
+    /// First known nonce above the gap.
+    pub hi_nonce: u64,
+    /// Block number of the lo_nonce tx (lower bound for the scan).
+    pub lo_block: u64,
+    /// Block number of the hi_nonce tx (upper bound for the scan).
+    pub hi_block: u64,
+    /// Number of missing nonces between lo and hi (exclusive).
+    pub missing_count: u64,
+    /// Whether the fill action has already been dispatched for this gap.
+    pub fill_dispatched: bool,
+}
+
 /// All state related to the address info view.
 pub struct AddressInfoState {
     pub info: Option<SnAddressInfo>,
@@ -59,6 +79,10 @@ pub struct AddressInfoState {
     pub ws_subscribed: bool,
     /// Whether the post-display sanity check has already been dispatched.
     pub sanity_check_dispatched: bool,
+    /// Detected large nonce gap that has NOT been auto-filled (issue #10).
+    /// Set after the initial load settles; filled on-demand when the user
+    /// scrolls near the bottom of the list.
+    pub unfilled_gap: Option<UnfilledGap>,
 }
 
 impl Default for AddressInfoState {
@@ -88,6 +112,7 @@ impl Default for AddressInfoState {
             rpc_has_more: false,
             ws_subscribed: false,
             sanity_check_dispatched: false,
+            unfilled_gap: None,
         }
     }
 }
@@ -117,6 +142,7 @@ impl AddressInfoState {
         self.rpc_has_more = false;
         self.ws_subscribed = false;
         self.sanity_check_dispatched = false;
+        self.unfilled_gap = None;
     }
 
     /// Whether any source thinks there is more data to fetch.
@@ -256,6 +282,68 @@ impl AddressInfoState {
             self.oldest_event_block = Some(oldest);
         }
     }
+
+    /// Scan the current tx list for a "large" nonce gap that we want to defer
+    /// filling until the user asks for it.
+    ///
+    /// Returns `Some(gap)` when the biggest contiguous missing-nonce run is large
+    /// enough to justify deferring (either many missing entries, or a wide block
+    /// span). Small gaps are left to the normal enrichment path and return `None`
+    /// so the caller can auto-fill them.
+    pub fn detect_unfilled_gap(&self) -> Option<UnfilledGap> {
+        // Only meaningful for account txs (contracts don't have sequential nonces).
+        if self.is_contract {
+            return None;
+        }
+        // Build sorted (nonce, block) pairs for txs that have landed in a block.
+        let mut pairs: Vec<(u64, u64)> = self
+            .txs
+            .items
+            .iter()
+            .filter(|t| t.block_number > 0)
+            .map(|t| (t.nonce, t.block_number))
+            .collect();
+        if pairs.len() < 2 {
+            return None;
+        }
+        pairs.sort_by_key(|(n, _)| *n);
+
+        // Find the biggest missing-nonce run.
+        let mut best: Option<UnfilledGap> = None;
+        for w in pairs.windows(2) {
+            let (lo_nonce, lo_block) = w[0];
+            let (hi_nonce, hi_block) = w[1];
+            let missing = hi_nonce.saturating_sub(lo_nonce).saturating_sub(1);
+            if missing == 0 {
+                continue;
+            }
+            let keep = best.as_ref().is_none_or(|b| missing > b.missing_count);
+            if keep {
+                best = Some(UnfilledGap {
+                    lo_nonce,
+                    hi_nonce,
+                    lo_block,
+                    hi_block,
+                    missing_count: missing,
+                    fill_dispatched: false,
+                });
+            }
+        }
+        let gap = best?;
+
+        // Only defer when the gap is "large". Small gaps fall through to the
+        // existing enrichment path (RPC block scan or small Dune query).
+        // Thresholds picked to match the existing small/large split in
+        // fill_nonce_gaps_phase (50-block small path) while leaving slack for
+        // genuinely benign gaps that the endpoint-enrichment phase will absorb.
+        const LARGE_MISSING_COUNT: u64 = 50;
+        const LARGE_BLOCK_SPAN: u64 = 1000;
+        let span = gap.hi_block.saturating_sub(gap.lo_block);
+        if gap.missing_count < LARGE_MISSING_COUNT && span < LARGE_BLOCK_SPAN {
+            return None;
+        }
+        Some(gap)
+    }
 }
 
 /// Upgrade an existing tx summary with better data from an incoming one.
@@ -280,5 +368,97 @@ pub fn upgrade_tx_summary(existing: &mut AddressTxSummary, incoming: &AddressTxS
     }
     if existing.tip == 0 && incoming.tip > 0 {
         existing.tip = incoming.tip;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::types::AddressTxSummary;
+    use starknet::core::types::Felt;
+
+    fn summary(nonce: u64, block: u64) -> AddressTxSummary {
+        AddressTxSummary {
+            hash: Felt::from(nonce + 1),
+            nonce,
+            block_number: block,
+            timestamp: 0,
+            endpoint_names: String::new(),
+            total_fee_fri: 0,
+            tip: 0,
+            tx_type: "INVOKE".into(),
+            status: "OK".into(),
+            sender: None,
+        }
+    }
+
+    fn state_with(txs: Vec<AddressTxSummary>) -> AddressInfoState {
+        let mut s = AddressInfoState::default();
+        s.txs.items = txs;
+        s
+    }
+
+    #[test]
+    fn no_gap_when_contiguous() {
+        let state = state_with(vec![
+            summary(10, 100),
+            summary(11, 102),
+            summary(12, 104),
+        ]);
+        assert!(state.detect_unfilled_gap().is_none());
+    }
+
+    #[test]
+    fn no_gap_for_small_missing_count_and_narrow_span() {
+        // 5 missing nonces across 30 blocks — well below the large thresholds.
+        let state = state_with(vec![summary(10, 100), summary(16, 130)]);
+        assert!(state.detect_unfilled_gap().is_none());
+    }
+
+    #[test]
+    fn detects_gap_by_missing_count() {
+        // 100 missing nonces — exceeds LARGE_MISSING_COUNT.
+        let state = state_with(vec![
+            summary(10, 100),
+            summary(11, 105),
+            summary(112, 210), // 100 missing (12..=111)
+            summary(113, 215),
+        ]);
+        let g = state.detect_unfilled_gap().expect("large gap expected");
+        assert_eq!(g.lo_nonce, 11);
+        assert_eq!(g.hi_nonce, 112);
+        assert_eq!(g.missing_count, 100);
+        assert!(!g.fill_dispatched);
+    }
+
+    #[test]
+    fn detects_gap_by_block_span() {
+        // Only 10 missing nonces but spanning >1000 blocks.
+        let state = state_with(vec![summary(10, 100), summary(21, 2000)]);
+        let g = state.detect_unfilled_gap().expect("wide-span gap expected");
+        assert_eq!(g.lo_nonce, 10);
+        assert_eq!(g.hi_nonce, 21);
+        assert_eq!(g.missing_count, 10);
+    }
+
+    #[test]
+    fn contract_addresses_never_report_gap() {
+        let mut state = state_with(vec![summary(10, 100), summary(200, 500)]);
+        state.is_contract = true;
+        assert!(state.detect_unfilled_gap().is_none());
+    }
+
+    #[test]
+    fn biggest_gap_wins_when_multiple() {
+        let state = state_with(vec![
+            summary(10, 100),
+            summary(20, 110),    // 9 missing
+            summary(200, 5000),  // 179 missing — winner
+            summary(201, 5001),
+        ]);
+        let g = state.detect_unfilled_gap().expect("should pick biggest gap");
+        assert_eq!(g.lo_nonce, 20);
+        assert_eq!(g.hi_nonce, 200);
+        assert_eq!(g.missing_count, 179);
     }
 }

--- a/src/app/views/address_info.rs
+++ b/src/app/views/address_info.rs
@@ -12,6 +12,13 @@ use crate::decode::events::DecodedEvent;
 use crate::network::dune::AddressActivityProbe;
 use crate::ui::widgets::stateful_list::StatefulList;
 
+/// Maximum block span a nonce gap can cover before we stop auto-filling it
+/// via RPC block scans. Gaps wider than this are deferred to on-demand Dune
+/// queries (`run_nonce_gap_fill`). Shared between the detector
+/// (`detect_unfilled_gap`) and the filler (`fill_small_nonce_gaps_phase`) so
+/// they stay aligned — drift between the two causes silent data loss.
+pub const SMALL_GAP_SPAN_BLOCKS: u64 = 50;
+
 /// A detected, unfilled nonce gap in the tx list that has been deferred
 /// for on-demand filling (issue #10). We do NOT auto-fill large gaps on
 /// address load; instead we wait until the user scrolls toward the gap
@@ -331,15 +338,11 @@ impl AddressInfoState {
         }
         let gap = best?;
 
-        // Only defer when the gap is "large". Small gaps fall through to the
-        // existing enrichment path (RPC block scan or small Dune query).
-        // Thresholds picked to match the existing small/large split in
-        // fill_nonce_gaps_phase (50-block small path) while leaving slack for
-        // genuinely benign gaps that the endpoint-enrichment phase will absorb.
-        const LARGE_MISSING_COUNT: u64 = 50;
-        const LARGE_BLOCK_SPAN: u64 = 1000;
+        // Defer any gap the RPC small-gap path can't handle. `fill_small_nonce_gaps_phase`
+        // only scans spans ≤ `SMALL_GAP_SPAN_BLOCKS` — anything wider must be
+        // filled via Dune on-demand or it would otherwise be dropped silently.
         let span = gap.hi_block.saturating_sub(gap.lo_block);
-        if gap.missing_count < LARGE_MISSING_COUNT && span < LARGE_BLOCK_SPAN {
+        if span <= SMALL_GAP_SPAN_BLOCKS {
             return None;
         }
         Some(gap)
@@ -400,45 +403,54 @@ mod tests {
 
     #[test]
     fn no_gap_when_contiguous() {
-        let state = state_with(vec![
-            summary(10, 100),
-            summary(11, 102),
-            summary(12, 104),
-        ]);
+        let state = state_with(vec![summary(10, 100), summary(11, 102), summary(12, 104)]);
         assert!(state.detect_unfilled_gap().is_none());
     }
 
     #[test]
-    fn no_gap_for_small_missing_count_and_narrow_span() {
-        // 5 missing nonces across 30 blocks — well below the large thresholds.
+    fn no_gap_for_small_span() {
+        // Gap spans only 30 blocks — RPC small-gap path handles this.
         let state = state_with(vec![summary(10, 100), summary(16, 130)]);
         assert!(state.detect_unfilled_gap().is_none());
     }
 
     #[test]
-    fn detects_gap_by_missing_count() {
-        // 100 missing nonces — exceeds LARGE_MISSING_COUNT.
-        let state = state_with(vec![
-            summary(10, 100),
-            summary(11, 105),
-            summary(112, 210), // 100 missing (12..=111)
-            summary(113, 215),
-        ]);
-        let g = state.detect_unfilled_gap().expect("large gap expected");
-        assert_eq!(g.lo_nonce, 11);
-        assert_eq!(g.hi_nonce, 112);
-        assert_eq!(g.missing_count, 100);
+    fn detects_wide_gap_even_with_few_missing() {
+        // Only 2 missing nonces but span = 100 blocks > SMALL_GAP_SPAN_BLOCKS.
+        // This is the medium-gap case that would otherwise be silently dropped.
+        let state = state_with(vec![summary(10, 100), summary(13, 200)]);
+        let g = state.detect_unfilled_gap().expect("wide-span gap expected");
+        assert_eq!(g.lo_nonce, 10);
+        assert_eq!(g.hi_nonce, 13);
+        assert_eq!(g.missing_count, 2);
         assert!(!g.fill_dispatched);
     }
 
     #[test]
     fn detects_gap_by_block_span() {
-        // Only 10 missing nonces but spanning >1000 blocks.
+        // Large block span well above the RPC small-gap limit.
         let state = state_with(vec![summary(10, 100), summary(21, 2000)]);
         let g = state.detect_unfilled_gap().expect("wide-span gap expected");
         assert_eq!(g.lo_nonce, 10);
         assert_eq!(g.hi_nonce, 21);
         assert_eq!(g.missing_count, 10);
+    }
+
+    #[test]
+    fn gap_threshold_boundary() {
+        // Exactly at the threshold: span == SMALL_GAP_SPAN_BLOCKS → no defer.
+        let state = state_with(vec![
+            summary(10, 100),
+            summary(12, 100 + SMALL_GAP_SPAN_BLOCKS),
+        ]);
+        assert!(state.detect_unfilled_gap().is_none());
+
+        // One over: span == SMALL_GAP_SPAN_BLOCKS + 1 → deferred.
+        let state = state_with(vec![
+            summary(10, 100),
+            summary(12, 100 + SMALL_GAP_SPAN_BLOCKS + 1),
+        ]);
+        assert!(state.detect_unfilled_gap().is_some());
     }
 
     #[test]
@@ -449,14 +461,36 @@ mod tests {
     }
 
     #[test]
+    fn reset_clears_unfilled_gap() {
+        // Guards the 'r'-refresh path: `NavigateToAddress` calls `reset()`, and
+        // the UI hint "retry with 'r'" only works if this wipes
+        // `unfilled_gap` + `fill_dispatched` so the next load re-detects.
+        let mut state = state_with(vec![summary(10, 100), summary(21, 2000)]);
+        state.unfilled_gap = Some(UnfilledGap {
+            lo_nonce: 10,
+            hi_nonce: 21,
+            lo_block: 100,
+            hi_block: 2000,
+            missing_count: 10,
+            fill_dispatched: true,
+        });
+        state.sanity_check_dispatched = true;
+        state.clear();
+        assert!(state.unfilled_gap.is_none());
+        assert!(!state.sanity_check_dispatched);
+    }
+
+    #[test]
     fn biggest_gap_wins_when_multiple() {
         let state = state_with(vec![
             summary(10, 100),
-            summary(20, 110),    // 9 missing
-            summary(200, 5000),  // 179 missing — winner
+            summary(20, 110),   // 9 missing
+            summary(200, 5000), // 179 missing — winner
             summary(201, 5001),
         ]);
-        let g = state.detect_unfilled_gap().expect("should pick biggest gap");
+        let g = state
+            .detect_unfilled_gap()
+            .expect("should pick biggest gap");
         assert_eq!(g.lo_nonce, 20);
         assert_eq!(g.hi_nonce, 200);
         assert_eq!(g.missing_count, 179);

--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -602,8 +602,19 @@ impl DataSource for CachingDataSource {
         &self,
         address: Felt,
         from_block: Option<u64>,
+        to_block: Option<u64>,
         limit: usize,
     ) -> Result<Vec<SnEvent>> {
+        // Bounded (paginating into history) — bypass cache merge and pass through.
+        // The cache only accelerates the "newest events" path; old-window fetches
+        // shouldn't poison the cache with partial windows.
+        if to_block.is_some() {
+            return self
+                .upstream
+                .get_events_for_address(address, from_block, to_block, limit)
+                .await;
+        }
+
         // Load cached events
         let cached = self.load_address_events(&address);
 
@@ -619,7 +630,7 @@ impl DataSource for CachingDataSource {
         // Fetch from upstream
         let new_events = self
             .upstream
-            .get_events_for_address(address, fetch_from, limit)
+            .get_events_for_address(address, fetch_from, None, limit)
             .await
             .unwrap_or_default();
 
@@ -817,8 +828,17 @@ impl DataSource for CachingDataSource {
         &self,
         address: Felt,
         from_block: Option<u64>,
+        to_block: Option<u64>,
         limit: usize,
     ) -> Result<Vec<SnEvent>> {
+        // Bounded pagination: skip cache merge (see `get_events_for_address`).
+        if to_block.is_some() {
+            return self
+                .upstream
+                .get_contract_events(address, from_block, to_block, limit)
+                .await;
+        }
+
         // Incremental caching for contract events (all events, no key filter)
         let cached = self.load_contract_events(&address);
 
@@ -831,7 +851,7 @@ impl DataSource for CachingDataSource {
 
         let new_events = match self
             .upstream
-            .get_contract_events(address, fetch_from, limit)
+            .get_contract_events(address, fetch_from, None, limit)
             .await
         {
             Ok(events) => events,

--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -1,7 +1,12 @@
+use std::collections::HashMap;
+use std::future::Future;
 use std::path::Path;
-use std::sync::Mutex;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use futures::FutureExt;
+use futures::future::Shared;
 use rusqlite::{Connection, params};
 use starknet::core::types::{ContractClass, Felt};
 use tracing::{debug, trace, warn};
@@ -11,16 +16,29 @@ use super::DataSource;
 use super::types::*;
 use crate::error::{Result, SnbeatError};
 
+/// Shared future output: errors are stringified so the future is `Clone`-able
+/// (SnbeatError is not Clone due to `std::io::Error`).
+type SharedTxFut =
+    Shared<Pin<Box<dyn Future<Output = std::result::Result<SnTransaction, String>> + Send>>>;
+type SharedRxFut =
+    Shared<Pin<Box<dyn Future<Output = std::result::Result<SnReceipt, String>> + Send>>>;
+
 /// Persistent cache backed by SQLite + in-memory LRU.
 /// Wraps any DataSource: checks cache first, fetches from upstream on miss,
 /// writes through to cache on fetch. Persists across restarts.
+///
+/// Also deduplicates concurrent in-flight `get_transaction` / `get_receipt`
+/// fetches so that N parallel callers for the same hash produce one RPC round
+/// trip, not N. Prevents the user-click-races-background-enrichment storm.
 pub struct CachingDataSource {
-    upstream: Box<dyn DataSource>,
+    upstream: Arc<dyn DataSource>,
     db: Mutex<Connection>,
+    pending_txs: Mutex<HashMap<Felt, SharedTxFut>>,
+    pending_receipts: Mutex<HashMap<Felt, SharedRxFut>>,
 }
 
 impl CachingDataSource {
-    pub fn new(upstream: Box<dyn DataSource>, cache_path: &Path) -> Result<Self> {
+    pub fn new(upstream: Arc<dyn DataSource>, cache_path: &Path) -> Result<Self> {
         let db = Connection::open(cache_path)
             .map_err(|e| SnbeatError::Config(format!("Failed to open cache db: {e}")))?;
 
@@ -140,6 +158,8 @@ impl CachingDataSource {
         Ok(Self {
             upstream,
             db: Mutex::new(db),
+            pending_txs: Mutex::new(HashMap::new()),
+            pending_receipts: Mutex::new(HashMap::new()),
         })
     }
 
@@ -551,10 +571,47 @@ impl DataSource for CachingDataSource {
             trace!(tx_hash = %format!("{:#x}", hash), "cache hit: transaction");
             return Ok(tx);
         }
-        debug!(tx_hash = %format!("{:#x}", hash), "cache miss: transaction, fetching from RPC");
-        let tx = self.upstream.get_transaction(hash).await?;
-        self.cache_transaction(&tx);
-        Ok(tx)
+
+        // In-flight dedup: if another caller is already fetching this hash,
+        // await their future instead of firing a second RPC.
+        let fut = {
+            let mut pending = self.pending_txs.lock().unwrap();
+            if let Some(existing) = pending.get(&hash) {
+                trace!(tx_hash = %format!("{:#x}", hash), "dedup: joining in-flight transaction fetch");
+                existing.clone()
+            } else {
+                debug!(tx_hash = %format!("{:#x}", hash), "cache miss: transaction, fetching from RPC");
+                let upstream = Arc::clone(&self.upstream);
+                let fut: Pin<
+                    Box<dyn Future<Output = std::result::Result<SnTransaction, String>> + Send>,
+                > = Box::pin(async move {
+                    upstream
+                        .get_transaction(hash)
+                        .await
+                        .map_err(|e| e.to_string())
+                });
+                let shared = fut.shared();
+                pending.insert(hash, shared.clone());
+                shared
+            }
+        };
+
+        let result = fut.await;
+
+        // Leader cleanup: whichever task observes it first removes the entry
+        // so a later miss can start a fresh fetch.
+        {
+            let mut pending = self.pending_txs.lock().unwrap();
+            pending.remove(&hash);
+        }
+
+        match result {
+            Ok(tx) => {
+                self.cache_transaction(&tx);
+                Ok(tx)
+            }
+            Err(e) => Err(SnbeatError::Rpc(e)),
+        }
     }
 
     async fn get_receipt(&self, hash: Felt) -> Result<SnReceipt> {
@@ -562,10 +619,40 @@ impl DataSource for CachingDataSource {
             trace!(tx_hash = %format!("{:#x}", hash), "cache hit: receipt");
             return Ok(receipt);
         }
-        debug!(tx_hash = %format!("{:#x}", hash), "cache miss: receipt, fetching from RPC");
-        let receipt = self.upstream.get_receipt(hash).await?;
-        self.cache_receipt(&receipt);
-        Ok(receipt)
+
+        let fut = {
+            let mut pending = self.pending_receipts.lock().unwrap();
+            if let Some(existing) = pending.get(&hash) {
+                trace!(tx_hash = %format!("{:#x}", hash), "dedup: joining in-flight receipt fetch");
+                existing.clone()
+            } else {
+                debug!(tx_hash = %format!("{:#x}", hash), "cache miss: receipt, fetching from RPC");
+                let upstream = Arc::clone(&self.upstream);
+                let fut: Pin<
+                    Box<dyn Future<Output = std::result::Result<SnReceipt, String>> + Send>,
+                > = Box::pin(
+                    async move { upstream.get_receipt(hash).await.map_err(|e| e.to_string()) },
+                );
+                let shared = fut.shared();
+                pending.insert(hash, shared.clone());
+                shared
+            }
+        };
+
+        let result = fut.await;
+
+        {
+            let mut pending = self.pending_receipts.lock().unwrap();
+            pending.remove(&hash);
+        }
+
+        match result {
+            Ok(receipt) => {
+                self.cache_receipt(&receipt);
+                Ok(receipt)
+            }
+            Err(e) => Err(SnbeatError::Rpc(e)),
+        }
     }
 
     async fn get_nonce(&self, address: Felt) -> Result<Felt> {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -25,10 +25,14 @@ pub trait DataSource: Send + Sync {
     async fn get_class(&self, class_hash: Felt) -> Result<ContractClass>;
     async fn get_recent_blocks(&self, count: usize) -> Result<Vec<SnBlock>>;
     /// Fetch recent events emitted by or targeting an address.
+    ///
+    /// `to_block` is an inclusive upper bound; `None` means "up to latest".
+    /// Used by pagination to fetch events strictly older than a cursor.
     async fn get_events_for_address(
         &self,
         address: Felt,
         from_block: Option<u64>,
+        to_block: Option<u64>,
         limit: usize,
     ) -> Result<Vec<SnEvent>>;
     /// Load cached tx summaries for an address (returns empty if none).
@@ -72,14 +76,17 @@ pub trait DataSource: Send + Sync {
     }
     /// Fetch events emitted by a contract (all events, not just transaction_executed).
     /// Used for finding calls TO a contract.
+    ///
+    /// `to_block` is an inclusive upper bound; `None` means "up to latest".
     async fn get_contract_events(
         &self,
         address: Felt,
         from_block: Option<u64>,
+        to_block: Option<u64>,
         limit: usize,
     ) -> Result<Vec<SnEvent>> {
         // Default: same as get_events_for_address (overridden in RPC impl)
-        self.get_events_for_address(address, from_block, limit)
+        self.get_events_for_address(address, from_block, to_block, limit)
             .await
     }
     /// Call a contract view function (e.g., balance_of).

--- a/src/data/pathfinder.rs
+++ b/src/data/pathfinder.rs
@@ -1,7 +1,13 @@
+use crate::data::types::SnEvent;
 use serde::Deserialize;
 use starknet::core::types::Felt;
 use std::time::Duration;
 use tracing::debug;
+
+/// `transaction_executed` event selector — emitted once per invoke by every account contract.
+/// Shared with `src/data/rpc.rs` so both paths use the same filter.
+pub const TRANSACTION_EXECUTED_SELECTOR: &str =
+    "0x01dcde06aabdbca2f80aa51392b345d7549d7757aa855f7e37f5d335ac8243b1";
 
 /// HTTP client for the pf-query service.
 pub struct PathfinderClient {
@@ -63,6 +69,78 @@ pub struct ContractByClassEntry {
 #[derive(Debug, Clone, Deserialize)]
 pub struct ClassDeclarationInfo {
     pub block_number: u64,
+}
+
+/// Raw /contract-events event payload (hex strings, as pf-query returns them).
+#[derive(Debug, Clone, Deserialize)]
+struct PfContractEvent {
+    #[allow(dead_code)]
+    tx_index: usize,
+    event_index: usize,
+    tx_hash: String,
+    from_address: String,
+    keys: Vec<String>,
+    data: Vec<String>,
+    block_number: u64,
+    #[allow(dead_code)]
+    #[serde(default)]
+    timestamp: u64,
+}
+
+/// Paginated /contract-events response.
+#[derive(Debug, Clone, Deserialize)]
+struct PfContractEventsResponse {
+    events: Vec<PfContractEvent>,
+    continuation_token: Option<u64>,
+}
+
+/// Serialize a positional key filter as pf-query expects:
+/// groups separated by `;`, OR-keys within a group by `,`.
+/// Empty groups => wildcard at that position.
+fn encode_keys_filter(keys: &[Vec<Felt>]) -> Option<String> {
+    if keys.is_empty() {
+        return None;
+    }
+    let parts: Vec<String> = keys
+        .iter()
+        .map(|group| {
+            group
+                .iter()
+                .map(|k| format!("{:#x}", k))
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .collect();
+    Some(parts.join(";"))
+}
+
+fn parse_felt(s: &str) -> anyhow::Result<Felt> {
+    Felt::from_hex(s).map_err(|e| anyhow::anyhow!("bad hex {s}: {e}"))
+}
+
+impl PfContractEvent {
+    fn into_sn_event(self) -> anyhow::Result<SnEvent> {
+        let from_address = parse_felt(&self.from_address)?;
+        let transaction_hash = parse_felt(&self.tx_hash)?;
+        let keys = self
+            .keys
+            .iter()
+            .map(|k| parse_felt(k))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let data = self
+            .data
+            .iter()
+            .map(|d| parse_felt(d))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(SnEvent {
+            from_address,
+            keys,
+            data,
+            transaction_hash,
+            block_number: self.block_number,
+            event_index: self.event_index as u64,
+        })
+    }
 }
 
 impl PathfinderClient {
@@ -188,6 +266,78 @@ impl PathfinderClient {
         Ok(resp.block_number)
     }
 
+    /// Fetch events emitted by a contract / account, newest-first.
+    ///
+    /// - `keys`: positional filter groups (empty = unfiltered).
+    ///   For accounts, pass `&[vec![TRANSACTION_EXECUTED_SELECTOR.parse()?]]`
+    ///   (or use [`PathfinderClient::get_events_for_address`]).
+    /// - `continuation_token`: pass `None` for first page, or the token from
+    ///   the previous response for subsequent pages.
+    ///
+    /// Returns `(events, next_continuation_token)`. When the token is `None`,
+    /// the range `[from_block, to_block]` has been fully scanned.
+    pub async fn get_contract_events(
+        &self,
+        address: Felt,
+        from_block: u64,
+        to_block: Option<u64>,
+        keys: &[Vec<Felt>],
+        limit: u32,
+        continuation_token: Option<u64>,
+    ) -> anyhow::Result<(Vec<SnEvent>, Option<u64>)> {
+        let addr_hex = format!("{:#x}", address);
+        let mut url = format!(
+            "{}/contract-events/{}?from_block={}&limit={}",
+            self.base_url, addr_hex, from_block, limit
+        );
+        if let Some(to) = to_block {
+            url.push_str(&format!("&to_block={to}"));
+        }
+        if let Some(tok) = continuation_token {
+            url.push_str(&format!("&continuation_token={tok}"));
+        }
+        if let Some(k) = encode_keys_filter(keys) {
+            // `,` and `;` are sub-delimiters in RFC 3986 but valid in query values
+            // per the generic syntax. Percent-encode `;` defensively since some
+            // intermediaries treat it as a pair separator. `,` stays literal.
+            let encoded = k.replace(';', "%3B");
+            url.push_str(&format!("&keys={encoded}"));
+        }
+
+        debug!(url = %url, "Fetching contract events from pf-query");
+        let resp: PfContractEventsResponse = self
+            .client
+            .get(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        let events = resp
+            .events
+            .into_iter()
+            .map(PfContractEvent::into_sn_event)
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok((events, resp.continuation_token))
+    }
+
+    /// Convenience: fetch account-emitted `transaction_executed` events for an address.
+    pub async fn get_events_for_address(
+        &self,
+        address: Felt,
+        from_block: u64,
+        to_block: Option<u64>,
+        limit: u32,
+        continuation_token: Option<u64>,
+    ) -> anyhow::Result<(Vec<SnEvent>, Option<u64>)> {
+        let selector = Felt::from_hex(TRANSACTION_EXECUTED_SELECTOR)
+            .expect("TRANSACTION_EXECUTED_SELECTOR is a valid felt");
+        let keys = vec![vec![selector]];
+        self.get_contract_events(address, from_block, to_block, &keys, limit, continuation_token)
+            .await
+    }
+
     pub async fn health(&self) -> anyhow::Result<HealthResponse> {
         let url = format!("{}/health", self.base_url);
         let resp = self
@@ -199,5 +349,287 @@ impl PathfinderClient {
             .json::<HealthResponse>()
             .await?;
         Ok(resp)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Benchmark & correctness tests that require live RPC + pf-query endpoints.
+    //! Run with:
+    //!   APP_RPC_URL=... APP_PATHFINDER_SERVICE_URL=... \
+    //!   BENCH_EVENTS_ADDRS="0xabc,account,label1;0xdef,contract,label2" \
+    //!   cargo test --release -- --ignored bench_events_rpc_vs_pathfinder --nocapture
+    use super::*;
+    use crate::data::DataSource;
+    use crate::data::rpc::RpcDataSource;
+    use std::collections::HashSet;
+    use std::time::Instant;
+
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    enum Role {
+        Account,
+        Contract,
+    }
+
+    impl Role {
+        fn parse(s: &str) -> anyhow::Result<Self> {
+            match s {
+                "account" => Ok(Role::Account),
+                "contract" => Ok(Role::Contract),
+                other => anyhow::bail!("unknown role {other:?}, expected 'account' or 'contract'"),
+            }
+        }
+    }
+
+    struct Case {
+        addr: Felt,
+        role: Role,
+        label: String,
+    }
+
+    fn parse_cases(raw: &str) -> anyhow::Result<Vec<Case>> {
+        raw.split(';')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|entry| {
+                let parts: Vec<&str> = entry.split(',').map(str::trim).collect();
+                anyhow::ensure!(
+                    parts.len() == 3,
+                    "bad case {entry:?}: expected 'addr,role,label'"
+                );
+                Ok(Case {
+                    addr: Felt::from_hex(parts[0])
+                        .map_err(|e| anyhow::anyhow!("bad addr {}: {e}", parts[0]))?,
+                    role: Role::parse(parts[1])?,
+                    label: parts[2].to_string(),
+                })
+            })
+            .collect()
+    }
+
+    /// Identity key for cross-source event comparison. Uses
+    /// `(tx_hash, block_number, keys, data)` — resilient to `event_index`
+    /// differences between RPC and pathfinder paths.
+    fn event_key(e: &SnEvent) -> (Felt, u64, Vec<Felt>, Vec<Felt>) {
+        (
+            e.transaction_hash,
+            e.block_number,
+            e.keys.clone(),
+            e.data.clone(),
+        )
+    }
+
+    fn event_set(events: &[SnEvent]) -> HashSet<(Felt, u64, Vec<Felt>, Vec<Felt>)> {
+        events.iter().map(event_key).collect()
+    }
+
+    /// Compare RPC vs PF event sets within the overlap block range.
+    /// Returns (matched, rpc_only, pf_only).
+    fn diff_sets(rpc: &[SnEvent], pf: &[SnEvent]) -> (usize, usize, usize) {
+        // Only compare events within the block range that BOTH sides cover.
+        let rpc_min = rpc.iter().map(|e| e.block_number).min().unwrap_or(u64::MAX);
+        let rpc_max = rpc.iter().map(|e| e.block_number).max().unwrap_or(0);
+        let pf_min = pf.iter().map(|e| e.block_number).min().unwrap_or(u64::MAX);
+        let pf_max = pf.iter().map(|e| e.block_number).max().unwrap_or(0);
+        let lo = rpc_min.max(pf_min);
+        let hi = rpc_max.min(pf_max);
+        if lo > hi {
+            return (0, rpc.len(), pf.len());
+        }
+
+        let rpc_in: Vec<_> = rpc
+            .iter()
+            .filter(|e| e.block_number >= lo && e.block_number <= hi)
+            .cloned()
+            .collect();
+        let pf_in: Vec<_> = pf
+            .iter()
+            .filter(|e| e.block_number >= lo && e.block_number <= hi)
+            .cloned()
+            .collect();
+        let rpc_set = event_set(&rpc_in);
+        let pf_set = event_set(&pf_in);
+        let matched = rpc_set.intersection(&pf_set).count();
+        let rpc_only = rpc_set.difference(&pf_set).count();
+        let pf_only = pf_set.difference(&rpc_set).count();
+        (matched, rpc_only, pf_only)
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn bench_events_rpc_vs_pathfinder() -> anyhow::Result<()> {
+        let rpc_url = std::env::var("APP_RPC_URL")
+            .map_err(|_| anyhow::anyhow!("APP_RPC_URL must be set for this benchmark"))?;
+        let pf_url = std::env::var("APP_PATHFINDER_SERVICE_URL").map_err(|_| {
+            anyhow::anyhow!("APP_PATHFINDER_SERVICE_URL must be set for this benchmark")
+        })?;
+        let cases_raw = std::env::var("BENCH_EVENTS_ADDRS").map_err(|_| {
+            anyhow::anyhow!(
+                "BENCH_EVENTS_ADDRS must be set, e.g. \
+                 '0x213...,account,hi-acct;0x5dd...,contract,hi-ctr'"
+            )
+        })?;
+        let cases = parse_cases(&cases_raw)?;
+
+        let rpc = RpcDataSource::new(&rpc_url);
+        let pf = PathfinderClient::new(pf_url);
+
+        let latest = pf.health().await?.latest_block;
+
+        // Bench window: recent ~500k blocks. Wide enough that a stale account
+        // (>1 month inactive, ~86k blocks/week ≈ 350k/month) still has a hit.
+        let from_block = latest.saturating_sub(500_000);
+        // Page-size target. Matches a reasonable UI page; both paths should
+        // return roughly the same count for the same window.
+        const PAGE_LIMIT: u32 = 500;
+        // Time-to-first-event probe size (lower = closer to "first byte").
+        const TTFE_LIMIT: u32 = 1;
+
+        println!();
+        println!("# events bench — window [{from_block}, {latest}]  (limit={PAGE_LIMIT})");
+        println!();
+        println!(
+            "| label | role | source | ttfe_ms | page_ms | events | matched | rpc_only | pf_only |"
+        );
+        println!(
+            "|-------|------|--------|---------|---------|--------|---------|----------|---------|"
+        );
+
+        for case in &cases {
+            let Case { addr, role, label } = case;
+
+            // --- TTFE: fetch the very first event only. ---
+            let rpc_ttfe = {
+                let t = Instant::now();
+                let res = match role {
+                    Role::Account => {
+                        rpc.get_events_for_address(*addr, Some(from_block), TTFE_LIMIT as usize)
+                            .await
+                    }
+                    Role::Contract => {
+                        rpc.get_contract_events(*addr, Some(from_block), TTFE_LIMIT as usize)
+                            .await
+                    }
+                };
+                match res {
+                    Ok(_) => Some(t.elapsed().as_millis()),
+                    Err(e) => {
+                        eprintln!("rpc ttfe error for {label}: {e}");
+                        None
+                    }
+                }
+            };
+            let pf_ttfe = {
+                let t = Instant::now();
+                let res = match role {
+                    Role::Account => {
+                        pf.get_events_for_address(*addr, from_block, Some(latest), TTFE_LIMIT, None)
+                            .await
+                    }
+                    Role::Contract => {
+                        pf.get_contract_events(
+                            *addr,
+                            from_block,
+                            Some(latest),
+                            &[],
+                            TTFE_LIMIT,
+                            None,
+                        )
+                        .await
+                    }
+                };
+                match res {
+                    Ok(_) => Some(t.elapsed().as_millis()),
+                    Err(e) => {
+                        eprintln!("pf ttfe error for {label}: {e}");
+                        None
+                    }
+                }
+            };
+
+            // --- Full page: fetch up to PAGE_LIMIT events. ---
+            let t = Instant::now();
+            let rpc_events = match role {
+                Role::Account => {
+                    rpc.get_events_for_address(*addr, Some(from_block), PAGE_LIMIT as usize)
+                        .await
+                }
+                Role::Contract => {
+                    rpc.get_contract_events(*addr, Some(from_block), PAGE_LIMIT as usize)
+                        .await
+                }
+            }
+            .unwrap_or_else(|e| {
+                eprintln!("rpc page error for {label}: {e}");
+                Vec::new()
+            });
+            let rpc_page_ms = t.elapsed().as_millis();
+
+            let t = Instant::now();
+            let (pf_events, _tok) = match role {
+                Role::Account => pf
+                    .get_events_for_address(*addr, from_block, Some(latest), PAGE_LIMIT, None)
+                    .await
+                    .unwrap_or_else(|e| {
+                        eprintln!("pf page error for {label}: {e}");
+                        (Vec::new(), None)
+                    }),
+                Role::Contract => pf
+                    .get_contract_events(*addr, from_block, Some(latest), &[], PAGE_LIMIT, None)
+                    .await
+                    .unwrap_or_else(|e| {
+                        eprintln!("pf page error for {label}: {e}");
+                        (Vec::new(), None)
+                    }),
+            };
+            let pf_page_ms = t.elapsed().as_millis();
+
+            let (matched, rpc_only, pf_only) = diff_sets(&rpc_events, &pf_events);
+            let role_s = match role {
+                Role::Account => "account",
+                Role::Contract => "contract",
+            };
+            let ttfe_str = |v: Option<u128>| match v {
+                Some(ms) => ms.to_string(),
+                None => "ERR".to_string(),
+            };
+
+            println!(
+                "| {label} | {role_s} | rpc | {} | {rpc_page_ms} | {} | {matched} | {rpc_only} | {pf_only} |",
+                ttfe_str(rpc_ttfe),
+                rpc_events.len()
+            );
+            println!(
+                "| {label} | {role_s} | pf  | {} | {pf_page_ms} | {} |         |          |         |",
+                ttfe_str(pf_ttfe),
+                pf_events.len()
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn encode_keys_filter_shapes() {
+        let f1 = Felt::from_hex("0x1").unwrap();
+        let f2 = Felt::from_hex("0x2").unwrap();
+        let f3 = Felt::from_hex("0x3").unwrap();
+
+        assert_eq!(encode_keys_filter(&[]), None);
+        assert_eq!(
+            encode_keys_filter(&[vec![f1]]).unwrap(),
+            "0x1",
+            "single group, single key"
+        );
+        assert_eq!(
+            encode_keys_filter(&[vec![f1, f2]]).unwrap(),
+            "0x1,0x2",
+            "single group, OR'd keys"
+        );
+        assert_eq!(
+            encode_keys_filter(&[vec![f1], vec![], vec![f3]]).unwrap(),
+            "0x1;;0x3",
+            "empty middle group is a wildcard"
+        );
     }
 }

--- a/src/data/pathfinder.rs
+++ b/src/data/pathfinder.rs
@@ -476,27 +476,41 @@ mod tests {
 
         let latest = pf.health().await?.latest_block;
 
-        // Bench window: recent ~500k blocks. Wide enough that a stale account
-        // (>1 month inactive, ~86k blocks/week ≈ 350k/month) still has a hit.
-        let from_block = latest.saturating_sub(500_000);
-        // Page-size target. Matches a reasonable UI page; both paths should
-        // return roughly the same count for the same window.
+        // Two scenarios:
+        //  - "cold"  : matches the app's initial fetch window in
+        //              src/network/address.rs (10k blocks for contracts,
+        //              5k for accounts).
+        //  - "scroll": simulates scroll-to-bottom paging over a deeper range.
         const PAGE_LIMIT: u32 = 500;
         // Time-to-first-event probe size (lower = closer to "first byte").
         const TTFE_LIMIT: u32 = 1;
 
-        println!();
-        println!("# events bench — window [{from_block}, {latest}]  (limit={PAGE_LIMIT})");
+        let scenarios: [(&str, u64, u64); 2] = [
+            // name, account_window, contract_window
+            ("cold", 5_000, 10_000),
+            ("scroll", 500_000, 500_000),
+        ];
+
         println!();
         println!(
-            "| label | role | source | ttfe_ms | page_ms | events | matched | rpc_only | pf_only |"
+            "# events bench — latest={latest}, page_limit={PAGE_LIMIT}, ttfe_limit={TTFE_LIMIT}"
+        );
+        println!();
+        println!(
+            "| scenario | label | role | window | source | ttfe_ms | page_ms | events | matched | rpc_only | pf_only |"
         );
         println!(
-            "|-------|------|--------|---------|---------|--------|---------|----------|---------|"
+            "|----------|-------|------|--------|--------|---------|---------|--------|---------|----------|---------|"
         );
 
+        for (scenario, acct_win, ctr_win) in scenarios.iter() {
         for case in &cases {
             let Case { addr, role, label } = case;
+            let window = match role {
+                Role::Account => *acct_win,
+                Role::Contract => *ctr_win,
+            };
+            let from_block = latest.saturating_sub(window);
 
             // --- TTFE: fetch the very first event only. ---
             let rpc_ttfe = {
@@ -595,15 +609,16 @@ mod tests {
             };
 
             println!(
-                "| {label} | {role_s} | rpc | {} | {rpc_page_ms} | {} | {matched} | {rpc_only} | {pf_only} |",
+                "| {scenario} | {label} | {role_s} | {window} | rpc | {} | {rpc_page_ms} | {} | {matched} | {rpc_only} | {pf_only} |",
                 ttfe_str(rpc_ttfe),
                 rpc_events.len()
             );
             println!(
-                "| {label} | {role_s} | pf  | {} | {pf_page_ms} | {} |         |          |         |",
+                "| {scenario} | {label} | {role_s} | {window} | pf  | {} | {pf_page_ms} | {} |         |          |         |",
                 ttfe_str(pf_ttfe),
                 pf_events.len()
             );
+        }
         }
 
         Ok(())

--- a/src/data/pathfinder.rs
+++ b/src/data/pathfinder.rs
@@ -58,6 +58,38 @@ pub struct TxHashLookup {
     pub tx_index: u64,
 }
 
+/// Per-tx data returned by `POST /txs-by-hash`.
+///
+/// Covers everything the address-view enrichment path needs without an RPC
+/// round trip: multicall calldata (for endpoint name decoding), sender,
+/// nonce, fee, status, and block timestamp.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TxByHashData {
+    pub hash: String,
+    pub block_number: u64,
+    pub block_timestamp: u64,
+    #[allow(dead_code)]
+    pub tx_index: u64,
+    pub sender: String,
+    pub nonce: Option<u64>,
+    pub tx_type: String,
+    /// Calldata felts, `0x`-prefixed hex. For invoke txs this is the multicall
+    /// payload (matches RPC `InvokeTransaction.calldata`); empty for declare.
+    pub calldata: Vec<String>,
+    pub actual_fee: String,
+    #[allow(dead_code)]
+    pub tip: u64,
+    pub status: String,
+    pub revert_reason: Option<String>,
+}
+
+/// Entry from `GET /block-timestamps`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BlockTimestamp {
+    pub block_number: u64,
+    pub timestamp: u64,
+}
+
 /// A contract deployed with a given class hash.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ContractByClassEntry {
@@ -231,6 +263,50 @@ impl PathfinderClient {
         Ok(resp)
     }
 
+    /// Bulk-fetch tx + receipt data by hash in one round trip.
+    ///
+    /// Hashes not present in the Pathfinder DB are silently omitted from the
+    /// response — callers should diff requested vs returned and fall back
+    /// (e.g. to RPC) for missing ones.
+    pub async fn get_txs_by_hash(&self, hashes: &[Felt]) -> anyhow::Result<Vec<TxByHashData>> {
+        if hashes.is_empty() {
+            return Ok(Vec::new());
+        }
+        let url = format!("{}/txs-by-hash", self.base_url);
+        let hashes_hex: Vec<String> = hashes.iter().map(|h| format!("{:#x}", h)).collect();
+        let body = serde_json::json!({ "hashes": hashes_hex });
+        debug!(url = %url, count = hashes.len(), "Fetching txs by hash from pf-query");
+        let entries = self
+            .client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<Vec<TxByHashData>>()
+            .await?;
+        Ok(entries)
+    }
+
+    /// Bulk-fetch block timestamps over an inclusive range.
+    pub async fn get_block_timestamps(
+        &self,
+        from: u64,
+        to: u64,
+    ) -> anyhow::Result<Vec<BlockTimestamp>> {
+        let url = format!("{}/block-timestamps?from={}&to={}", self.base_url, from, to);
+        debug!(url = %url, "Fetching block timestamps from pf-query");
+        let entries = self
+            .client
+            .get(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<Vec<BlockTimestamp>>()
+            .await?;
+        Ok(entries)
+    }
+
     /// Fetch all contracts deployed with a given class hash.
     pub async fn get_contracts_by_class(
         &self,
@@ -334,8 +410,15 @@ impl PathfinderClient {
         let selector = Felt::from_hex(TRANSACTION_EXECUTED_SELECTOR)
             .expect("TRANSACTION_EXECUTED_SELECTOR is a valid felt");
         let keys = vec![vec![selector]];
-        self.get_contract_events(address, from_block, to_block, &keys, limit, continuation_token)
-            .await
+        self.get_contract_events(
+            address,
+            from_block,
+            to_block,
+            &keys,
+            limit,
+            continuation_token,
+        )
+        .await
     }
 
     pub async fn health(&self) -> anyhow::Result<HealthResponse> {
@@ -504,121 +587,142 @@ mod tests {
         );
 
         for (scenario, acct_win, ctr_win) in scenarios.iter() {
-        for case in &cases {
-            let Case { addr, role, label } = case;
-            let window = match role {
-                Role::Account => *acct_win,
-                Role::Contract => *ctr_win,
-            };
-            let from_block = latest.saturating_sub(window);
+            for case in &cases {
+                let Case { addr, role, label } = case;
+                let window = match role {
+                    Role::Account => *acct_win,
+                    Role::Contract => *ctr_win,
+                };
+                let from_block = latest.saturating_sub(window);
 
-            // --- TTFE: fetch the very first event only. ---
-            let rpc_ttfe = {
-                let t = Instant::now();
-                let res = match role {
-                    Role::Account => {
-                        rpc.get_events_for_address(*addr, Some(from_block), TTFE_LIMIT as usize)
+                // --- TTFE: fetch the very first event only. ---
+                let rpc_ttfe = {
+                    let t = Instant::now();
+                    let res = match role {
+                        Role::Account => {
+                            rpc.get_events_for_address(
+                                *addr,
+                                Some(from_block),
+                                None,
+                                TTFE_LIMIT as usize,
+                            )
                             .await
-                    }
-                    Role::Contract => {
-                        rpc.get_contract_events(*addr, Some(from_block), TTFE_LIMIT as usize)
+                        }
+                        Role::Contract => {
+                            rpc.get_contract_events(
+                                *addr,
+                                Some(from_block),
+                                None,
+                                TTFE_LIMIT as usize,
+                            )
                             .await
+                        }
+                    };
+                    match res {
+                        Ok(_) => Some(t.elapsed().as_millis()),
+                        Err(e) => {
+                            eprintln!("rpc ttfe error for {label}: {e}");
+                            None
+                        }
                     }
                 };
-                match res {
-                    Ok(_) => Some(t.elapsed().as_millis()),
-                    Err(e) => {
-                        eprintln!("rpc ttfe error for {label}: {e}");
-                        None
-                    }
-                }
-            };
-            let pf_ttfe = {
-                let t = Instant::now();
-                let res = match role {
-                    Role::Account => {
-                        pf.get_events_for_address(*addr, from_block, Some(latest), TTFE_LIMIT, None)
+                let pf_ttfe = {
+                    let t = Instant::now();
+                    let res = match role {
+                        Role::Account => {
+                            pf.get_events_for_address(
+                                *addr,
+                                from_block,
+                                Some(latest),
+                                TTFE_LIMIT,
+                                None,
+                            )
                             .await
+                        }
+                        Role::Contract => {
+                            pf.get_contract_events(
+                                *addr,
+                                from_block,
+                                Some(latest),
+                                &[],
+                                TTFE_LIMIT,
+                                None,
+                            )
+                            .await
+                        }
+                    };
+                    match res {
+                        Ok(_) => Some(t.elapsed().as_millis()),
+                        Err(e) => {
+                            eprintln!("pf ttfe error for {label}: {e}");
+                            None
+                        }
                     }
-                    Role::Contract => {
-                        pf.get_contract_events(
+                };
+
+                // --- Full page: fetch up to PAGE_LIMIT events. ---
+                let t = Instant::now();
+                let rpc_events = match role {
+                    Role::Account => {
+                        rpc.get_events_for_address(
                             *addr,
-                            from_block,
-                            Some(latest),
-                            &[],
-                            TTFE_LIMIT,
+                            Some(from_block),
                             None,
+                            PAGE_LIMIT as usize,
                         )
                         .await
                     }
-                };
-                match res {
-                    Ok(_) => Some(t.elapsed().as_millis()),
-                    Err(e) => {
-                        eprintln!("pf ttfe error for {label}: {e}");
-                        None
+                    Role::Contract => {
+                        rpc.get_contract_events(*addr, Some(from_block), None, PAGE_LIMIT as usize)
+                            .await
                     }
                 }
-            };
+                .unwrap_or_else(|e| {
+                    eprintln!("rpc page error for {label}: {e}");
+                    Vec::new()
+                });
+                let rpc_page_ms = t.elapsed().as_millis();
 
-            // --- Full page: fetch up to PAGE_LIMIT events. ---
-            let t = Instant::now();
-            let rpc_events = match role {
-                Role::Account => {
-                    rpc.get_events_for_address(*addr, Some(from_block), PAGE_LIMIT as usize)
+                let t = Instant::now();
+                let (pf_events, _tok) = match role {
+                    Role::Account => pf
+                        .get_events_for_address(*addr, from_block, Some(latest), PAGE_LIMIT, None)
                         .await
-                }
-                Role::Contract => {
-                    rpc.get_contract_events(*addr, Some(from_block), PAGE_LIMIT as usize)
+                        .unwrap_or_else(|e| {
+                            eprintln!("pf page error for {label}: {e}");
+                            (Vec::new(), None)
+                        }),
+                    Role::Contract => pf
+                        .get_contract_events(*addr, from_block, Some(latest), &[], PAGE_LIMIT, None)
                         .await
-                }
+                        .unwrap_or_else(|e| {
+                            eprintln!("pf page error for {label}: {e}");
+                            (Vec::new(), None)
+                        }),
+                };
+                let pf_page_ms = t.elapsed().as_millis();
+
+                let (matched, rpc_only, pf_only) = diff_sets(&rpc_events, &pf_events);
+                let role_s = match role {
+                    Role::Account => "account",
+                    Role::Contract => "contract",
+                };
+                let ttfe_str = |v: Option<u128>| match v {
+                    Some(ms) => ms.to_string(),
+                    None => "ERR".to_string(),
+                };
+
+                println!(
+                    "| {scenario} | {label} | {role_s} | {window} | rpc | {} | {rpc_page_ms} | {} | {matched} | {rpc_only} | {pf_only} |",
+                    ttfe_str(rpc_ttfe),
+                    rpc_events.len()
+                );
+                println!(
+                    "| {scenario} | {label} | {role_s} | {window} | pf  | {} | {pf_page_ms} | {} |         |          |         |",
+                    ttfe_str(pf_ttfe),
+                    pf_events.len()
+                );
             }
-            .unwrap_or_else(|e| {
-                eprintln!("rpc page error for {label}: {e}");
-                Vec::new()
-            });
-            let rpc_page_ms = t.elapsed().as_millis();
-
-            let t = Instant::now();
-            let (pf_events, _tok) = match role {
-                Role::Account => pf
-                    .get_events_for_address(*addr, from_block, Some(latest), PAGE_LIMIT, None)
-                    .await
-                    .unwrap_or_else(|e| {
-                        eprintln!("pf page error for {label}: {e}");
-                        (Vec::new(), None)
-                    }),
-                Role::Contract => pf
-                    .get_contract_events(*addr, from_block, Some(latest), &[], PAGE_LIMIT, None)
-                    .await
-                    .unwrap_or_else(|e| {
-                        eprintln!("pf page error for {label}: {e}");
-                        (Vec::new(), None)
-                    }),
-            };
-            let pf_page_ms = t.elapsed().as_millis();
-
-            let (matched, rpc_only, pf_only) = diff_sets(&rpc_events, &pf_events);
-            let role_s = match role {
-                Role::Account => "account",
-                Role::Contract => "contract",
-            };
-            let ttfe_str = |v: Option<u128>| match v {
-                Some(ms) => ms.to_string(),
-                None => "ERR".to_string(),
-            };
-
-            println!(
-                "| {scenario} | {label} | {role_s} | {window} | rpc | {} | {rpc_page_ms} | {} | {matched} | {rpc_only} | {pf_only} |",
-                ttfe_str(rpc_ttfe),
-                rpc_events.len()
-            );
-            println!(
-                "| {scenario} | {label} | {role_s} | {window} | pf  | {} | {pf_page_ms} | {} |         |          |         |",
-                ttfe_str(pf_ttfe),
-                pf_events.len()
-            );
-        }
         }
 
         Ok(())
@@ -646,5 +750,44 @@ mod tests {
             "0x1;;0x3",
             "empty middle group is a wildcard"
         );
+    }
+
+    /// Local re-implementation of `pf-query::parse_keys_filter` used as a
+    /// contract check: anything `encode_keys_filter` produces must be parseable
+    /// by the pf-query side with the same semantics. The two live in separate
+    /// crates, so we mirror the parser here and assert round-trip equivalence.
+    /// If this ever drifts, update both sides at once.
+    fn parse_keys_filter_mirror(raw: &str) -> Vec<Vec<Felt>> {
+        raw.split(';')
+            .map(|group_str| {
+                group_str
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(|k| Felt::from_hex(k).expect("valid hex"))
+                    .collect()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn encode_keys_filter_round_trips_through_pf_query_parser() {
+        let f1 = Felt::from_hex("0x1").unwrap();
+        let f2 = Felt::from_hex("0x2").unwrap();
+        let f3 = Felt::from_hex("0x3").unwrap();
+        let cases: Vec<Vec<Vec<Felt>>> = vec![
+            vec![vec![f1]],
+            vec![vec![f1, f2]],
+            vec![vec![f1], vec![], vec![f3]],
+            vec![vec![f1, f2, f3]],
+        ];
+        for input in cases {
+            let encoded = encode_keys_filter(&input).expect("non-empty filter encodes");
+            let round_tripped = parse_keys_filter_mirror(&encoded);
+            assert_eq!(
+                round_tripped, input,
+                "round-trip mismatch for {input:?} (encoded = {encoded:?})"
+            );
+        }
     }
 }

--- a/src/data/rpc.rs
+++ b/src/data/rpc.rs
@@ -32,7 +32,13 @@ impl RpcDataSource {
     }
 
     /// Shared helper: find the starting block with an expanding-window search, then
-    /// paginate through all matching events (newest-first on return).
+    /// paginate through matching events newest-first.
+    ///
+    /// Unlike `starknet_getEvents` (which returns oldest-first and has no
+    /// reverse flag), this walks the range in fixed windows from `latest`
+    /// downward. Each window is fully paginated oldest-first, then reversed
+    /// locally, so the caller sees the *globally newest* events first and we
+    /// stop as soon as `limit` is satisfied.
     async fn fetch_events_paginated(
         &self,
         address: Felt,
@@ -47,9 +53,11 @@ impl RpcDataSource {
             .await
             .map_err(|e| SnbeatError::Provider(e.to_string()))?;
 
-        // If from_block is specified (incremental from cache), use it directly.
-        // Otherwise, search backwards from the tip with expanding windows.
-        let from = if let Some(fb) = from_block {
+        // Resolve the lower bound of the search range.
+        // - Caller-provided: use as-is (cache-driven incremental).
+        // - Otherwise: expanding-window probe from the tip to find the oldest
+        //   window that still has events, so we don't walk the whole chain.
+        let lower = if let Some(fb) = from_block {
             fb
         } else {
             let windows = [50_000u64, 200_000, 1_000_000, latest];
@@ -74,50 +82,83 @@ impl RpcDataSource {
             found_from
         };
 
-        let filter = EventFilter {
-            from_block: Some(BlockId::Number(from)),
-            to_block: Some(BlockId::Tag(BlockTag::Latest)),
-            address: Some(AddressFilter::Single(address)),
-            keys,
-        };
+        // Walk backwards in fixed windows, newest-first.
+        // Window size is a trade-off: larger = fewer RPC calls on dense
+        // addresses; smaller = less overfetch on sparse ones. 10k matches the
+        // app's cold-start window for contracts in network/address.rs.
+        const WINDOW: u64 = 10_000;
+        const CHUNK_SIZE: u64 = 1000;
 
-        // Paginate through ALL events in range (RPC returns oldest-first)
-        let mut all_events = Vec::new();
-        let mut continuation_token = None;
-        let chunk_size = 1000u64;
-        let hard_limit = limit.max(5000);
+        let mut collected: Vec<SnEvent> = Vec::new();
+        let mut to = latest;
 
-        loop {
-            let page = self
-                .provider
-                .get_events(filter.clone(), continuation_token.clone(), chunk_size)
-                .await
-                .map_err(|e| SnbeatError::Provider(e.to_string()))?;
+        'outer: while to >= lower && collected.len() < limit {
+            let win_from = lower.max(to.saturating_sub(WINDOW));
 
-            for e in &page.events {
-                all_events.push(SnEvent {
-                    from_address: e.from_address,
-                    keys: e.keys.clone(),
-                    data: e.data.clone(),
-                    transaction_hash: e.transaction_hash,
-                    block_number: e.block_number.unwrap_or(0),
-                    event_index: 0,
-                });
+            // Fully paginate this window (oldest-first per RPC contract).
+            let mut window_events: Vec<SnEvent> = Vec::new();
+            let mut continuation_token: Option<String> = None;
+            let filter = EventFilter {
+                from_block: Some(BlockId::Number(win_from)),
+                to_block: Some(BlockId::Number(to)),
+                address: Some(AddressFilter::Single(address)),
+                keys: keys.clone(),
+            };
+
+            // Per-block event index — reset every time the block changes so
+            // (tx_hash, block_number, event_index) is a stable dedup key
+            // matching what pathfinder emits.
+            let mut prev_block: u64 = u64::MAX;
+            let mut idx_in_block: u64 = 0;
+
+            loop {
+                let page = self
+                    .provider
+                    .get_events(filter.clone(), continuation_token.clone(), CHUNK_SIZE)
+                    .await
+                    .map_err(|e| SnbeatError::Provider(e.to_string()))?;
+
+                for e in &page.events {
+                    let bn = e.block_number.unwrap_or(0);
+                    if bn != prev_block {
+                        idx_in_block = 0;
+                        prev_block = bn;
+                    }
+                    window_events.push(SnEvent {
+                        from_address: e.from_address,
+                        keys: e.keys.clone(),
+                        data: e.data.clone(),
+                        transaction_hash: e.transaction_hash,
+                        block_number: bn,
+                        event_index: idx_in_block,
+                    });
+                    idx_in_block += 1;
+                }
+
+                match page.continuation_token {
+                    Some(token) => continuation_token = Some(token),
+                    None => break,
+                }
             }
 
-            if all_events.len() >= hard_limit {
+            // Reverse within-window events so this window's newest come first,
+            // then append to the (globally newest-first) accumulator.
+            window_events.reverse();
+            collected.extend(window_events);
+
+            if collected.len() >= limit {
+                break 'outer;
+            }
+            if win_from == lower {
                 break;
             }
-
-            match page.continuation_token {
-                Some(token) => continuation_token = Some(token),
-                None => break,
-            }
+            to = win_from.saturating_sub(1);
         }
 
-        debug!(total = all_events.len(), from_block = from, "{debug_label}");
-        all_events.reverse();
-        Ok(all_events)
+        debug!(total = collected.len(), lower, "{debug_label}");
+        // Trim to limit (windows may overshoot if the final window is dense).
+        collected.truncate(limit);
+        Ok(collected)
     }
 }
 

--- a/src/data/rpc.rs
+++ b/src/data/rpc.rs
@@ -43,6 +43,7 @@ impl RpcDataSource {
         &self,
         address: Felt,
         from_block: Option<u64>,
+        to_block: Option<u64>,
         limit: usize,
         keys: Option<Vec<Vec<Felt>>>,
         debug_label: &str,
@@ -52,6 +53,9 @@ impl RpcDataSource {
             .block_number()
             .await
             .map_err(|e| SnbeatError::Provider(e.to_string()))?;
+        // Upper bound for the reverse walk. Caller-specified `to_block` is
+        // clamped to `latest` so requests for future blocks don't error out.
+        let upper = to_block.map(|b| b.min(latest)).unwrap_or(latest);
 
         // Resolve the lower bound of the search range.
         // - Caller-provided: use as-is (cache-driven incremental).
@@ -63,10 +67,10 @@ impl RpcDataSource {
             let windows = [50_000u64, 200_000, 1_000_000, latest];
             let mut found_from = 0;
             for window in windows {
-                let test_from = latest.saturating_sub(window);
+                let test_from = upper.saturating_sub(window);
                 let test_filter = EventFilter {
                     from_block: Some(BlockId::Number(test_from)),
-                    to_block: Some(BlockId::Tag(BlockTag::Latest)),
+                    to_block: Some(BlockId::Number(upper)),
                     address: Some(AddressFilter::Single(address)),
                     keys: keys.clone(),
                 };
@@ -90,7 +94,7 @@ impl RpcDataSource {
         const CHUNK_SIZE: u64 = 1000;
 
         let mut collected: Vec<SnEvent> = Vec::new();
-        let mut to = latest;
+        let mut to = upper;
 
         'outer: while to >= lower && collected.len() < limit {
             let win_from = lower.max(to.saturating_sub(WINDOW));
@@ -332,17 +336,18 @@ impl DataSource for RpcDataSource {
         &self,
         address: Felt,
         from_block: Option<u64>,
+        to_block: Option<u64>,
         limit: usize,
     ) -> Result<Vec<SnEvent>> {
         // Use transaction_executed selector to get exactly 1 event per account tx.
         // This is emitted by every account contract on every invoke.
         let tx_executed_selector =
-            Felt::from_hex("0x01dcde06aabdbca2f80aa51392b345d7549d7757aa855f7e37f5d335ac8243b1")
-                .unwrap();
+            Felt::from_hex(crate::data::pathfinder::TRANSACTION_EXECUTED_SELECTOR).unwrap();
         let keys = Some(vec![vec![tx_executed_selector]]);
         self.fetch_events_paginated(
             address,
             from_block,
+            to_block,
             limit,
             keys,
             "Fetched events for address",
@@ -354,11 +359,19 @@ impl DataSource for RpcDataSource {
         &self,
         address: Felt,
         from_block: Option<u64>,
+        to_block: Option<u64>,
         limit: usize,
     ) -> Result<Vec<SnEvent>> {
         // No key filter — get ALL events from this contract
-        self.fetch_events_paginated(address, from_block, limit, None, "Fetched contract events")
-            .await
+        self.fetch_events_paginated(
+            address,
+            from_block,
+            to_block,
+            limit,
+            None,
+            "Fetched contract events",
+        )
+        .await
     }
 
     async fn call_contract(

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Create data source with persistent cache
     let rpc = RpcDataSource::new(&config.rpc_url);
-    let cached = CachingDataSource::new(Box::new(rpc), &cache_db)?;
+    let cached = CachingDataSource::new(Arc::new(rpc) as Arc<dyn data::DataSource>, &cache_db)?;
     let data_source: Arc<dyn data::DataSource> = Arc::new(cached);
 
     // ABI registry with persistent class cache

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -25,6 +25,81 @@ use super::voyager;
 const UDC_CONTRACT_DEPLOYED: &str =
     "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d";
 
+/// Fetch contract events via pathfinder when available, falling back to RPC.
+///
+/// Pathfinder wins on all contract event benchmarks (1-2ms TTFE vs ~1s cold RPC
+/// probe, 36-138ms page vs ~230ms RPC) thanks to its bloom-filter index on
+/// `from_address`. RPC is only exercised when PF is absent or the PF request
+/// fails (service down, transient error).
+async fn fetch_contract_events_routed(
+    pf: Option<&Arc<crate::data::pathfinder::PathfinderClient>>,
+    ds: &Arc<dyn DataSource>,
+    address: starknet::core::types::Felt,
+    from_block: Option<u64>,
+    limit: usize,
+) -> crate::error::Result<Vec<crate::data::types::SnEvent>> {
+    if let Some(pf_client) = pf {
+        match pf_client
+            .get_contract_events(
+                address,
+                from_block.unwrap_or(0),
+                None,
+                &[],
+                limit as u32,
+                None,
+            )
+            .await
+        {
+            Ok((events, _token)) => return Ok(events),
+            Err(e) => {
+                warn!(error = %e, "PF contract events failed, falling back to RPC");
+            }
+        }
+    }
+    ds.get_contract_events(address, from_block, limit).await
+}
+
+/// Fetch account `transaction_executed` events via RPC primarily, with PF fallback.
+///
+/// Bench shows RPC wins for account events on cold windows (20-30ms vs
+/// 165-634ms) and on stale accounts (11-17ms vs 118-131ms). PF's bloom filter
+/// indexes only `from_address` (not keys), so the `transaction_executed`
+/// filter doesn't narrow its scan. PF fallback covers RPC outages.
+async fn fetch_account_events_routed(
+    pf: Option<&Arc<crate::data::pathfinder::PathfinderClient>>,
+    ds: &Arc<dyn DataSource>,
+    address: starknet::core::types::Felt,
+    from_block: Option<u64>,
+    limit: usize,
+) -> crate::error::Result<Vec<crate::data::types::SnEvent>> {
+    match ds.get_events_for_address(address, from_block, limit).await {
+        Ok(events) => Ok(events),
+        Err(rpc_err) => {
+            if let Some(pf_client) = pf {
+                warn!(error = %rpc_err, "RPC account events failed, falling back to PF");
+                match pf_client
+                    .get_events_for_address(
+                        address,
+                        from_block.unwrap_or(0),
+                        None,
+                        limit as u32,
+                        None,
+                    )
+                    .await
+                {
+                    Ok((events, _token)) => Ok(events),
+                    Err(pf_err) => {
+                        warn!(error = %pf_err, "PF account events fallback also failed");
+                        Err(rpc_err)
+                    }
+                }
+            } else {
+                Err(rpc_err)
+            }
+        }
+    }
+}
+
 /// Fetch token balances for all known tokens for an address.
 async fn fetch_token_balances(
     address: starknet::core::types::Felt,
@@ -855,7 +930,8 @@ pub(super) async fn fetch_and_send_address_info(
     }
 
     // =====================================================================
-    // TASK C: RPC Events — small window first, probe-guided fallback, pagination for deeper
+    // TASK C: Events — pathfinder-first for contracts, RPC-first for accounts.
+    // Probe-guided fallback for sparse addresses; pagination for deeper history.
     // =====================================================================
     {
         let ds_c = Arc::clone(ds);
@@ -863,6 +939,7 @@ pub(super) async fn fetch_and_send_address_info(
         let tx_c = tx.clone();
         let voyager_c2 = voyager_c.clone();
         let _pf_ok = Arc::clone(&pf_succeeded);
+        let pf_c = pf.as_ref().map(Arc::clone);
         let mut probe_rx_c = probe_watch_rx.clone();
 
         tokio::spawn(async move {
@@ -906,11 +983,23 @@ pub(super) async fn fetch_and_send_address_info(
             let phase1_limit = if is_contract { 500 } else { 100 };
 
             let events_result = if is_contract {
-                ds_c.get_contract_events(address, Some(from_block), phase1_limit)
-                    .await
+                fetch_contract_events_routed(
+                    pf_c.as_ref(),
+                    &ds_c,
+                    address,
+                    Some(from_block),
+                    phase1_limit,
+                )
+                .await
             } else {
-                ds_c.get_events_for_address(address, Some(from_block), phase1_limit)
-                    .await
+                fetch_account_events_routed(
+                    pf_c.as_ref(),
+                    &ds_c,
+                    address,
+                    Some(from_block),
+                    phase1_limit,
+                )
+                .await
             };
             let events = match events_result {
                 Ok(evts) => evts,
@@ -1100,11 +1189,23 @@ pub(super) async fn fetch_and_send_address_info(
                         )));
 
                         let deeper_events = if is_contract {
-                            ds_c.get_contract_events(address, Some(search_from), 500)
-                                .await
+                            fetch_contract_events_routed(
+                                pf_c.as_ref(),
+                                &ds_c,
+                                address,
+                                Some(search_from),
+                                500,
+                            )
+                            .await
                         } else {
-                            ds_c.get_events_for_address(address, Some(search_from), 500)
-                                .await
+                            fetch_account_events_routed(
+                                pf_c.as_ref(),
+                                &ds_c,
+                                address,
+                                Some(search_from),
+                                500,
+                            )
+                            .await
                         };
 
                         if let Ok(deeper_events) = deeper_events {
@@ -1317,9 +1418,13 @@ pub(super) async fn enrich_address_txs(
     }
 }
 
-/// Post-display sanity check: fill nonce gaps and enrich all txs with missing endpoints.
-/// Runs once after all data sources complete, as a background pass.
-pub(super) async fn run_sanity_check(
+/// Post-display enrichment: fill only *small* nonce gaps and enrich all txs
+/// with missing endpoint names.
+///
+/// Large gaps (the pathological case from issue #10) are left untouched here;
+/// they are deferred to `run_nonce_gap_fill` which fires only when the user
+/// scrolls toward the gap.
+pub(super) async fn run_endpoint_enrichment(
     address: starknet::core::types::Felt,
     current_nonce: u64,
     known_txs: Vec<crate::data::types::AddressTxSummary>,
@@ -1333,7 +1438,7 @@ pub(super) async fn run_sanity_check(
             address = %format!("{:#x}", address),
             txs = known_txs.len(),
             current_nonce,
-            "Sanity check: skipping nonce gaps (empty txs or nonce=0), running endpoint enrichment only"
+            "Endpoint enrich: skipping nonce gaps (empty txs or nonce=0), running endpoint enrichment only"
         );
         enrich_all_empty_endpoints(address, &known_txs, ds, abi_reg, action_tx).await;
         return;
@@ -1352,12 +1457,13 @@ pub(super) async fn run_sanity_check(
         min_nonce,
         max_nonce,
         empty_endpoints,
-        "Sanity check: starting (nonce range {}..{}, {} txs, {} missing endpoints)",
+        "Endpoint enrich: starting (nonce range {}..{}, {} txs, {} missing endpoints)",
         min_nonce, max_nonce, known_txs.len(), empty_endpoints
     );
 
-    // --- Phase 1: Fill nonce gaps ---
-    let gap_txs = fill_nonce_gaps_phase(
+    // --- Phase 1: Fill only small nonce gaps ---
+    // Large gaps are left for on-demand fill via `run_nonce_gap_fill`.
+    let gap_txs = fill_small_nonce_gaps_phase(
         address,
         current_nonce,
         &known_txs,
@@ -1368,13 +1474,12 @@ pub(super) async fn run_sanity_check(
     )
     .await;
 
-    // Send gap-fill results through existing merge path
     if !gap_txs.is_empty() {
         let gap_nonces: Vec<u64> = gap_txs.iter().map(|t| t.nonce).collect();
         info!(
             found = gap_txs.len(),
             nonces = ?gap_nonces,
-            "Sanity check: filled {} nonce gaps, sending to UI",
+            "Endpoint enrich: filled {} small nonce gaps, sending to UI",
             gap_txs.len()
         );
         let _ = action_tx.send(Action::AddressTxsEnriched {
@@ -1382,11 +1487,10 @@ pub(super) async fn run_sanity_check(
             updates: gap_txs.clone(),
         });
     } else {
-        info!("Sanity check: no nonce gaps to fill");
+        info!("Endpoint enrich: no small nonce gaps to fill");
     }
 
     // --- Phase 2: Enrich all txs with missing endpoint names ---
-    // Combine original known_txs + newly found gap txs for a complete picture
     let mut all_txs = known_txs;
     for gt in &gap_txs {
         if !all_txs.iter().any(|t| t.hash == gt.hash) {
@@ -1397,19 +1501,84 @@ pub(super) async fn run_sanity_check(
 
     debug!(
         address = %format!("{:#x}", address),
-        "Sanity check complete"
+        "Endpoint enrich complete"
     );
 }
 
-/// Phase 1 of sanity check: detect and fill nonce gaps.
-/// Small gaps (≤50 blocks) are filled via RPC block scanning.
-/// Large gaps use Dune windowed queries when available.
-async fn fill_nonce_gaps_phase(
+/// On-demand fill of a single large nonce gap (issue #10).
+///
+/// Queries Dune for the gap's block range (if available) to locate missing
+/// txs, then enriches missing endpoints on the returned set. Progressive
+/// results flow through `AddressTxsEnriched` like the auto path.
+pub(super) async fn run_nonce_gap_fill(
+    address: starknet::core::types::Felt,
+    known_txs: Vec<crate::data::types::AddressTxSummary>,
+    gap: crate::app::views::address_info::UnfilledGap,
+    ds: &Arc<dyn DataSource>,
+    dune: &Option<Arc<dune::DuneClient>>,
+    abi_reg: &Arc<AbiRegistry>,
+    action_tx: &mpsc::UnboundedSender<Action>,
+) {
+    info!(
+        address = %format!("{:#x}", address),
+        lo_nonce = gap.lo_nonce,
+        hi_nonce = gap.hi_nonce,
+        lo_block = gap.lo_block,
+        hi_block = gap.hi_block,
+        missing = gap.missing_count,
+        "Gap fill: filling large nonce gap on demand"
+    );
+
+    let _ = action_tx.send(Action::LoadingStatus(format!(
+        "Filling gap of {} txs...",
+        gap.missing_count
+    )));
+
+    let found = fill_specific_large_gap(address, &known_txs, &gap, dune, action_tx).await;
+
+    if !found.is_empty() {
+        info!(
+            found = found.len(),
+            "Gap fill: Dune returned {} new txs, enriching endpoints",
+            found.len()
+        );
+        let _ = action_tx.send(Action::AddressTxsEnriched {
+            address,
+            updates: found.clone(),
+        });
+
+        // Enrich endpoints for the newly discovered txs (they usually arrive from
+        // Dune without endpoint names decoded).
+        let mut combined = known_txs;
+        for t in &found {
+            if !combined.iter().any(|k| k.hash == t.hash) {
+                combined.push(t.clone());
+            }
+        }
+        enrich_all_empty_endpoints(address, &combined, ds, abi_reg, action_tx).await;
+    } else {
+        info!("Gap fill: no txs returned from Dune for this range");
+        let _ = action_tx.send(Action::LoadingStatus(String::new()));
+    }
+
+    debug!(
+        address = %format!("{:#x}", address),
+        "Gap fill complete"
+    );
+}
+
+/// Fill only the *small* nonce gaps (≤50 blocks each) via RPC block scans.
+///
+/// Large gaps are skipped here and deferred to on-demand fill via
+/// `run_nonce_gap_fill` (issue #10). This function retains the same gap
+/// classification the original code used; the only behavior change is the
+/// removal of the Dune-driven large-gap path.
+async fn fill_small_nonce_gaps_phase(
     address: starknet::core::types::Felt,
     current_nonce: u64,
     known_txs: &[crate::data::types::AddressTxSummary],
     ds: &Arc<dyn DataSource>,
-    dune: &Option<Arc<dune::DuneClient>>,
+    _dune: &Option<Arc<dune::DuneClient>>,
     abi_reg: &Arc<AbiRegistry>,
     action_tx: &mpsc::UnboundedSender<Action>,
 ) -> Vec<crate::data::types::AddressTxSummary> {
@@ -1481,7 +1650,9 @@ async fn fill_nonce_gaps_phase(
         }
     }
 
-    let total_gaps = small_gaps.len() + large_gap_ranges.len();
+    let small_count = small_gaps.len();
+    let large_count = large_gap_ranges.len();
+    let total_gaps = small_count + large_count;
     if total_gaps == 0 {
         info!(
             "Sanity gap check: no nonce gaps found in range {}..{}",
@@ -1490,26 +1661,27 @@ async fn fill_nonce_gaps_phase(
         return Vec::new();
     }
 
-    // Log the first few missing nonces for debugging
     let small_nonces: Vec<u64> = small_gaps.iter().map(|(n, _, _)| *n).take(10).collect();
     info!(
-        small = small_gaps.len(),
-        large = large_gap_ranges.len(),
+        small = small_count,
+        large = large_count,
         total = total_gaps,
         first_small_nonces = ?small_nonces,
         large_ranges = ?large_gap_ranges.iter().take(5).collect::<Vec<_>>(),
-        "Sanity check: detected {} nonce gaps ({} small, {} large)",
-        total_gaps, small_gaps.len(), large_gap_ranges.len()
+        "Sanity check: detected {} nonce gaps ({} small, {} large — large deferred to on-demand fill)",
+        total_gaps, small_count, large_count
     );
 
-    let _ = action_tx.send(Action::LoadingStatus(format!(
-        "Filling {} nonce gaps...",
-        total_gaps
-    )));
+    if small_count > 0 {
+        let _ = action_tx.send(Action::LoadingStatus(format!(
+            "Filling {} small nonce gaps...",
+            small_count
+        )));
+    }
 
     let mut found_txs = Vec::new();
 
-    // Small gaps: RPC block scan
+    // Small gaps only: RPC block scan. Large gaps are left for on-demand fill.
     if !small_gaps.is_empty() {
         let mut blocks_to_scan: std::collections::BTreeSet<u64> = std::collections::BTreeSet::new();
         for (_, from, to) in &small_gaps {
@@ -1543,81 +1715,73 @@ async fn fill_nonce_gaps_phase(
         }
     }
 
-    // Large gaps: Dune windowed query — merge adjacent ranges into bigger windows
-    if let Some(dune_c) = dune {
-        large_gap_ranges.sort();
-        // Merge overlapping/adjacent ranges (within 500 blocks of each other)
-        let mut merged: Vec<(u64, u64)> = Vec::new();
-        for (from, to) in large_gap_ranges {
-            if let Some(last) = merged.last_mut() {
-                if from <= last.1 + 500 {
-                    last.1 = last.1.max(to);
-                    continue;
-                }
-            }
-            merged.push((from, to));
-        }
+    found_txs
+}
 
-        info!(
-            merged_ranges = merged.len(),
-            "Sanity gap-fill: merged large gaps into {} Dune queries",
-            merged.len()
+/// On-demand Dune query for a single large nonce gap (issue #10).
+///
+/// Caller supplies the known lo/hi block bounds of the gap; we query Dune's
+/// windowed account-tx endpoint for that range, deduplicate against known
+/// hashes, and return the new entries.
+async fn fill_specific_large_gap(
+    address: starknet::core::types::Felt,
+    known_txs: &[crate::data::types::AddressTxSummary],
+    gap: &crate::app::views::address_info::UnfilledGap,
+    dune: &Option<Arc<dune::DuneClient>>,
+    action_tx: &mpsc::UnboundedSender<Action>,
+) -> Vec<crate::data::types::AddressTxSummary> {
+    let Some(dune_c) = dune.as_ref() else {
+        warn!(
+            "Gap fill: Dune client unavailable, cannot fill gap {}..{}",
+            gap.lo_block, gap.hi_block
         );
+        let _ = action_tx.send(Action::LoadingStatus(
+            "Gap fill unavailable (Dune not configured)".to_string(),
+        ));
+        return Vec::new();
+    };
 
-        let known_hashes: std::collections::HashSet<_> = known_txs
-            .iter()
-            .chain(found_txs.iter())
-            .map(|t| t.hash)
-            .collect();
+    let from = gap.lo_block;
+    let to = gap.hi_block;
+    info!(
+        from,
+        to,
+        span = to.saturating_sub(from),
+        "Gap fill: querying Dune for blocks {}..{}",
+        from,
+        to
+    );
 
-        for (from, to) in &merged {
+    let known_hashes: std::collections::HashSet<_> = known_txs.iter().map(|t| t.hash).collect();
+
+    match dune_c
+        .query_account_txs_windowed(address, from, to, 1000)
+        .await
+    {
+        Ok(dune_txs) => {
+            let total_returned = dune_txs.len();
+            let new: Vec<_> = dune_txs
+                .into_iter()
+                .filter(|t| !known_hashes.contains(&t.hash))
+                .collect();
             info!(
+                returned = total_returned,
+                new = new.len(),
                 from,
                 to,
-                span = to - from,
-                "Sanity gap-fill: querying Dune for blocks {}..{} (span {})",
+                "Gap fill: Dune returned {} txs, {} new for blocks {}..{}",
+                total_returned,
+                new.len(),
                 from,
-                to,
-                to - from
+                to
             );
-            match dune_c
-                .query_account_txs_windowed(address, *from, *to, 200)
-                .await
-            {
-                Ok(dune_txs) => {
-                    let total_returned = dune_txs.len();
-                    let new: Vec<_> = dune_txs
-                        .into_iter()
-                        .filter(|t| !known_hashes.contains(&t.hash))
-                        .collect();
-                    info!(
-                        returned = total_returned,
-                        new = new.len(),
-                        from,
-                        to,
-                        "Sanity gap-fill: Dune returned {} txs, {} new for blocks {}..{}",
-                        total_returned,
-                        new.len(),
-                        from,
-                        to
-                    );
-                    if !new.is_empty() {
-                        // Send intermediate results so the UI updates progressively
-                        let _ = action_tx.send(Action::AddressTxsEnriched {
-                            address,
-                            updates: new.clone(),
-                        });
-                        found_txs.extend(new);
-                    }
-                }
-                Err(e) => {
-                    warn!(error = %e, from, to, "Sanity gap-fill: Dune query failed for blocks {}..{}", from, to);
-                }
-            }
+            new
+        }
+        Err(e) => {
+            warn!(error = %e, from, to, "Gap fill: Dune query failed for blocks {}..{}", from, to);
+            Vec::new()
         }
     }
-
-    found_txs
 }
 
 /// Phase 2 of sanity check: enrich ALL txs that have empty endpoint names.
@@ -1732,6 +1896,7 @@ pub(super) async fn fetch_more_address_txs(
     is_contract: bool,
     ds: &Arc<dyn crate::data::DataSource>,
     dune: &Option<Arc<dune::DuneClient>>,
+    pf: &Option<Arc<crate::data::pathfinder::PathfinderClient>>,
     abi_reg: &Arc<AbiRegistry>,
     tx: &mpsc::UnboundedSender<Action>,
 ) {
@@ -1796,26 +1961,47 @@ pub(super) async fn fetch_more_address_txs(
         before_block.saturating_sub(1)
     )));
 
-    // Fire RPC + Dune in parallel
+    // Fire events-source + Dune in parallel.
+    //
+    // Events source routing (matches initial fetch):
+    //  - Contracts: pathfinder primary (bloom-indexed, fast for dense contracts),
+    //    RPC fallback on PF error. Used to be skipped entirely because RPC was
+    //    too slow for dense contracts at scroll depth — PF resolves that.
+    //  - Accounts: RPC primary (narrow window + key filter is fast), PF fallback.
     let rpc_ds = Arc::clone(ds);
+    let pf_c = pf.as_ref().map(Arc::clone);
     let rpc_addr = address;
     let rpc_before = before_block;
     let rpc_is_contract = is_contract;
     // Cap RPC window at 10k blocks — RPC is slow for large ranges.
-    // For contracts, skip RPC entirely — Dune is the primary source for contract calls.
     let rpc_window = window_size.min(10_000);
     let rpc_from = before_block.saturating_sub(rpc_window);
 
     let rpc_fut = async move {
-        if rpc_is_contract {
-            // Skip RPC for contract pagination — events are rarely found via RPC
-            // for high-traffic contracts, and the scan blocks the response.
-            return Vec::new();
-        }
-        let events = rpc_ds
-            .get_events_for_address(rpc_addr, Some(rpc_from), 500)
+        let events = if rpc_is_contract {
+            // Pathfinder can scan the full window range efficiently via bloom
+            // filters; use window_size directly rather than clamping to 10k.
+            let pf_from = before_block.saturating_sub(window_size);
+            fetch_contract_events_routed(
+                pf_c.as_ref(),
+                &rpc_ds,
+                rpc_addr,
+                Some(pf_from),
+                500,
+            )
             .await
-            .unwrap_or_default();
+            .unwrap_or_default()
+        } else {
+            fetch_account_events_routed(
+                pf_c.as_ref(),
+                &rpc_ds,
+                rpc_addr,
+                Some(rpc_from),
+                500,
+            )
+            .await
+            .unwrap_or_default()
+        };
         events
             .into_iter()
             .filter(|e| e.block_number < rpc_before)

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -1923,10 +1923,20 @@ async fn enrich_all_empty_endpoints(
     abi_reg: &Arc<AbiRegistry>,
     action_tx: &mpsc::UnboundedSender<Action>,
 ) {
+    // Viewport-scoped: only proactively enrich an initial buffer large enough
+    // to cover the visible list + some scroll-ahead. Rows outside this buffer
+    // get enriched on demand as the user scrolls to them (see
+    // `maybe_enrich_visible_address_txs`). Prevents the 60-batch RPC storm
+    // for accounts with thousands of missing endpoints.
+    const ENRICH_BUFFER: usize = 200;
+
     let total_invoke = all_txs.iter().filter(|t| t.tx_type == "INVOKE").count();
+    // `all_txs` is newest-first, so taking the first N missing items
+    // prioritizes the rows the user will see immediately.
     let missing: Vec<starknet::core::types::Felt> = all_txs
         .iter()
         .filter(|t| t.endpoint_names.is_empty() && t.tx_type == "INVOKE")
+        .take(ENRICH_BUFFER)
         .map(|t| t.hash)
         .collect();
 
@@ -1939,21 +1949,21 @@ async fn enrich_all_empty_endpoints(
     }
 
     info!(
-        missing = missing.len(),
+        enriching = missing.len(),
         total_invoke,
-        "Sanity check endpoints: {} of {} INVOKE txs missing endpoints, enriching in batches",
-        missing.len(),
-        total_invoke
+        buffer = ENRICH_BUFFER,
+        "Sanity check endpoints: enriching top {} missing (viewport buffer), remainder on-demand",
+        missing.len()
     );
 
-    // Process in batches of 20
+    // Process in batches of 20 for streaming UI updates.
     for (i, chunk) in missing.chunks(20).enumerate() {
         info!(
             batch = i + 1,
             size = chunk.len(),
             "Sanity check endpoints: enriching batch {}/{}",
             i + 1,
-            (missing.len() + 19) / 20
+            missing.len().div_ceil(20)
         );
         enrich_address_txs(address, chunk.to_vec(), ds, pf, abi_reg, action_tx).await;
     }

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -3,9 +3,17 @@
 
 use std::sync::Arc;
 
+use std::sync::LazyLock;
 use std::sync::atomic::{AtomicBool, Ordering};
-use tokio::sync::mpsc;
+use tokio::sync::{Semaphore, mpsc};
 use tracing::{debug, info, warn};
+
+/// Caps concurrent RPC `get_transaction` / `get_receipt` calls fired from the
+/// background enrichment path so that a user-initiated `FetchTransaction`
+/// never queues behind dozens of enrichment round trips. Only applies when
+/// pf-query is unavailable (or didn't return the requested hash). User clicks
+/// bypass this semaphore entirely.
+static ENRICH_RPC_SEMAPHORE: LazyLock<Semaphore> = LazyLock::new(|| Semaphore::new(8));
 
 use crate::app::actions::{Action, Source};
 use crate::data::DataSource;
@@ -25,76 +33,130 @@ use super::voyager;
 const UDC_CONTRACT_DEPLOYED: &str =
     "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d";
 
-/// Fetch contract events via pathfinder when available, falling back to RPC.
+/// Whether we're fetching events for a contract or a user account.
 ///
-/// Pathfinder wins on all contract event benchmarks (1-2ms TTFE vs ~1s cold RPC
-/// probe, 36-138ms page vs ~230ms RPC) thanks to its bloom-filter index on
-/// `from_address`. RPC is only exercised when PF is absent or the PF request
-/// fails (service down, transient error).
-async fn fetch_contract_events_routed(
+/// Determines both the event filter (accounts use the `transaction_executed`
+/// selector key filter; contracts fetch everything the contract emitted) and
+/// the preferred primary data source — see [`fetch_events_routed`].
+#[derive(Debug, Clone, Copy)]
+pub(super) enum EventQueryKind {
+    /// Account address — we want one event per invoke (`transaction_executed`).
+    Account,
+    /// Contract address — we want all events emitted by the contract.
+    Contract,
+}
+
+/// Fetch address-scoped events, routing between pathfinder and RPC per benchmark.
+///
+/// Routing (from `bench_events_rpc_vs_pathfinder`):
+///  - **Contracts** → pathfinder primary, RPC fallback.
+///    PF's bloom-filter index on `from_address` makes it 1-2ms TTFE vs ~1s
+///    cold RPC probe; page fetches are 36-138ms vs ~230ms on RPC.
+///  - **Accounts** → RPC primary, PF fallback.
+///    PF's bloom indexes `from_address` but not keys, so the
+///    `transaction_executed` filter doesn't narrow its scan — RPC with the
+///    key filter wins on cold windows (20-30ms vs 165-634ms) and on stale
+///    accounts (11-17ms vs 118-131ms).
+///
+/// `to_block` is an inclusive upper bound (useful for pagination into older
+/// history); `None` means "up to latest".
+pub(super) async fn fetch_events_routed(
+    kind: EventQueryKind,
     pf: Option<&Arc<crate::data::pathfinder::PathfinderClient>>,
     ds: &Arc<dyn DataSource>,
     address: starknet::core::types::Felt,
     from_block: Option<u64>,
+    to_block: Option<u64>,
     limit: usize,
 ) -> crate::error::Result<Vec<crate::data::types::SnEvent>> {
-    if let Some(pf_client) = pf {
-        match pf_client
-            .get_contract_events(
-                address,
-                from_block.unwrap_or(0),
-                None,
-                &[],
-                limit as u32,
-                None,
-            )
-            .await
-        {
-            Ok((events, _token)) => return Ok(events),
-            Err(e) => {
-                warn!(error = %e, "PF contract events failed, falling back to RPC");
+    // Local helpers capture the `kind`-dependent calls in one place so the
+    // primary/fallback flow below stays agnostic.
+    async fn from_pf(
+        kind: EventQueryKind,
+        pf: &Arc<crate::data::pathfinder::PathfinderClient>,
+        address: starknet::core::types::Felt,
+        from_block: Option<u64>,
+        to_block: Option<u64>,
+        limit: usize,
+    ) -> crate::error::Result<Vec<crate::data::types::SnEvent>> {
+        let res = match kind {
+            EventQueryKind::Contract => {
+                pf.get_contract_events(
+                    address,
+                    from_block.unwrap_or(0),
+                    to_block,
+                    &[],
+                    limit as u32,
+                    None,
+                )
+                .await
+            }
+            EventQueryKind::Account => {
+                pf.get_events_for_address(
+                    address,
+                    from_block.unwrap_or(0),
+                    to_block,
+                    limit as u32,
+                    None,
+                )
+                .await
+            }
+        };
+        res.map(|(events, _token)| events)
+            .map_err(|e| crate::error::SnbeatError::Provider(e.to_string()))
+    }
+
+    async fn from_ds(
+        kind: EventQueryKind,
+        ds: &Arc<dyn DataSource>,
+        address: starknet::core::types::Felt,
+        from_block: Option<u64>,
+        to_block: Option<u64>,
+        limit: usize,
+    ) -> crate::error::Result<Vec<crate::data::types::SnEvent>> {
+        match kind {
+            EventQueryKind::Contract => {
+                ds.get_contract_events(address, from_block, to_block, limit)
+                    .await
+            }
+            EventQueryKind::Account => {
+                ds.get_events_for_address(address, from_block, to_block, limit)
+                    .await
             }
         }
     }
-    ds.get_contract_events(address, from_block, limit).await
-}
 
-/// Fetch account `transaction_executed` events via RPC primarily, with PF fallback.
-///
-/// Bench shows RPC wins for account events on cold windows (20-30ms vs
-/// 165-634ms) and on stale accounts (11-17ms vs 118-131ms). PF's bloom filter
-/// indexes only `from_address` (not keys), so the `transaction_executed`
-/// filter doesn't narrow its scan. PF fallback covers RPC outages.
-async fn fetch_account_events_routed(
-    pf: Option<&Arc<crate::data::pathfinder::PathfinderClient>>,
-    ds: &Arc<dyn DataSource>,
-    address: starknet::core::types::Felt,
-    from_block: Option<u64>,
-    limit: usize,
-) -> crate::error::Result<Vec<crate::data::types::SnEvent>> {
-    match ds.get_events_for_address(address, from_block, limit).await {
-        Ok(events) => Ok(events),
-        Err(rpc_err) => {
+    match kind {
+        EventQueryKind::Contract => {
+            // PF primary, RPC fallback.
             if let Some(pf_client) = pf {
-                warn!(error = %rpc_err, "RPC account events failed, falling back to PF");
-                match pf_client
-                    .get_events_for_address(
-                        address,
-                        from_block.unwrap_or(0),
-                        None,
-                        limit as u32,
-                        None,
-                    )
-                    .await
-                {
-                    Ok((events, _token)) => Ok(events),
-                    Err(pf_err) => {
-                        warn!(error = %pf_err, "PF account events fallback also failed");
+                match from_pf(kind, pf_client, address, from_block, to_block, limit).await {
+                    Ok(events) => return Ok(events),
+                    Err(e) => {
+                        warn!(error = %e, "PF contract events failed, falling back to RPC");
+                    }
+                }
+            }
+            from_ds(kind, ds, address, from_block, to_block, limit).await
+        }
+        EventQueryKind::Account => {
+            // RPC primary, PF fallback.
+            match from_ds(kind, ds, address, from_block, to_block, limit).await {
+                Ok(events) => Ok(events),
+                Err(rpc_err) => {
+                    if let Some(pf_client) = pf {
+                        warn!(error = %rpc_err, "RPC account events failed, falling back to PF");
+                        match from_pf(kind, pf_client, address, from_block, to_block, limit).await {
+                            Ok(events) => Ok(events),
+                            Err(pf_err) => {
+                                warn!(error = %pf_err, "PF account events fallback also failed");
+                                Err(rpc_err)
+                            }
+                        }
+                    } else {
                         Err(rpc_err)
                     }
                 }
-            } else {
-                Err(rpc_err)
             }
         }
     }
@@ -221,6 +283,7 @@ async fn fetch_tx_summaries_from_hashes(
     hashes: &[starknet::core::types::Felt],
     block_map: &std::collections::HashMap<starknet::core::types::Felt, u64>,
     ds: &Arc<dyn DataSource>,
+    pf: Option<&Arc<crate::data::pathfinder::PathfinderClient>>,
     abi_reg: &Arc<AbiRegistry>,
     tx: &mpsc::UnboundedSender<Action>,
     progress_prefix: &str,
@@ -267,7 +330,7 @@ async fn fetch_tx_summaries_from_hashes(
         }
     }
 
-    helpers::backfill_timestamps(&mut summaries, ds).await;
+    helpers::backfill_timestamps(&mut summaries, ds, pf).await;
     summaries
 }
 
@@ -277,6 +340,7 @@ pub(super) async fn build_contract_calls_from_hashes(
     address: starknet::core::types::Felt,
     hashes_with_blocks: &[(starknet::core::types::Felt, u64)],
     ds: &Arc<dyn DataSource>,
+    pf: Option<&Arc<crate::data::pathfinder::PathfinderClient>>,
     abi_reg: &Arc<AbiRegistry>,
 ) -> Vec<crate::data::types::ContractCallSummary> {
     // Pre-fetch ABI for the target contract so selector→name lookups succeed.
@@ -349,7 +413,7 @@ pub(super) async fn build_contract_calls_from_hashes(
         }
     }
 
-    helpers::backfill_call_timestamps(&mut calls_list, ds).await;
+    helpers::backfill_call_timestamps(&mut calls_list, ds, pf).await;
     crate::data::types::deduplicate_contract_calls(calls_list)
 }
 
@@ -647,6 +711,7 @@ pub(super) async fn fetch_and_send_address_info(
         let tx_b = tx.clone();
         let abi_b = Arc::clone(abi_reg);
         let ds_b = Arc::clone(ds);
+        let pf_b = pf.as_ref().map(Arc::clone);
         let mut probe_rx_b = probe_watch_rx.clone();
         const DUNE_PAGE_LIMIT: u32 = 100;
         const INITIAL_WINDOW: u64 = 5_000;
@@ -671,7 +736,8 @@ pub(super) async fn fetch_and_send_address_info(
                         info!(calls = count, "Dune windowed contract calls complete");
 
                         let dune_calls =
-                            enrich_dune_calls(address, calls, &abi_b, &ds_b, &tx_b).await;
+                            enrich_dune_calls(address, calls, &abi_b, &ds_b, pf_b.as_ref(), &tx_b)
+                                .await;
 
                         if !dune_calls.is_empty() {
                             let min_b = dune_calls.last().map(|c| c.block_number).unwrap_or(0);
@@ -742,9 +808,15 @@ pub(super) async fn fetch_and_send_address_info(
                                         let _ = tx_b.send(dune_source_update(
                                             crate::app::state::SourceStatus::Live,
                                         ));
-                                        let dune_calls =
-                                            enrich_dune_calls(address, calls, &abi_b, &ds_b, &tx_b)
-                                                .await;
+                                        let dune_calls = enrich_dune_calls(
+                                            address,
+                                            calls,
+                                            &abi_b,
+                                            &ds_b,
+                                            pf_b.as_ref(),
+                                            &tx_b,
+                                        )
+                                        .await;
                                         if !dune_calls.is_empty() {
                                             let min_b = dune_calls
                                                 .last()
@@ -982,25 +1054,21 @@ pub(super) async fn fetch_and_send_address_info(
             )));
             let phase1_limit = if is_contract { 500 } else { 100 };
 
-            let events_result = if is_contract {
-                fetch_contract_events_routed(
-                    pf_c.as_ref(),
-                    &ds_c,
-                    address,
-                    Some(from_block),
-                    phase1_limit,
-                )
-                .await
+            let kind = if is_contract {
+                EventQueryKind::Contract
             } else {
-                fetch_account_events_routed(
-                    pf_c.as_ref(),
-                    &ds_c,
-                    address,
-                    Some(from_block),
-                    phase1_limit,
-                )
-                .await
+                EventQueryKind::Account
             };
+            let events_result = fetch_events_routed(
+                kind,
+                pf_c.as_ref(),
+                &ds_c,
+                address,
+                Some(from_block),
+                None,
+                phase1_limit,
+            )
+            .await;
             let events = match events_result {
                 Ok(evts) => evts,
                 Err(e) => {
@@ -1079,8 +1147,14 @@ pub(super) async fn fetch_and_send_address_info(
                     .map(|h| (*h, *tx_block_map.get(h).unwrap_or(&0)))
                     .collect();
 
-                let mut contract_calls_list =
-                    build_contract_calls_from_hashes(address, &call_hashes, &ds_c, &abi_c).await;
+                let mut contract_calls_list = build_contract_calls_from_hashes(
+                    address,
+                    &call_hashes,
+                    &ds_c,
+                    pf_c.as_ref(),
+                    &abi_c,
+                )
+                .await;
                 contract_calls_list.sort_by(|a, b| b.block_number.cmp(&a.block_number));
 
                 {
@@ -1131,6 +1205,7 @@ pub(super) async fn fetch_and_send_address_info(
                         &hashes_to_fetch,
                         &tx_block_map,
                         &ds_c,
+                        pf_c.as_ref(),
                         &abi_c,
                         &tx_c,
                         "RPC: fetching txs",
@@ -1188,25 +1263,22 @@ pub(super) async fn fetch_and_send_address_info(
                             search_from, search_to
                         )));
 
-                        let deeper_events = if is_contract {
-                            fetch_contract_events_routed(
-                                pf_c.as_ref(),
-                                &ds_c,
-                                address,
-                                Some(search_from),
-                                500,
-                            )
-                            .await
+                        let kind = if is_contract {
+                            EventQueryKind::Contract
                         } else {
-                            fetch_account_events_routed(
-                                pf_c.as_ref(),
-                                &ds_c,
-                                address,
-                                Some(search_from),
-                                500,
-                            )
-                            .await
+                            EventQueryKind::Account
                         };
+                        // `search_to` is inclusive to match the probe range.
+                        let deeper_events = fetch_events_routed(
+                            kind,
+                            pf_c.as_ref(),
+                            &ds_c,
+                            address,
+                            Some(search_from),
+                            Some(search_to),
+                            500,
+                        )
+                        .await;
 
                         if let Ok(deeper_events) = deeper_events {
                             if !deeper_events.is_empty() {
@@ -1261,6 +1333,7 @@ pub(super) async fn fetch_and_send_address_info(
                                         address,
                                         &call_hashes,
                                         &ds_c,
+                                        pf_c.as_ref(),
                                         &abi_c,
                                     )
                                     .await;
@@ -1299,6 +1372,7 @@ pub(super) async fn fetch_and_send_address_info(
                                             &to_fetch,
                                             &deep_block_map,
                                             &ds_c,
+                                            pf_c.as_ref(),
                                             &abi_c,
                                             &tx_c,
                                             "RPC: fetching probe-guided txs",
@@ -1349,10 +1423,22 @@ pub(super) async fn fetch_and_send_address_info(
 
 /// Enrich a set of address tx summaries that are missing endpoint/timestamp data.
 /// Called lazily after the initial view load for visible transactions.
+///
+/// Prefers pf-query (`/txs-by-hash`) when available: one round trip to the
+/// local Pathfinder DB returns calldata + fee + status + timestamp for every
+/// requested hash. This removes enrichment traffic from the shared RPC pool,
+/// which was saturating on large accounts and making user-initiated
+/// `FetchTransaction` clicks block behind enrichment.
+///
+/// Falls back to RPC (per-hash `get_transaction` + `get_receipt`) for any
+/// hashes pf doesn't return, guarded by `ENRICH_RPC_SEMAPHORE` so that even
+/// RPC-only users never have more than a handful of concurrent enrichment
+/// requests competing with a click.
 pub(super) async fn enrich_address_txs(
     address: starknet::core::types::Felt,
     hashes: Vec<starknet::core::types::Felt>,
     ds: &Arc<dyn DataSource>,
+    pf: Option<&Arc<crate::data::pathfinder::PathfinderClient>>,
     abi_reg: &Arc<AbiRegistry>,
     action_tx: &mpsc::UnboundedSender<Action>,
 ) {
@@ -1364,53 +1450,100 @@ pub(super) async fn enrich_address_txs(
         "Enriching address txs (endpoints/timestamps)"
     );
 
-    // Fetch tx + receipt in parallel
-    let futs: Vec<_> = hashes
-        .iter()
-        .map(|hash| {
-            let ds_t = Arc::clone(ds);
-            let ds_r = Arc::clone(ds);
-            let h = *hash;
-            async move {
-                let (tx_r, rx_r) = tokio::join!(ds_t.get_transaction(h), ds_r.get_receipt(h));
-                (h, tx_r, rx_r)
-            }
-        })
-        .collect();
-    let results = futures::future::join_all(futs).await;
+    let mut updates: Vec<crate::data::types::AddressTxSummary> = Vec::new();
+    let mut missing: Vec<starknet::core::types::Felt> = hashes.clone();
 
-    // Pre-fetch ABIs for all contract addresses referenced in multicall calldata.
-    // This populates the selector→name cache so that format_endpoint_names can
-    // resolve function names instead of showing raw hex selectors.
-    let mut target_addresses = std::collections::HashSet::new();
-    for (_hash, tx_result, _rx_result) in &results {
-        if let Ok(SnTransaction::Invoke(invoke)) = tx_result {
-            for call in parse_multicall(&invoke.calldata) {
-                target_addresses.insert(call.contract_address);
+    // --- Fast path: pf-query ------------------------------------------------
+    if let Some(pf) = pf {
+        match pf.get_txs_by_hash(&hashes).await {
+            Ok(pf_rows) => {
+                debug!(
+                    requested = hashes.len(),
+                    returned = pf_rows.len(),
+                    "enrich_address_txs: pf-query returned"
+                );
+
+                // Pre-warm the ABI registry for every target contract seen in
+                // the multicall calldata so `build_tx_summary_from_pf_data`
+                // can resolve selector names.
+                let mut target_addresses: std::collections::HashSet<starknet::core::types::Felt> =
+                    std::collections::HashSet::new();
+                for row in &pf_rows {
+                    for addr in helpers::pf_tx_target_addresses(row) {
+                        target_addresses.insert(addr);
+                    }
+                }
+                for addr in target_addresses {
+                    let _ = abi_reg.get_abi_for_address(&addr).await;
+                }
+
+                let mut returned_hashes: std::collections::HashSet<starknet::core::types::Felt> =
+                    std::collections::HashSet::new();
+                for row in &pf_rows {
+                    if let Some(summary) = helpers::build_tx_summary_from_pf_data(row, abi_reg) {
+                        returned_hashes.insert(summary.hash);
+                        updates.push(summary);
+                    }
+                }
+
+                missing.retain(|h| !returned_hashes.contains(h));
+            }
+            Err(e) => {
+                warn!(error = %e, "enrich_address_txs: pf-query failed, falling back to RPC for all hashes");
             }
         }
     }
-    for addr in target_addresses {
-        let _ = abi_reg.get_abi_for_address(&addr).await;
-    }
 
-    let mut updates = Vec::new();
-    for (hash, tx_result, rx_result) in results {
-        if let Ok(fetched_tx) = tx_result {
-            let receipt = rx_result.ok();
-            let block_num = receipt.as_ref().map(|r| r.block_number).unwrap_or(0);
-            updates.push(helpers::build_tx_summary(
-                hash,
-                &fetched_tx,
-                receipt.as_ref(),
-                block_num,
-                0,
-                abi_reg,
-            ));
+    // --- Fallback path: RPC (bounded concurrency) --------------------------
+    if !missing.is_empty() {
+        let futs: Vec<_> = missing
+            .iter()
+            .map(|hash| {
+                let ds_t = Arc::clone(ds);
+                let ds_r = Arc::clone(ds);
+                let h = *hash;
+                async move {
+                    // One permit per tx — keeps enrichment from saturating the
+                    // HTTP pool while a user click is in flight.
+                    let _permit = ENRICH_RPC_SEMAPHORE.acquire().await.ok();
+                    let (tx_r, rx_r) = tokio::join!(ds_t.get_transaction(h), ds_r.get_receipt(h));
+                    (h, tx_r, rx_r)
+                }
+            })
+            .collect();
+        let results = futures::future::join_all(futs).await;
+
+        // Pre-fetch ABIs for every contract address referenced in multicall
+        // calldata (same warmup path as the pf branch).
+        let mut target_addresses = std::collections::HashSet::new();
+        for (_hash, tx_result, _rx_result) in &results {
+            if let Ok(SnTransaction::Invoke(invoke)) = tx_result {
+                for call in parse_multicall(&invoke.calldata) {
+                    target_addresses.insert(call.contract_address);
+                }
+            }
+        }
+        for addr in target_addresses {
+            let _ = abi_reg.get_abi_for_address(&addr).await;
+        }
+
+        for (hash, tx_result, rx_result) in results {
+            if let Ok(fetched_tx) = tx_result {
+                let receipt = rx_result.ok();
+                let block_num = receipt.as_ref().map(|r| r.block_number).unwrap_or(0);
+                updates.push(helpers::build_tx_summary(
+                    hash,
+                    &fetched_tx,
+                    receipt.as_ref(),
+                    block_num,
+                    0,
+                    abi_reg,
+                ));
+            }
         }
     }
 
-    helpers::backfill_timestamps(&mut updates, ds).await;
+    helpers::backfill_timestamps(&mut updates, ds, pf).await;
 
     if !updates.is_empty() {
         let _ =
@@ -1430,6 +1563,7 @@ pub(super) async fn run_endpoint_enrichment(
     known_txs: Vec<crate::data::types::AddressTxSummary>,
     ds: &Arc<dyn DataSource>,
     dune: &Option<Arc<dune::DuneClient>>,
+    pf: &Option<Arc<crate::data::pathfinder::PathfinderClient>>,
     abi_reg: &Arc<AbiRegistry>,
     action_tx: &mpsc::UnboundedSender<Action>,
 ) {
@@ -1440,7 +1574,7 @@ pub(super) async fn run_endpoint_enrichment(
             current_nonce,
             "Endpoint enrich: skipping nonce gaps (empty txs or nonce=0), running endpoint enrichment only"
         );
-        enrich_all_empty_endpoints(address, &known_txs, ds, abi_reg, action_tx).await;
+        enrich_all_empty_endpoints(address, &known_txs, ds, pf.as_ref(), abi_reg, action_tx).await;
         return;
     }
 
@@ -1497,7 +1631,7 @@ pub(super) async fn run_endpoint_enrichment(
             all_txs.push(gt.clone());
         }
     }
-    enrich_all_empty_endpoints(address, &all_txs, ds, abi_reg, action_tx).await;
+    enrich_all_empty_endpoints(address, &all_txs, ds, pf.as_ref(), abi_reg, action_tx).await;
 
     debug!(
         address = %format!("{:#x}", address),
@@ -1516,6 +1650,7 @@ pub(super) async fn run_nonce_gap_fill(
     gap: crate::app::views::address_info::UnfilledGap,
     ds: &Arc<dyn DataSource>,
     dune: &Option<Arc<dune::DuneClient>>,
+    pf: &Option<Arc<crate::data::pathfinder::PathfinderClient>>,
     abi_reg: &Arc<AbiRegistry>,
     action_tx: &mpsc::UnboundedSender<Action>,
 ) {
@@ -1555,7 +1690,7 @@ pub(super) async fn run_nonce_gap_fill(
                 combined.push(t.clone());
             }
         }
-        enrich_all_empty_endpoints(address, &combined, ds, abi_reg, action_tx).await;
+        enrich_all_empty_endpoints(address, &combined, ds, pf.as_ref(), abi_reg, action_tx).await;
     } else {
         info!("Gap fill: no txs returned from Dune for this range");
         let _ = action_tx.send(Action::LoadingStatus(String::new()));
@@ -1607,9 +1742,11 @@ async fn fill_small_nonce_gaps_phase(
         known_nonces.len()
     );
 
-    // Categorize gaps by block span size
+    // Only small-span gaps are handled here; wider gaps are picked up by
+    // `detect_unfilled_gap` and filled on-demand via `run_nonce_gap_fill`.
+    // Both paths share `SMALL_GAP_SPAN_BLOCKS` so they stay aligned.
+    use crate::app::views::address_info::SMALL_GAP_SPAN_BLOCKS;
     let mut small_gaps: Vec<(u64, u64, u64)> = Vec::new(); // (nonce, from_block, to_block)
-    let mut large_gap_ranges: Vec<(u64, u64)> = Vec::new(); // (from_block, to_block) for Dune
 
     for nonce in min_known..check_up_to {
         if known_nonces.contains_key(&nonce) {
@@ -1643,19 +1780,16 @@ async fn fill_small_nonce_gaps_phase(
             block_before + 10
         };
 
-        if scan_to.saturating_sub(scan_from) <= 50 {
+        if scan_to.saturating_sub(scan_from) <= SMALL_GAP_SPAN_BLOCKS {
             small_gaps.push((nonce, scan_from, scan_to));
-        } else {
-            large_gap_ranges.push((scan_from, scan_to));
         }
+        // else: caught by detect_unfilled_gap → run_nonce_gap_fill.
     }
 
     let small_count = small_gaps.len();
-    let large_count = large_gap_ranges.len();
-    let total_gaps = small_count + large_count;
-    if total_gaps == 0 {
+    if small_count == 0 {
         info!(
-            "Sanity gap check: no nonce gaps found in range {}..{}",
+            "Sanity gap check: no small nonce gaps in range {}..{}",
             min_known, check_up_to
         );
         return Vec::new();
@@ -1664,20 +1798,15 @@ async fn fill_small_nonce_gaps_phase(
     let small_nonces: Vec<u64> = small_gaps.iter().map(|(n, _, _)| *n).take(10).collect();
     info!(
         small = small_count,
-        large = large_count,
-        total = total_gaps,
         first_small_nonces = ?small_nonces,
-        large_ranges = ?large_gap_ranges.iter().take(5).collect::<Vec<_>>(),
-        "Sanity check: detected {} nonce gaps ({} small, {} large — large deferred to on-demand fill)",
-        total_gaps, small_count, large_count
+        "Sanity check: filling {} small nonce gaps (wider gaps deferred to on-demand fill)",
+        small_count
     );
 
-    if small_count > 0 {
-        let _ = action_tx.send(Action::LoadingStatus(format!(
-            "Filling {} small nonce gaps...",
-            small_count
-        )));
-    }
+    let _ = action_tx.send(Action::LoadingStatus(format!(
+        "Filling {} small nonce gaps...",
+        small_count
+    )));
 
     let mut found_txs = Vec::new();
 
@@ -1790,6 +1919,7 @@ async fn enrich_all_empty_endpoints(
     address: starknet::core::types::Felt,
     all_txs: &[crate::data::types::AddressTxSummary],
     ds: &Arc<dyn DataSource>,
+    pf: Option<&Arc<crate::data::pathfinder::PathfinderClient>>,
     abi_reg: &Arc<AbiRegistry>,
     action_tx: &mpsc::UnboundedSender<Action>,
 ) {
@@ -1825,7 +1955,7 @@ async fn enrich_all_empty_endpoints(
             i + 1,
             (missing.len() + 19) / 20
         );
-        enrich_address_txs(address, chunk.to_vec(), ds, abi_reg, action_tx).await;
+        enrich_address_txs(address, chunk.to_vec(), ds, pf, abi_reg, action_tx).await;
     }
 }
 
@@ -1971,41 +2101,42 @@ pub(super) async fn fetch_more_address_txs(
     let rpc_ds = Arc::clone(ds);
     let pf_c = pf.as_ref().map(Arc::clone);
     let rpc_addr = address;
-    let rpc_before = before_block;
     let rpc_is_contract = is_contract;
-    // Cap RPC window at 10k blocks — RPC is slow for large ranges.
-    let rpc_window = window_size.min(10_000);
-    let rpc_from = before_block.saturating_sub(rpc_window);
+    // Window size per source:
+    //  - Contracts use pathfinder (bloom-indexed), which can scan the full
+    //    `window_size` cheaply.
+    //  - Accounts use RPC which is slow on wide ranges, so clamp to 10k.
+    let (events_from, events_to) = if rpc_is_contract {
+        (
+            before_block.saturating_sub(window_size),
+            before_block.saturating_sub(1),
+        )
+    } else {
+        (
+            before_block.saturating_sub(window_size.min(10_000)),
+            before_block.saturating_sub(1),
+        )
+    };
 
     let rpc_fut = async move {
-        let events = if rpc_is_contract {
-            // Pathfinder can scan the full window range efficiently via bloom
-            // filters; use window_size directly rather than clamping to 10k.
-            let pf_from = before_block.saturating_sub(window_size);
-            fetch_contract_events_routed(
-                pf_c.as_ref(),
-                &rpc_ds,
-                rpc_addr,
-                Some(pf_from),
-                500,
-            )
-            .await
-            .unwrap_or_default()
+        let kind = if rpc_is_contract {
+            EventQueryKind::Contract
         } else {
-            fetch_account_events_routed(
-                pf_c.as_ref(),
-                &rpc_ds,
-                rpc_addr,
-                Some(rpc_from),
-                500,
-            )
-            .await
-            .unwrap_or_default()
+            EventQueryKind::Account
         };
-        events
-            .into_iter()
-            .filter(|e| e.block_number < rpc_before)
-            .collect::<Vec<_>>()
+        // `to_block = before_block - 1` keeps the scan below the already-known
+        // range, so we don't refetch newer events only to filter them out.
+        fetch_events_routed(
+            kind,
+            pf_c.as_ref(),
+            &rpc_ds,
+            rpc_addr,
+            Some(events_from),
+            Some(events_to),
+            500,
+        )
+        .await
+        .unwrap_or_default()
     };
 
     let dune_c = dune.as_ref().map(Arc::clone);
@@ -2068,7 +2199,8 @@ pub(super) async fn fetch_more_address_txs(
             .iter()
             .map(|h| (*h, *tx_block_map.get(h).unwrap_or(&0)))
             .collect();
-        rpc_calls = build_contract_calls_from_hashes(address, &call_hashes, ds, abi_reg).await;
+        rpc_calls =
+            build_contract_calls_from_hashes(address, &call_hashes, ds, pf.as_ref(), abi_reg).await;
     } else if !unique_hashes.is_empty() {
         // Build tx summaries for accounts
         for chunk in unique_hashes.chunks(20) {
@@ -2105,7 +2237,7 @@ pub(super) async fn fetch_more_address_txs(
                 }
             }
         }
-        helpers::backfill_timestamps(&mut summaries, ds).await;
+        helpers::backfill_timestamps(&mut summaries, ds, pf.as_ref()).await;
     }
 
     // Merge Dune account txs into summaries (dedup by hash)
@@ -2122,7 +2254,7 @@ pub(super) async fn fetch_more_address_txs(
 
     // Enrich + deduplicate Dune contract calls (same as initial fetch)
     let dune_calls = if !dune_calls.is_empty() {
-        enrich_dune_calls(address, dune_calls, abi_reg, ds, tx).await
+        enrich_dune_calls(address, dune_calls, abi_reg, ds, pf.as_ref(), tx).await
     } else {
         Vec::new()
     };
@@ -2189,6 +2321,7 @@ pub(super) async fn enrich_dune_calls(
     mut dune_calls: Vec<crate::data::types::ContractCallSummary>,
     abi_reg: &Arc<AbiRegistry>,
     ds: &Arc<dyn DataSource>,
+    pf: Option<&Arc<crate::data::pathfinder::PathfinderClient>>,
     tx: &mpsc::UnboundedSender<Action>,
 ) -> Vec<crate::data::types::ContractCallSummary> {
     // Resolve selectors
@@ -2255,7 +2388,7 @@ pub(super) async fn enrich_dune_calls(
         }
     }
 
-    helpers::backfill_call_timestamps(&mut dune_calls, ds).await;
+    helpers::backfill_call_timestamps(&mut dune_calls, ds, pf).await;
 
     dune_calls.sort_by(|a, b| b.block_number.cmp(&a.block_number));
     dune_calls

--- a/src/network/helpers.rs
+++ b/src/network/helpers.rs
@@ -6,8 +6,10 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use starknet::core::types::Felt;
+use tracing::{debug, warn};
 
 use crate::data::DataSource;
+use crate::data::pathfinder::{PathfinderClient, TxByHashData};
 use crate::data::types::{
     AddressTxSummary, ContractCallSummary, ExecutionStatus, SnReceipt, SnTransaction,
 };
@@ -110,11 +112,91 @@ pub fn build_tx_summary(
     }
 }
 
+/// Normalize a pf-query tx_type (e.g. "INVOKE_V3") to snbeat's canonical
+/// form (e.g. "INVOKE"). pf returns a versioned string; `SnTransaction::type_name()`
+/// strips the version. Leaves `L1_HANDLER` as-is.
+pub fn normalize_pf_tx_type(pf_type: &str) -> String {
+    // Strip trailing `_V<n>` if present.
+    if let Some(idx) = pf_type.rfind("_V")
+        && pf_type[idx + 2..].chars().all(|c| c.is_ascii_digit())
+        && !pf_type[idx + 2..].is_empty()
+    {
+        return pf_type[..idx].to_string();
+    }
+    pf_type.to_string()
+}
+
+/// Build an `AddressTxSummary` directly from pf-query `TxByHashData`, without
+/// going through an `SnTransaction`. Parses calldata and resolves selectors
+/// via the ABI registry the same way `build_tx_summary` does for RPC-sourced
+/// transactions.
+///
+/// Returns `None` if the response is malformed (bad hex). Callers should
+/// fall through to the RPC path in that case.
+pub fn build_tx_summary_from_pf_data(
+    pf_tx: &TxByHashData,
+    abi_reg: &AbiRegistry,
+) -> Option<AddressTxSummary> {
+    let hash = Felt::from_hex(&pf_tx.hash).ok()?;
+    let sender = Felt::from_hex(&pf_tx.sender).ok()?;
+    let fee_fri = u128::from_str_radix(pf_tx.actual_fee.trim_start_matches("0x"), 16).unwrap_or(0);
+    let tx_type = normalize_pf_tx_type(&pf_tx.tx_type);
+
+    // Only INVOKE transactions have multicall calldata to decode.
+    let endpoint_names = if tx_type == "INVOKE" {
+        let calldata: Vec<Felt> = pf_tx
+            .calldata
+            .iter()
+            .filter_map(|h| Felt::from_hex(h).ok())
+            .collect();
+        let calls = parse_multicall(&calldata);
+        format_selector_names(calls.iter().map(|c| c.selector), abi_reg)
+    } else {
+        String::new()
+    };
+
+    Some(AddressTxSummary {
+        hash,
+        nonce: pf_tx.nonce.unwrap_or(0),
+        block_number: pf_tx.block_number,
+        timestamp: pf_tx.block_timestamp,
+        endpoint_names,
+        total_fee_fri: fee_fri,
+        tip: pf_tx.tip,
+        tx_type,
+        status: pf_tx.status.clone(),
+        sender: Some(sender),
+    })
+}
+
+/// Collect the set of target contract addresses referenced by a pf tx's
+/// multicall calldata. Used to pre-warm the ABI registry before building
+/// summaries in bulk.
+pub fn pf_tx_target_addresses(pf_tx: &TxByHashData) -> Vec<Felt> {
+    if normalize_pf_tx_type(&pf_tx.tx_type) != "INVOKE" {
+        return Vec::new();
+    }
+    let calldata: Vec<Felt> = pf_tx
+        .calldata
+        .iter()
+        .filter_map(|h| Felt::from_hex(h).ok())
+        .collect();
+    parse_multicall(&calldata)
+        .into_iter()
+        .map(|c| c.contract_address)
+        .collect()
+}
+
 /// Backfill timestamps on address tx summaries by fetching block data.
 ///
 /// Collects all unique block numbers where `timestamp == 0`, fetches them
-/// in parallel, and applies the timestamps.
-pub async fn backfill_timestamps(summaries: &mut [AddressTxSummary], ds: &Arc<dyn DataSource>) {
+/// via pf-query (range query, one round trip) when available, RPC per-block
+/// for anything pf doesn't return.
+pub async fn backfill_timestamps(
+    summaries: &mut [AddressTxSummary],
+    ds: &Arc<dyn DataSource>,
+    pf: Option<&Arc<PathfinderClient>>,
+) {
     let blocks_needing_ts: HashSet<u64> = summaries
         .iter()
         .filter(|s| s.timestamp == 0 && s.block_number > 0)
@@ -123,7 +205,7 @@ pub async fn backfill_timestamps(summaries: &mut [AddressTxSummary], ds: &Arc<dy
     if blocks_needing_ts.is_empty() {
         return;
     }
-    let ts_map = fetch_block_timestamps(blocks_needing_ts, ds).await;
+    let ts_map = fetch_block_timestamps(blocks_needing_ts, ds, pf).await;
     for s in summaries.iter_mut() {
         if s.timestamp == 0 {
             if let Some(&ts) = ts_map.get(&s.block_number) {
@@ -134,7 +216,11 @@ pub async fn backfill_timestamps(summaries: &mut [AddressTxSummary], ds: &Arc<dy
 }
 
 /// Backfill timestamps on contract call summaries by fetching block data.
-pub async fn backfill_call_timestamps(calls: &mut [ContractCallSummary], ds: &Arc<dyn DataSource>) {
+pub async fn backfill_call_timestamps(
+    calls: &mut [ContractCallSummary],
+    ds: &Arc<dyn DataSource>,
+    pf: Option<&Arc<PathfinderClient>>,
+) {
     let blocks_needing_ts: HashSet<u64> = calls
         .iter()
         .filter(|c| c.timestamp == 0 && c.block_number > 0)
@@ -143,7 +229,7 @@ pub async fn backfill_call_timestamps(calls: &mut [ContractCallSummary], ds: &Ar
     if blocks_needing_ts.is_empty() {
         return;
     }
-    let ts_map = fetch_block_timestamps(blocks_needing_ts, ds).await;
+    let ts_map = fetch_block_timestamps(blocks_needing_ts, ds, pf).await;
     for c in calls.iter_mut() {
         if c.timestamp == 0 {
             if let Some(&ts) = ts_map.get(&c.block_number) {
@@ -153,13 +239,51 @@ pub async fn backfill_call_timestamps(calls: &mut [ContractCallSummary], ds: &Ar
     }
 }
 
-/// Fetch timestamps for a set of block numbers in parallel.
+/// Fetch timestamps for a set of block numbers. Prefers pf-query (single
+/// range query over the min..=max span) when available; falls back to
+/// per-block RPC for any gaps.
 async fn fetch_block_timestamps(
     block_numbers: HashSet<u64>,
     ds: &Arc<dyn DataSource>,
+    pf: Option<&Arc<PathfinderClient>>,
 ) -> HashMap<u64, u64> {
     use futures::stream::{self, StreamExt};
-    stream::iter(block_numbers)
+
+    let mut ts_map: HashMap<u64, u64> = HashMap::new();
+
+    if let Some(pf) = pf {
+        let min = *block_numbers.iter().min().unwrap();
+        let max = *block_numbers.iter().max().unwrap();
+        match pf.get_block_timestamps(min, max).await {
+            Ok(entries) => {
+                debug!(
+                    requested = block_numbers.len(),
+                    returned = entries.len(),
+                    range = format!("{min}..={max}"),
+                    "Fetched block timestamps from pf-query"
+                );
+                for e in entries {
+                    if block_numbers.contains(&e.block_number) {
+                        ts_map.insert(e.block_number, e.timestamp);
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "pf-query block-timestamps failed, falling back to RPC");
+            }
+        }
+    }
+
+    let missing: Vec<u64> = block_numbers
+        .iter()
+        .copied()
+        .filter(|bn| !ts_map.contains_key(bn))
+        .collect();
+    if missing.is_empty() {
+        return ts_map;
+    }
+
+    let rpc_map: HashMap<u64, u64> = stream::iter(missing)
         .map(|bn| {
             let ds_blk = Arc::clone(ds);
             async move { (bn, ds_blk.get_block(bn).await) }
@@ -167,5 +291,7 @@ async fn fetch_block_timestamps(
         .buffer_unordered(10)
         .filter_map(|(bn, r)| async move { r.ok().map(|b| (bn, b.timestamp)) })
         .collect()
-        .await
+        .await;
+    ts_map.extend(rpc_map);
+    ts_map
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -124,7 +124,7 @@ pub async fn run_network_task(
                     debug!(sender = %format!("{:#x}", sender), current_nonce, target_nonce, "Searching for tx by nonce");
 
                     // Strategy: fetch events for the sender, find tx with target nonce
-                    match ds.get_events_for_address(sender, None, 200).await {
+                    match ds.get_events_for_address(sender, None, None, 200).await {
                         Ok(events) => {
                             // Collect unique tx hashes
                             let mut seen = std::collections::HashSet::new();
@@ -184,7 +184,8 @@ pub async fn run_network_task(
                     search::resolve_search(query, &ds, &abi_reg, &dune, &pf, &voyager, &tx).await;
                 }
                 Action::EnrichAddressTxs { address, hashes } => {
-                    address::enrich_address_txs(address, hashes, &ds, &abi_reg, &tx).await;
+                    address::enrich_address_txs(address, hashes, &ds, pf.as_ref(), &abi_reg, &tx)
+                        .await;
                 }
                 Action::EnrichAddressEndpoints {
                     address,
@@ -197,6 +198,7 @@ pub async fn run_network_task(
                         known_txs,
                         &ds,
                         &dune,
+                        &pf,
                         &abi_reg,
                         &tx,
                     )
@@ -207,8 +209,10 @@ pub async fn run_network_task(
                     known_txs,
                     gap,
                 } => {
-                    address::run_nonce_gap_fill(address, known_txs, gap, &ds, &dune, &abi_reg, &tx)
-                        .await;
+                    address::run_nonce_gap_fill(
+                        address, known_txs, gap, &ds, &dune, &pf, &abi_reg, &tx,
+                    )
+                    .await;
                 }
                 Action::EnrichAddressCalls {
                     address,
@@ -218,6 +222,7 @@ pub async fn run_network_task(
                         address,
                         &hashes_with_blocks,
                         &ds,
+                        pf.as_ref(),
                         &abi_reg,
                     )
                     .await;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -186,12 +186,12 @@ pub async fn run_network_task(
                 Action::EnrichAddressTxs { address, hashes } => {
                     address::enrich_address_txs(address, hashes, &ds, &abi_reg, &tx).await;
                 }
-                Action::SanityCheckAddress {
+                Action::EnrichAddressEndpoints {
                     address,
                     current_nonce,
                     known_txs,
                 } => {
-                    address::run_sanity_check(
+                    address::run_endpoint_enrichment(
                         address,
                         current_nonce,
                         known_txs,
@@ -201,6 +201,14 @@ pub async fn run_network_task(
                         &tx,
                     )
                     .await;
+                }
+                Action::FillAddressNonceGaps {
+                    address,
+                    known_txs,
+                    gap,
+                } => {
+                    address::run_nonce_gap_fill(address, known_txs, gap, &ds, &dune, &abi_reg, &tx)
+                        .await;
                 }
                 Action::EnrichAddressCalls {
                     address,
@@ -228,6 +236,7 @@ pub async fn run_network_task(
                         is_contract,
                         &ds,
                         &dune,
+                        &pf,
                         &abi_reg,
                         &tx,
                     )

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -293,6 +293,15 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
         return;
     }
 
+    // If a large nonce gap is deferred, remember its (hi_nonce → lo_nonce)
+    // boundary so we can render a divider above the row where the jump occurs.
+    let gap_boundary: Option<(u64, u64, u64, bool)> = app
+        .address
+        .unfilled_gap
+        .as_ref()
+        .map(|g| (g.hi_nonce, g.lo_nonce, g.missing_count, g.fill_dispatched));
+
+    let mut prev_nonce: Option<u64> = None;
     let items: Vec<ListItem> = app
         .address
         .txs
@@ -329,7 +338,7 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
                 _ => theme::NORMAL_STYLE,
             };
 
-            let line = Line::from(vec![
+            let main_line = Line::from(vec![
                 Span::styled(format!(" {:<8}", tx.nonce), theme::NORMAL_STYLE),
                 Span::styled(format!("{:<15}", tx.tx_type), type_style),
                 Span::styled(
@@ -346,17 +355,53 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
                 Span::styled(format!("{:<4}", &tx.status), status_style),
                 Span::styled(age, theme::BLOCK_AGE_STYLE),
             ]);
-            ListItem::new(line)
+
+            // Insert a dimmed divider above the row that sits on the far side
+            // of the unfilled gap (i.e. when we're about to step from hi_nonce
+            // down to lo_nonce in the descending list).
+            let separator: Option<Line> = match (prev_nonce, gap_boundary) {
+                (Some(prev), Some((hi, lo, missing, dispatched)))
+                    if prev == hi && tx.nonce == lo =>
+                {
+                    let msg = if dispatched {
+                        format!(" ── gap of {missing} txs — loading / retry with 'r' ──")
+                    } else {
+                        format!(" ── {missing} txs hidden — scroll down to load ──")
+                    };
+                    Some(Line::from(Span::styled(msg, theme::SUGGESTION_STYLE)))
+                }
+                _ => None,
+            };
+            prev_nonce = Some(tx.nonce);
+
+            let lines = match separator {
+                Some(sep) => vec![sep, main_line],
+                None => vec![main_line],
+            };
+            ListItem::new(lines)
         })
         .collect();
 
+    let gap_suffix = match &app.address.unfilled_gap {
+        Some(g) if !g.fill_dispatched => format!(
+            " — {} older txs deferred (scroll down to load) ",
+            g.missing_count
+        ),
+        Some(g) => format!(" — gap of {} txs (press r to retry) ", g.missing_count),
+        None => String::new(),
+    };
     let title = if app.is_loading {
         format!(
-            " Transactions ({}) fetching... ",
-            app.address.txs.items.len()
+            " Transactions ({}) fetching...{} ",
+            app.address.txs.items.len(),
+            gap_suffix
         )
     } else {
-        format!(" Transactions ({}) ", app.address.txs.items.len())
+        format!(
+            " Transactions ({}){} ",
+            app.address.txs.items.len(),
+            gap_suffix
+        )
     };
 
     let list = List::new(items)

--- a/src/ui/widgets/stateful_list.rs
+++ b/src/ui/widgets/stateful_list.rs
@@ -94,3 +94,46 @@ impl<T> Default for StatefulList<T> {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scroll_by_noop_on_empty_list() {
+        let mut list: StatefulList<u32> = StatefulList::new();
+        list.scroll_by(10);
+        assert_eq!(list.state.selected(), None);
+    }
+
+    #[test]
+    fn scroll_by_starts_from_zero_when_unselected() {
+        let mut list = StatefulList::with_items(vec![1, 2, 3, 4, 5]);
+        list.scroll_by(2);
+        assert_eq!(list.state.selected(), Some(2));
+    }
+
+    #[test]
+    fn scroll_by_clamps_to_bottom() {
+        let mut list = StatefulList::with_items(vec![1, 2, 3]);
+        list.state.select(Some(1));
+        list.scroll_by(100);
+        assert_eq!(list.state.selected(), Some(2));
+    }
+
+    #[test]
+    fn scroll_by_clamps_to_top() {
+        let mut list = StatefulList::with_items(vec![1, 2, 3]);
+        list.state.select(Some(1));
+        list.scroll_by(-100);
+        assert_eq!(list.state.selected(), Some(0));
+    }
+
+    #[test]
+    fn scroll_by_handles_negative_from_unselected() {
+        // Unselected defaults to 0; any negative delta clamps to 0.
+        let mut list = StatefulList::with_items(vec![1, 2, 3]);
+        list.scroll_by(-5);
+        assert_eq!(list.state.selected(), Some(0));
+    }
+}

--- a/src/ui/widgets/stateful_list.rs
+++ b/src/ui/widgets/stateful_list.rs
@@ -61,6 +61,18 @@ impl<T> StatefulList<T> {
         }
     }
 
+    /// Move the selection by `delta`, clamped to the list bounds.
+    /// Use positive delta to scroll down, negative to scroll up.
+    pub fn scroll_by(&mut self, delta: i64) {
+        if self.items.is_empty() {
+            return;
+        }
+        let cur = self.state.selected().unwrap_or(0) as i64;
+        let max = self.items.len() as i64 - 1;
+        let next = (cur + delta).clamp(0, max) as usize;
+        self.state.select(Some(next));
+    }
+
     pub fn selected_item(&self) -> Option<&T> {
         self.state.selected().and_then(|i| self.items.get(i))
     }

--- a/tests/enrich_bench_test.rs
+++ b/tests/enrich_bench_test.rs
@@ -1,0 +1,375 @@
+//! Benchmark: compare old RPC-only enrichment path vs. new pf-query-primary
+//! path. Requires both `APP_RPC_URL` and `APP_PATHFINDER_SERVICE_URL`. Ignored
+//! by default.
+//!
+//! Run with:
+//!   APP_RPC_URL=... APP_PATHFINDER_SERVICE_URL=... cargo test --test
+//!     enrich_bench_test -- --ignored --nocapture
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use starknet::core::types::Felt;
+
+use snbeat::data::DataSource;
+use snbeat::data::pathfinder::PathfinderClient;
+use snbeat::data::rpc::RpcDataSource;
+use snbeat::data::types::{AddressTxSummary, SnTransaction};
+use snbeat::decode::AbiRegistry;
+use snbeat::decode::class_cache::ClassCache;
+use snbeat::decode::functions::parse_multicall;
+use snbeat::network::helpers;
+
+fn rpc_url() -> String {
+    dotenvy::dotenv().ok();
+    std::env::var("APP_RPC_URL").expect("APP_RPC_URL must be set")
+}
+
+fn pf_url() -> String {
+    dotenvy::dotenv().ok();
+    std::env::var("APP_PATHFINDER_SERVICE_URL")
+        .expect("APP_PATHFINDER_SERVICE_URL must be set for benchmarks")
+}
+
+fn new_abi_registry(ds: Arc<dyn DataSource>) -> Arc<AbiRegistry> {
+    // Fresh in-memory SQLite — no persistence across runs so both paths start
+    // equally cold on class ABIs.
+    let db = rusqlite::Connection::open_in_memory().expect("in-memory sqlite");
+    db.execute_batch(
+        "CREATE TABLE IF NOT EXISTS parsed_abis (
+            class_hash TEXT PRIMARY KEY,
+            data TEXT NOT NULL
+        );",
+    )
+    .expect("init parsed_abis table");
+    let class_cache = ClassCache::new(db, 500);
+    Arc::new(AbiRegistry::new(ds, class_cache))
+}
+
+/// Pull ~N invoke tx hashes from a recent block (skipping a few blocks to
+/// avoid the pre-confirmed / latest boundary).
+async fn sample_invoke_hashes(ds: &Arc<dyn DataSource>, n: usize) -> Vec<Felt> {
+    let latest = ds.get_latest_block_number().await.expect("latest block");
+    let mut hashes: Vec<Felt> = Vec::new();
+    let mut blk = latest.saturating_sub(5);
+    while hashes.len() < n && blk > 0 {
+        if let Ok((_, txs)) = ds.get_block_with_txs(blk).await {
+            for t in &txs {
+                if matches!(t, SnTransaction::Invoke(_)) {
+                    hashes.push(t.hash());
+                    if hashes.len() >= n {
+                        break;
+                    }
+                }
+            }
+        }
+        blk = blk.saturating_sub(1);
+    }
+    hashes
+}
+
+/// Simulate the old enrichment path: per-hash parallel get_transaction +
+/// get_receipt via RPC, then build_tx_summary. Pre-warms ABIs for target
+/// addresses exactly the way `enrich_address_txs` did before this change.
+async fn enrich_rpc_path(
+    hashes: &[Felt],
+    ds: &Arc<dyn DataSource>,
+    abi_reg: &Arc<AbiRegistry>,
+) -> Vec<AddressTxSummary> {
+    let futs: Vec<_> = hashes
+        .iter()
+        .map(|h| {
+            let ds_t = Arc::clone(ds);
+            let ds_r = Arc::clone(ds);
+            let h = *h;
+            async move { (h, ds_t.get_transaction(h).await, ds_r.get_receipt(h).await) }
+        })
+        .collect();
+    let results = futures::future::join_all(futs).await;
+
+    let mut target_addresses = std::collections::HashSet::new();
+    for (_h, tx_r, _rx_r) in &results {
+        if let Ok(SnTransaction::Invoke(invoke)) = tx_r {
+            for call in parse_multicall(&invoke.calldata) {
+                target_addresses.insert(call.contract_address);
+            }
+        }
+    }
+    for addr in target_addresses {
+        let _ = abi_reg.get_abi_for_address(&addr).await;
+    }
+
+    let mut out = Vec::new();
+    for (hash, tx_r, rx_r) in results {
+        if let Ok(tx) = tx_r {
+            let receipt = rx_r.ok();
+            let block_num = receipt.as_ref().map(|r| r.block_number).unwrap_or(0);
+            out.push(helpers::build_tx_summary(
+                hash,
+                &tx,
+                receipt.as_ref(),
+                block_num,
+                0,
+                abi_reg,
+            ));
+        }
+    }
+    helpers::backfill_timestamps(&mut out, ds, None).await;
+    out
+}
+
+/// Simulate the new enrichment path: one `/txs-by-hash` round trip, pre-warm
+/// ABIs, then `build_tx_summary_from_pf_data`.
+async fn enrich_pf_path(
+    hashes: &[Felt],
+    ds: &Arc<dyn DataSource>,
+    pf: &Arc<PathfinderClient>,
+    abi_reg: &Arc<AbiRegistry>,
+) -> Vec<AddressTxSummary> {
+    let pf_rows = pf
+        .get_txs_by_hash(hashes)
+        .await
+        .expect("pf get_txs_by_hash");
+
+    let mut target_addresses = std::collections::HashSet::new();
+    for row in &pf_rows {
+        for addr in helpers::pf_tx_target_addresses(row) {
+            target_addresses.insert(addr);
+        }
+    }
+    for addr in target_addresses {
+        let _ = abi_reg.get_abi_for_address(&addr).await;
+    }
+
+    let mut out = Vec::new();
+    for row in &pf_rows {
+        if let Some(s) = helpers::build_tx_summary_from_pf_data(row, abi_reg) {
+            out.push(s);
+        }
+    }
+    helpers::backfill_timestamps(&mut out, ds, Some(pf)).await;
+    out
+}
+
+fn compare_summaries(
+    rpc_summaries: &[AddressTxSummary],
+    pf_summaries: &[AddressTxSummary],
+) -> Vec<String> {
+    let by_hash_pf: std::collections::HashMap<Felt, &AddressTxSummary> =
+        pf_summaries.iter().map(|s| (s.hash, s)).collect();
+
+    let mut mismatches = Vec::new();
+    for rpc_s in rpc_summaries {
+        let Some(pf_s) = by_hash_pf.get(&rpc_s.hash) else {
+            continue;
+        };
+        let h = rpc_s.hash;
+        if rpc_s.tx_type != pf_s.tx_type {
+            mismatches.push(format!(
+                "{h:#x}: tx_type rpc={} pf={}",
+                rpc_s.tx_type, pf_s.tx_type
+            ));
+        }
+        if rpc_s.nonce != pf_s.nonce {
+            mismatches.push(format!(
+                "{h:#x}: nonce rpc={} pf={}",
+                rpc_s.nonce, pf_s.nonce
+            ));
+        }
+        if rpc_s.total_fee_fri != pf_s.total_fee_fri {
+            mismatches.push(format!(
+                "{h:#x}: fee rpc={} pf={}",
+                rpc_s.total_fee_fri, pf_s.total_fee_fri
+            ));
+        }
+        if rpc_s.status != pf_s.status {
+            mismatches.push(format!(
+                "{h:#x}: status rpc={} pf={}",
+                rpc_s.status, pf_s.status
+            ));
+        }
+        if rpc_s.sender != pf_s.sender {
+            mismatches.push(format!(
+                "{h:#x}: sender rpc={:?} pf={:?}",
+                rpc_s.sender, pf_s.sender
+            ));
+        }
+        if rpc_s.block_number != pf_s.block_number {
+            mismatches.push(format!(
+                "{h:#x}: block_number rpc={} pf={}",
+                rpc_s.block_number, pf_s.block_number
+            ));
+        }
+        if rpc_s.endpoint_names != pf_s.endpoint_names {
+            mismatches.push(format!(
+                "{h:#x}: endpoint_names rpc={:?} pf={:?}",
+                rpc_s.endpoint_names, pf_s.endpoint_names
+            ));
+        }
+        if rpc_s.timestamp != pf_s.timestamp && pf_s.timestamp != 0 && rpc_s.timestamp != 0 {
+            mismatches.push(format!(
+                "{h:#x}: timestamp rpc={} pf={}",
+                rpc_s.timestamp, pf_s.timestamp
+            ));
+        }
+    }
+    mismatches
+}
+
+/// Benchmark + correctness check. Runs enrichment at a few different N and
+/// compares RPC-only vs. pf-primary paths side by side.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires APP_RPC_URL and APP_PATHFINDER_SERVICE_URL"]
+async fn bench_rpc_vs_pf_enrichment() {
+    let ds: Arc<dyn DataSource> = Arc::new(RpcDataSource::new(&rpc_url()));
+    let pf = Arc::new(PathfinderClient::new(pf_url()));
+
+    for &n in &[50usize, 200, 500] {
+        let hashes = sample_invoke_hashes(&ds, n).await;
+        if hashes.len() < n / 2 {
+            println!("skipping N={n}: only sampled {}", hashes.len());
+            continue;
+        }
+        println!("\n----- Benchmark N={} -----", hashes.len());
+
+        // Warm ABIs once via RPC path so both runs start with warm class
+        // cache — isolates the tx+receipt cost from ABI fetching.
+        let warm_abi = new_abi_registry(Arc::clone(&ds));
+        let _ = enrich_rpc_path(&hashes, &ds, &warm_abi).await;
+
+        let t0 = Instant::now();
+        let rpc_summaries = enrich_rpc_path(&hashes, &ds, &warm_abi).await;
+        let rpc_ms = t0.elapsed().as_millis();
+
+        let t0 = Instant::now();
+        let pf_summaries = enrich_pf_path(&hashes, &ds, &pf, &warm_abi).await;
+        let pf_ms = t0.elapsed().as_millis();
+
+        println!(
+            "  warm-ABI:  RPC {rpc_ms:>5} ms ({} txs)  |  PF {pf_ms:>5} ms ({} txs)  |  speedup {:.2}x",
+            rpc_summaries.len(),
+            pf_summaries.len(),
+            rpc_ms as f64 / pf_ms.max(1) as f64
+        );
+
+        let cold_rpc_abi = new_abi_registry(Arc::clone(&ds));
+        let t0 = Instant::now();
+        let _ = enrich_rpc_path(&hashes, &ds, &cold_rpc_abi).await;
+        let cold_rpc_ms = t0.elapsed().as_millis();
+
+        let cold_pf_abi = new_abi_registry(Arc::clone(&ds));
+        let t0 = Instant::now();
+        let _ = enrich_pf_path(&hashes, &ds, &pf, &cold_pf_abi).await;
+        let cold_pf_ms = t0.elapsed().as_millis();
+
+        println!(
+            "  cold-ABI:  RPC {cold_rpc_ms:>5} ms               |  PF {cold_pf_ms:>5} ms                |  speedup {:.2}x",
+            cold_rpc_ms as f64 / cold_pf_ms.max(1) as f64
+        );
+
+        let mismatches = compare_summaries(&rpc_summaries, &pf_summaries);
+        println!(
+            "  correctness: rpc={} pf={} mismatches={}",
+            rpc_summaries.len(),
+            pf_summaries.len(),
+            mismatches.len()
+        );
+        for m in mismatches.iter().take(10) {
+            println!("    MISMATCH {m}");
+        }
+        assert!(
+            mismatches.is_empty(),
+            "field mismatches between RPC and PF paths at N={}",
+            hashes.len()
+        );
+    }
+}
+
+/// Measure user-click latency while background enrichment is in-flight.
+///
+/// This models the bug the pf-query migration targets: a user click on a tx
+/// was blocked behind the enrichment's RPC storm. With the pf path, the
+/// enrichment hits Pathfinder instead of RPC, so user clicks against RPC
+/// should stay snappy.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[ignore = "requires APP_RPC_URL and APP_PATHFINDER_SERVICE_URL"]
+async fn bench_click_latency_under_enrichment_load() {
+    let ds: Arc<dyn DataSource> = Arc::new(RpcDataSource::new(&rpc_url()));
+    let pf = Arc::new(PathfinderClient::new(pf_url()));
+
+    // Large enrichment batch — the pathological case.
+    let enrich_hashes = sample_invoke_hashes(&ds, 400).await;
+    // Smaller set of hashes to simulate user clicks; drawn from the same
+    // pool so the server is asked for real data.
+    let click_hashes: Vec<Felt> = enrich_hashes
+        .iter()
+        .step_by(enrich_hashes.len() / 10)
+        .take(10)
+        .copied()
+        .collect();
+
+    println!(
+        "Enrichment batch: {} hashes, click samples: {}",
+        enrich_hashes.len(),
+        click_hashes.len()
+    );
+
+    for label in &["rpc-path", "pf-path"] {
+        let abi = new_abi_registry(Arc::clone(&ds));
+        // Warm ABIs so class fetches don't dominate.
+        let _ = enrich_rpc_path(&enrich_hashes, &ds, &abi).await;
+
+        // Spawn enrichment concurrently with click probes.
+        let ds_bg = Arc::clone(&ds);
+        let pf_bg = Arc::clone(&pf);
+        let abi_bg = Arc::clone(&abi);
+        let hashes_bg = enrich_hashes.clone();
+        let path = *label;
+        let enrich_start = Instant::now();
+        let enrich_task = tokio::spawn(async move {
+            match path {
+                "rpc-path" => {
+                    // Mimic the old `enrich_all_empty_endpoints` pattern:
+                    // batches of 20 running sequentially, each batch 20-way
+                    // parallel. That's what saturated the pool pre-fix.
+                    for chunk in hashes_bg.chunks(20) {
+                        let _ = enrich_rpc_path(chunk, &ds_bg, &abi_bg).await;
+                    }
+                }
+                "pf-path" => {
+                    let _ = enrich_pf_path(&hashes_bg, &ds_bg, &pf_bg, &abi_bg).await;
+                }
+                _ => unreachable!(),
+            }
+        });
+
+        // Fire click probes at 50ms intervals while enrichment runs.
+        let mut click_latencies: Vec<u128> = Vec::new();
+        for h in &click_hashes {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            let ds_c = Arc::clone(&ds);
+            let h = *h;
+            let t0 = Instant::now();
+            let (tx_r, rx_r) = tokio::join!(ds_c.get_transaction(h), ds_c.get_receipt(h));
+            let ms = t0.elapsed().as_millis();
+            let _ = tx_r;
+            let _ = rx_r;
+            click_latencies.push(ms);
+        }
+
+        let _ = enrich_task.await;
+        let enrich_ms = enrich_start.elapsed().as_millis();
+
+        click_latencies.sort();
+        let min = *click_latencies.first().unwrap();
+        let p50 = click_latencies[click_latencies.len() / 2];
+        let p90 = click_latencies[click_latencies.len() * 9 / 10];
+        let max = *click_latencies.last().unwrap();
+        let sum: u128 = click_latencies.iter().sum();
+        let mean = sum / click_latencies.len() as u128;
+
+        println!(
+            "\n[{label}] enrichment={enrich_ms} ms  click latency (ms) min={min} p50={p50} p90={p90} max={max} mean={mean}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Reworks the address-info enrichment path to use the `pf-query` service as the primary backend, with RPC as fallback. This removes the RPC storm that used to block user-initiated fetches while an address was loading.

### Changes

- **pf-query**: adds endpoints for bulk `get_txs_by_hash` plus account/contract event queries; updates bloom-filter handling so `from_address` lookups skip irrelevant blocks cheaply.
- **Enrichment path (`src/network/address.rs`)**: one pf-query round trip replaces per-hash `get_transaction` + `get_receipt` RPC pairs. Target-address ABIs are pre-warmed from pf rows instead of invoke calldata parsed from RPC results.
- **Event routing (`fetch_events_routed`)**: contracts go pf-primary (bloom index on `from_address`), accounts go RPC-primary (RPC's key filter on `transaction_executed` beats pf's bloom which doesn't index keys).
- **Backpressure**: a semaphore caps concurrent fallback RPC calls from the enrichment path so a user click on a tx isn't queued behind dozens of background requests.
- **Gap-fill guard**: skip filling address-history gaps larger than a threshold to avoid pathological backfills on stale accounts.
- **UI**: `Ctrl+U` / `Ctrl+D` scroll the active address tab by ~20 rows.
- **Bench test** (`tests/enrich_bench_test.rs`, `#[ignore]`): side-by-side RPC-only vs pf-primary enrichment — measures wall-clock, asserts field-level equivalence of the produced `AddressTxSummary`, and probes user-click latency while a large enrichment is in flight.

### Config

Set `APP_PATHFINDER_SERVICE_URL` to point at a running `pf-query`. Without it, the old RPC path is still used.

## Test plan

- [x] `cargo build --release`
- [x] `cargo clippy` / `cargo fmt --check`
- [x] `cargo test`
- [x] With `APP_RPC_URL` + `APP_PATHFINDER_SERVICE_URL` set: `cargo test --test enrich_bench_test -- --ignored --nocapture` — verify no mismatches and pf path is faster
- [x] Manual: open a busy address, confirm clicking a tx responds immediately while enrichment is still loading
- [x] Manual: open an address with stale history, confirm huge gaps are skipped rather than backfilled