### PR TITLE
Show USD prices for tracked tokens (closes #7)

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -17,17 +17,29 @@ use crate::network::dune::AddressActivityProbe;
 pub enum Action {
     // --- Requests (UI → network) ---
     /// Fetch the N most recent blocks.
-    FetchRecentBlocks { count: usize },
+    FetchRecentBlocks {
+        count: usize,
+    },
     /// Fetch a block with all its transactions.
-    FetchBlockDetail { number: u64 },
+    FetchBlockDetail {
+        number: u64,
+    },
     /// Fetch a transaction and its receipt.
-    FetchTransaction { hash: Felt },
+    FetchTransaction {
+        hash: Felt,
+    },
     /// Fetch address info (nonce, class hash, etc.).
-    FetchAddressInfo { address: Felt },
+    FetchAddressInfo {
+        address: Felt,
+    },
     /// Navigate to address view immediately (before data loads).
-    NavigateToAddress { address: Felt },
+    NavigateToAddress {
+        address: Felt,
+    },
     /// Resolve a search query (may need RPC to disambiguate tx vs address).
-    ResolveSearch { query: String },
+    ResolveSearch {
+        query: String,
+    },
     /// Fetch the next/prev tx by nonce for a given sender address.
     FetchTxByNonce {
         sender: Felt,
@@ -35,7 +47,10 @@ pub enum Action {
         direction: i64,
     },
     /// Enrich visible address txs that are missing endpoint/timestamp data.
-    EnrichAddressTxs { address: Felt, hashes: Vec<Felt> },
+    EnrichAddressTxs {
+        address: Felt,
+        hashes: Vec<Felt>,
+    },
     /// Post-load enrichment: fill small nonce gaps + enrich missing endpoint names.
     /// Fires automatically once initial sources settle. Large gaps are handled by
     /// `FillAddressNonceGaps` instead (on-demand, issue #10).
@@ -56,7 +71,10 @@ pub enum Action {
         hashes_with_blocks: Vec<(Felt, u64)>,
     },
     /// Fetch older blocks (pagination: blocks before `before` block number).
-    FetchOlderBlocks { before: u64, count: usize },
+    FetchOlderBlocks {
+        before: u64,
+        count: usize,
+    },
     /// Fetch more address transactions from before a given block (pagination).
     FetchMoreAddressTxs {
         address: Felt,
@@ -64,7 +82,9 @@ pub enum Action {
         is_contract: bool,
     },
     /// Fetch class hash info (ABI, declaration, deployed contracts).
-    FetchClassInfo { class_hash: Felt },
+    FetchClassInfo {
+        class_hash: Felt,
+    },
     /// Persist enriched address txs to cache (sent after enrichment completes).
     PersistAddressTxs {
         address: Felt,
@@ -74,6 +94,12 @@ pub enum Action {
     PersistAddressCalls {
         address: Felt,
         calls: Vec<ContractCallSummary>,
+    },
+    FetchTokenPricesToday {
+        tokens: Vec<Felt>,
+    },
+    FetchTokenPricesHistoric {
+        requests: Vec<(Felt, u64)>,
     },
 
     // --- Responses (network → UI) ---
@@ -100,6 +126,7 @@ pub enum Action {
         decoded_calls: Vec<RawCall>,
         /// Detected outside executions: (call_index, parsed_info).
         outside_executions: Vec<(usize, OutsideExecutionInfo)>,
+        block_timestamp: Option<u64>,
     },
     /// Address info loaded.
     AddressInfoLoaded {
@@ -141,7 +168,10 @@ pub enum Action {
         probe: AddressActivityProbe,
     },
     /// Tells the UI which data sources will be streaming tx data for this address load.
-    AddressSourcesPending { address: Felt, sources: Vec<Source> },
+    AddressSourcesPending {
+        address: Felt,
+        sources: Vec<Source>,
+    },
     /// Streaming partial tx results from a specific data source (merges, never replaces).
     AddressTxsStreamed {
         address: Felt,
@@ -176,7 +206,9 @@ pub enum Action {
     /// Update the loading status message shown in the status bar.
     LoadingStatus(String),
     /// Navigate to class info view immediately (before data loads).
-    NavigateToClassInfo { class_hash: Felt },
+    NavigateToClassInfo {
+        class_hash: Felt,
+    },
     /// Class ABI loaded from RPC/cache.
     ClassAbiLoaded {
         class_hash: Felt,
@@ -193,6 +225,7 @@ pub enum Action {
         contracts: Vec<ClassContractEntry>,
         declaration_block: Option<u64>,
     },
+    PricesUpdated,
     /// An error occurred in the network task.
     Error(String),
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -811,7 +811,22 @@ impl App {
                     info.nonce == starknet::core::types::Felt::ZERO && info.class_hash.is_some();
                 self.address.is_contract = is_contract;
 
+                // Preserve any balances that may have already arrived — the
+                // balance task runs in parallel with the nonce/class_hash
+                // fetch and can land first, and every callsite constructs
+                // `SnAddressInfo` with an empty `token_balances` by default.
+                let preserved_balances = self
+                    .address
+                    .info
+                    .as_ref()
+                    .map(|i| i.token_balances.clone())
+                    .unwrap_or_default();
+
                 // Only update info if it has real data
+                let mut info = info;
+                if info.token_balances.is_empty() && !preserved_balances.is_empty() {
+                    info.token_balances = preserved_balances;
+                }
                 if info.nonce != starknet::core::types::Felt::ZERO
                     || !info.token_balances.is_empty()
                     || info.class_hash.is_some()
@@ -1233,6 +1248,18 @@ impl App {
             }
             Action::AddressBalancesLoaded { address, balances } => {
                 if self.address.context == Some(address) {
+                    // Balances can beat the nonce/class_hash fetch to the UI —
+                    // seed a minimal info so the result isn't dropped while
+                    // `info` is still `None` waiting on `AddressInfoLoaded`.
+                    if self.address.info.is_none() {
+                        self.address.info = Some(crate::data::types::SnAddressInfo {
+                            address,
+                            nonce: starknet::core::types::Felt::ZERO,
+                            class_hash: None,
+                            recent_events: Vec::new(),
+                            token_balances: Vec::new(),
+                        });
+                    }
                     if let Some(info) = &mut self.address.info {
                         info.token_balances = balances;
                     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 
 use crate::data::types::{AddressTxSummary, SnBlock, VoyagerLabelInfo};
+use crate::network::prices::PriceClient;
 use crate::network::ws::WsSubscriptionManager;
 use crate::registry::SearchResult;
 use crate::search::SearchEngine;
@@ -95,6 +96,8 @@ pub struct App {
 
     /// Optional WebSocket subscription manager (present when APP_WS_URL is configured).
     pub ws_manager: Option<WsSubscriptionManager>,
+
+    pub price_client: Option<Arc<PriceClient>>,
 }
 
 impl App {
@@ -135,6 +138,7 @@ impl App {
             forward_history: Vec::new(),
 
             ws_manager: None,
+            price_client: None,
         }
     }
 
@@ -144,6 +148,48 @@ impl App {
         txs: Vec<AddressTxSummary>,
     ) -> Vec<AddressTxSummary> {
         self.address.filter_deployment_txs(address, txs)
+    }
+
+    fn dispatch_balance_price_fetch(&self) {
+        if self.price_client.is_none() {
+            return;
+        }
+        let tokens = crate::network::prices::TRACKED_TOKENS.clone();
+        if tokens.is_empty() {
+            return;
+        }
+        let _ = self
+            .action_tx
+            .send(Action::FetchTokenPricesToday { tokens });
+    }
+
+    fn dispatch_tx_price_fetch(&self) {
+        if self.price_client.is_none() {
+            return;
+        }
+        let mut event_tokens: Vec<starknet::core::types::Felt> = self
+            .tx_detail
+            .decoded_events
+            .iter()
+            .map(|e| e.contract_address)
+            .filter(crate::network::prices::is_tracked)
+            .collect();
+        event_tokens.sort();
+        event_tokens.dedup();
+        if event_tokens.is_empty() {
+            return;
+        }
+
+        let _ = self.action_tx.send(Action::FetchTokenPricesToday {
+            tokens: event_tokens.clone(),
+        });
+
+        if let Some(ts) = self.tx_detail.block_timestamp {
+            let requests: Vec<_> = event_tokens.into_iter().map(|t| (t, ts)).collect();
+            let _ = self
+                .action_tx
+                .send(Action::FetchTokenPricesHistoric { requests });
+        }
     }
 
     pub fn current_view(&self) -> View {
@@ -710,12 +756,14 @@ impl App {
                 decoded_events,
                 decoded_calls,
                 outside_executions,
+                block_timestamp,
             } => {
                 self.tx_detail.transaction = Some(transaction);
                 self.tx_detail.receipt = Some(receipt);
                 self.tx_detail.decoded_events = decoded_events;
                 self.tx_detail.decoded_calls = decoded_calls;
                 self.tx_detail.outside_executions = outside_executions;
+                self.tx_detail.block_timestamp = block_timestamp;
                 self.tx_detail.scroll = 0;
                 self.tx_detail.visual_mode = false;
                 self.build_tx_nav_items();
@@ -724,6 +772,7 @@ impl App {
                 if self.current_view() != View::TxDetail {
                     self.push_view(View::TxDetail);
                 }
+                self.dispatch_tx_price_fetch();
             }
             Action::NavigateToAddress { address } => {
                 // Push view immediately — show cached data while fresh data loads
@@ -1187,7 +1236,11 @@ impl App {
                     if let Some(info) = &mut self.address.info {
                         info.token_balances = balances;
                     }
+                    self.dispatch_balance_price_fetch();
                 }
+            }
+            Action::PricesUpdated => {
+                // Cache reads happen on next draw; no app state to update.
             }
             Action::VoyagerLabelLoaded { address, label } => {
                 // Add to search index so Voyager labels are searchable

--- a/src/app/views/tx_detail.rs
+++ b/src/app/views/tx_detail.rs
@@ -31,6 +31,7 @@ pub struct TxDetailState {
     pub outside_executions: Vec<(usize, OutsideExecutionInfo)>,
     /// Whether to show the expanded outside execution intent view.
     pub show_outside_execution: bool,
+    pub block_timestamp: Option<u64>,
 }
 
 impl Default for TxDetailState {
@@ -49,6 +50,7 @@ impl Default for TxDetailState {
             show_decoded_calldata: false,
             outside_executions: Vec::new(),
             show_outside_execution: false,
+            block_timestamp: None,
         }
     }
 }
@@ -67,6 +69,7 @@ impl TxDetailState {
         self.nav_items = Vec::new();
         self.nav_cursor = 0;
         self.nav_item_lines = Vec::new();
+        self.block_timestamp = None;
     }
 
     /// Build the list of navigable items for the current transaction.

--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -911,6 +911,15 @@ impl DataSource for CachingDataSource {
             .await
     }
 
+    async fn batch_call_contracts(
+        &self,
+        calls: Vec<(Felt, Felt, Vec<Felt>)>,
+    ) -> Vec<Result<Vec<Felt>>> {
+        // Pass through so the upstream's batched implementation is used —
+        // the default trait impl would silently run each call serially.
+        self.upstream.batch_call_contracts(calls).await
+    }
+
     async fn get_contract_events(
         &self,
         address: Felt,

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -97,6 +97,24 @@ pub trait DataSource: Send + Sync {
         calldata: Vec<Felt>,
     ) -> Result<Vec<Felt>>;
 
+    /// Batch multiple view-function calls into a single JSON-RPC round trip.
+    ///
+    /// Returns per-call results in the same order as `calls`. The default
+    /// implementation issues each call sequentially — the RPC-backed source
+    /// overrides this to use `starknet_call` batching (issue #12), which
+    /// turns N round trips into one for things like fetching balances across
+    /// a fixed set of tokens.
+    async fn batch_call_contracts(
+        &self,
+        calls: Vec<(Felt, Felt, Vec<Felt>)>,
+    ) -> Vec<Result<Vec<Felt>>> {
+        let mut out = Vec::with_capacity(calls.len());
+        for (contract, selector, calldata) in calls {
+            out.push(self.call_contract(contract, selector, calldata).await);
+        }
+        out
+    }
+
     // --- Deploy info cache ---
     /// Load cached deploy tx info for an address. Returns (tx_hash, block, deployer).
     fn load_cached_deploy_info(&self, _address: &Felt) -> Option<(Felt, u64, Option<Felt>)> {

--- a/src/data/rpc.rs
+++ b/src/data/rpc.rs
@@ -1,12 +1,15 @@
 use async_trait::async_trait;
+use starknet::core::types::requests::CallRequest;
 use starknet::core::types::{
     AddressFilter, BlockId, BlockTag, BlockWithTxs, ContractClass, DeclareTransaction,
     DeployAccountTransaction, EventFilter, ExecutionResult, Felt, FunctionCall, InvokeTransaction,
     MaybePreConfirmedBlockWithTxs, Transaction, TransactionReceipt,
 };
 use starknet::core::utils::get_contract_address;
-use starknet::providers::{JsonRpcClient, Provider, jsonrpc::HttpTransport};
-use tracing::debug;
+use starknet::providers::{
+    JsonRpcClient, Provider, ProviderRequestData, ProviderResponseData, jsonrpc::HttpTransport,
+};
+use tracing::{debug, warn};
 use url::Url;
 
 use super::DataSource;
@@ -389,6 +392,52 @@ impl DataSource for RpcDataSource {
             .call(call, BlockId::Tag(BlockTag::Latest))
             .await
             .map_err(|e| SnbeatError::Provider(e.to_string()))
+    }
+
+    async fn batch_call_contracts(
+        &self,
+        calls: Vec<(Felt, Felt, Vec<Felt>)>,
+    ) -> Vec<Result<Vec<Felt>>> {
+        if calls.is_empty() {
+            return Vec::new();
+        }
+        let requests: Vec<ProviderRequestData> = calls
+            .iter()
+            .map(|(contract_address, selector, calldata)| {
+                ProviderRequestData::Call(CallRequest {
+                    request: FunctionCall {
+                        contract_address: *contract_address,
+                        entry_point_selector: *selector,
+                        calldata: calldata.clone(),
+                    },
+                    block_id: BlockId::Tag(BlockTag::Latest),
+                })
+            })
+            .collect();
+
+        match self.provider.batch_requests(&requests).await {
+            Ok(responses) => responses
+                .into_iter()
+                .map(|resp| match resp {
+                    ProviderResponseData::Call(v) => Ok(v),
+                    _ => Err(SnbeatError::Provider(
+                        "unexpected response type in batch".into(),
+                    )),
+                })
+                .collect(),
+            Err(e) => {
+                // `batch_requests` is all-or-nothing — if any single call in the
+                // batch fails, the whole thing errors. Fall back to per-call
+                // requests so one bad call (e.g., a contract without the
+                // expected selector) doesn't sink the rest.
+                warn!(error = %e, "batch_requests failed, falling back to sequential");
+                let mut out = Vec::with_capacity(calls.len());
+                for (contract, selector, calldata) in calls {
+                    out.push(self.call_contract(contract, selector, calldata).await);
+                }
+                out
+            }
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,20 @@ async fn main() -> anyhow::Result<()> {
             Arc::new(network::dune::DuneClient::new(key.clone()))
         });
 
+    // DefiLlama needs no API key, so the client is always created when the cache opens.
+    let price_client: Option<Arc<network::prices::PriceClient>> =
+        match network::prices::PriceClient::new(&cache_db) {
+            Ok(client) => {
+                info!("DefiLlama price client enabled");
+                Some(Arc::new(client))
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed to initialize price client (USD prices disabled)");
+                None
+            }
+        };
+    app.price_client = price_client.clone();
+
     // Create Voyager client (optional — only if API key is set)
     let voyager_client: Option<Arc<network::voyager::VoyagerClient>> = config
         .voyager_api_key
@@ -291,6 +305,7 @@ async fn main() -> anyhow::Result<()> {
             dune_client,
             pf_client,
             voyager_client,
+            price_client,
             action_rx,
             resp_tx_clone,
         )

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -433,6 +433,17 @@ pub(super) async fn fetch_and_send_address_info(
     let start = std::time::Instant::now();
     debug!(address = %format!("{:#x}", address), "Fetching address info");
 
+    // Kick off token balance fetch immediately — it's independent of nonce/class_hash
+    // and is the primary "is this address active?" signal, so we want it visible ASAP.
+    {
+        let ds_bal = Arc::clone(ds);
+        let tx_bal = tx.clone();
+        tokio::spawn(async move {
+            let balances = fetch_token_balances(address, &ds_bal).await;
+            let _ = tx_bal.send(Action::AddressBalancesLoaded { address, balances });
+        });
+    }
+
     // Kick off Voyager label fetch immediately — runs fully in parallel with all other IO.
     if let Some(vc) = voyager_c {
         let vc = Arc::clone(vc);
@@ -532,16 +543,6 @@ pub(super) async fn fetch_and_send_address_info(
         tx_summaries: ds.load_cached_address_txs(&address),
         contract_calls: ds.load_cached_address_calls(&address),
     });
-
-    // Fetch balances in background
-    {
-        let ds_bal = Arc::clone(ds);
-        let tx_bal = tx.clone();
-        tokio::spawn(async move {
-            let balances = fetch_token_balances(address, &ds_bal).await;
-            let _ = tx_bal.send(Action::AddressBalancesLoaded { address, balances });
-        });
-    }
 
     // Check cached activity range — if fresh, skip Dune probe entirely.
     let cached_range = ds.load_cached_activity_range(&address);

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -163,11 +163,16 @@ pub(super) async fn fetch_events_routed(
 }
 
 /// Fetch token balances for all known tokens for an address.
+///
+/// Tries `balanceOf` (SNIP-2/Cairo 1 camelCase) first, falls back to legacy
+/// `balance_of` (Cairo 0 snake_case). Most modern tokens expose both; wBTC
+/// and some older tokens only expose camelCase.
 async fn fetch_token_balances(
     address: starknet::core::types::Felt,
     ds: &Arc<dyn DataSource>,
 ) -> Vec<crate::data::types::TokenBalance> {
-    let balance_selector = starknet::core::utils::get_selector_from_name("balance_of").unwrap();
+    let balance_of_camel = starknet::core::utils::get_selector_from_name("balanceOf").unwrap();
+    let balance_of_snake = starknet::core::utils::get_selector_from_name("balance_of").unwrap();
     let known_tokens: &[(&str, &str, u8)] = &[
         (
             "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
@@ -209,9 +214,14 @@ async fn fetch_token_balances(
             let name = name.to_string();
             let decimals = *decimals;
             async move {
-                let result = ds_bal
-                    .call_contract(token, balance_selector, vec![address])
+                let mut result = ds_bal
+                    .call_contract(token, balance_of_camel, vec![address])
                     .await;
+                if result.is_err() {
+                    result = ds_bal
+                        .call_contract(token, balance_of_snake, vec![address])
+                        .await;
+                }
                 (token, name, decimals, result)
             }
         })
@@ -220,10 +230,16 @@ async fn fetch_token_balances(
     let balance_results = futures::future::join_all(balance_futures).await;
     let mut token_balances = Vec::new();
     for (token, name, decimals, result) in balance_results {
-        let balance_felt = result
-            .ok()
-            .and_then(|v| v.first().copied())
-            .unwrap_or(starknet::core::types::Felt::ZERO);
+        let balance_felt = match result {
+            Ok(v) => v
+                .first()
+                .copied()
+                .unwrap_or(starknet::core::types::Felt::ZERO),
+            Err(e) => {
+                warn!(token = %name, error = %e, "balanceOf call failed");
+                starknet::core::types::Felt::ZERO
+            }
+        };
         token_balances.push(crate::data::types::TokenBalance {
             token_address: token,
             token_name: name,

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -162,89 +162,114 @@ pub(super) async fn fetch_events_routed(
     }
 }
 
+/// Well-known tokens whose balances we probe for every address.
+///
+/// `(contract_address, display_name, decimals)`. Extend cautiously: each
+/// entry adds a call to the `balanceOf` batch.
+const KNOWN_TOKENS: &[(&str, &str, u8)] = &[
+    (
+        "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+        "STRK",
+        18,
+    ),
+    (
+        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "ETH",
+        18,
+    ),
+    (
+        "0x0124aeb495b947201f5fac96fd1138e326ad86195b98df6dec9009158a533b49",
+        "wBTC",
+        8,
+    ),
+    (
+        "0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb",
+        "USDC",
+        6,
+    ),
+    (
+        "0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+        "USDC.e",
+        6,
+    ),
+    (
+        "0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
+        "USDT",
+        6,
+    ),
+];
+
 /// Fetch token balances for all known tokens for an address.
 ///
-/// Tries `balanceOf` (SNIP-2/Cairo 1 camelCase) first, falls back to legacy
-/// `balance_of` (Cairo 0 snake_case). Most modern tokens expose both; wBTC
-/// and some older tokens only expose camelCase.
-async fn fetch_token_balances(
+/// Uses JSON-RPC batching (issue #12) so all `balanceOf` probes land in a
+/// single round trip. Only non-zero balances are returned; the caller uses
+/// the returned length directly for the `Balances(N)` tab counter.
+///
+/// Tries `balanceOf` (SNIP-2/Cairo 1 camelCase) first via the batch. Any
+/// token that errors out (e.g., legacy Cairo 0 token that only exposes
+/// `balance_of`) is retried individually with snake_case selector.
+pub(crate) async fn fetch_token_balances(
     address: starknet::core::types::Felt,
     ds: &Arc<dyn DataSource>,
 ) -> Vec<crate::data::types::TokenBalance> {
     let balance_of_camel = starknet::core::utils::get_selector_from_name("balanceOf").unwrap();
     let balance_of_snake = starknet::core::utils::get_selector_from_name("balance_of").unwrap();
-    let known_tokens: &[(&str, &str, u8)] = &[
-        (
-            "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
-            "STRK",
-            18,
-        ),
-        (
-            "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-            "ETH",
-            18,
-        ),
-        (
-            "0x0124aeb495b947201f5fac96fd1138e326ad86195b98df6dec9009158a533b49",
-            "wBTC",
-            8,
-        ),
-        (
-            "0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb",
-            "USDC",
-            6,
-        ),
-        (
-            "0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
-            "USDC.e",
-            6,
-        ),
-        (
-            "0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
-            "USDT",
-            6,
-        ),
-    ];
 
-    let balance_futures: Vec<_> = known_tokens
+    // Build the batched call list (balanceOf for every known token).
+    let tokens: Vec<(starknet::core::types::Felt, &'static str, u8)> = KNOWN_TOKENS
         .iter()
         .map(|(hex, name, decimals)| {
-            let ds_bal = Arc::clone(ds);
-            let token = starknet::core::types::Felt::from_hex(hex).unwrap();
-            let name = name.to_string();
-            let decimals = *decimals;
-            async move {
-                let mut result = ds_bal
-                    .call_contract(token, balance_of_camel, vec![address])
-                    .await;
-                if result.is_err() {
-                    result = ds_bal
-                        .call_contract(token, balance_of_snake, vec![address])
-                        .await;
-                }
-                (token, name, decimals, result)
-            }
+            (
+                starknet::core::types::Felt::from_hex(hex).unwrap(),
+                *name,
+                *decimals,
+            )
         })
         .collect();
+    let batch_calls: Vec<_> = tokens
+        .iter()
+        .map(|(token, _, _)| (*token, balance_of_camel, vec![address]))
+        .collect();
 
-    let balance_results = futures::future::join_all(balance_futures).await;
+    let batch_results = ds.batch_call_contracts(batch_calls).await;
+
     let mut token_balances = Vec::new();
-    for (token, name, decimals, result) in balance_results {
+    for ((token, name, decimals), result) in tokens.iter().zip(batch_results.into_iter()) {
         let balance_felt = match result {
             Ok(v) => v
                 .first()
                 .copied()
                 .unwrap_or(starknet::core::types::Felt::ZERO),
-            Err(e) => {
-                warn!(token = %name, error = %e, "balanceOf call failed");
-                starknet::core::types::Felt::ZERO
+            Err(camel_err) => {
+                // Legacy token fallback: retry this single call with snake_case.
+                match ds
+                    .call_contract(*token, balance_of_snake, vec![address])
+                    .await
+                {
+                    Ok(v) => v
+                        .first()
+                        .copied()
+                        .unwrap_or(starknet::core::types::Felt::ZERO),
+                    Err(snake_err) => {
+                        warn!(
+                            token = %name,
+                            camel_error = %camel_err,
+                            snake_error = %snake_err,
+                            "balanceOf/balance_of both failed"
+                        );
+                        starknet::core::types::Felt::ZERO
+                    }
+                }
             }
         };
+        if felt_to_u128(&balance_felt) == 0 {
+            continue; // Only surface non-zero balances.
+        }
         token_balances.push(crate::data::types::TokenBalance {
-            token_address: token,
-            token_name: name,
+            token_address: *token,
+            token_name: name.to_string(),
             balance_raw: balance_felt,
-            decimals,
+            decimals: *decimals,
         });
     }
     token_balances
@@ -2558,4 +2583,89 @@ pub(super) async fn find_deploy_tx(
     }
 
     debug!(%addr, deploy_block, "Deploy tx not found in block (neither native nor UDC)");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::rpc::RpcDataSource;
+    use starknet::core::types::Felt;
+
+    fn rpc_ds() -> Arc<dyn DataSource> {
+        dotenvy::dotenv().ok();
+        let rpc_url =
+            std::env::var("APP_RPC_URL").expect("APP_RPC_URL must be set for integration tests");
+        Arc::new(RpcDataSource::new(&rpc_url))
+    }
+
+    /// Major public AMM/DEX contracts on Starknet mainnet. Chosen because
+    /// they hold large LP balances across multiple tokens, so at least one
+    /// of the well-known tokens must return non-zero. Pure on-chain public
+    /// addresses — no ownership/activity implication.
+    const WELL_KNOWN_ADDRESSES: &[(&str, &str)] = &[(
+        "0x00000005dd3d2f4429af886cd1a3b08289dbcea99a294197e9eb43b0e0325b4b",
+        "Ekubo Core",
+    )];
+
+    #[tokio::test]
+    #[ignore = "requires APP_RPC_URL"]
+    async fn fetch_balances_for_well_known_addresses() {
+        let ds = rpc_ds();
+        for (hex, label) in WELL_KNOWN_ADDRESSES {
+            let address = Felt::from_hex(hex).unwrap();
+            let balances = fetch_token_balances(address, &ds).await;
+            println!("{} ({}): {} non-zero balances", label, hex, balances.len());
+            for b in &balances {
+                println!("  {} = {:#x}", b.token_name, b.balance_raw);
+            }
+            assert!(
+                !balances.is_empty(),
+                "{} should have at least one non-zero token balance",
+                label
+            );
+            // Invariant enforced by fetch_token_balances: zero balances are filtered out.
+            for b in &balances {
+                assert_ne!(
+                    crate::utils::felt_to_u128(&b.balance_raw),
+                    0,
+                    "{}: {} had zero balance but was returned",
+                    label,
+                    b.token_name
+                );
+            }
+        }
+    }
+
+    /// Smoke test that `batch_call_contracts` matches individual `call_contract`
+    /// results. Guards against regressions where the batched path silently
+    /// returns results in the wrong order.
+    #[tokio::test]
+    #[ignore = "requires APP_RPC_URL"]
+    async fn batch_call_matches_sequential() {
+        let ds = rpc_ds();
+        let balance_of = starknet::core::utils::get_selector_from_name("balanceOf").unwrap();
+        // Ekubo Core — has mixed-token balances.
+        let address = Felt::from_hex(WELL_KNOWN_ADDRESSES[0].0).unwrap();
+
+        let calls: Vec<(Felt, Felt, Vec<Felt>)> = KNOWN_TOKENS
+            .iter()
+            .map(|(hex, _, _)| (Felt::from_hex(hex).unwrap(), balance_of, vec![address]))
+            .collect();
+
+        let batched = ds.batch_call_contracts(calls.clone()).await;
+        assert_eq!(batched.len(), calls.len(), "batch returned wrong count");
+
+        for ((contract, selector, calldata), batch_result) in calls.iter().zip(batched.iter()) {
+            let seq = ds
+                .call_contract(*contract, *selector, calldata.clone())
+                .await;
+            match (batch_result, &seq) {
+                (Ok(a), Ok(b)) => assert_eq!(a, b, "batched and sequential results diverged"),
+                (Err(_), Err(_)) => {}
+                (Ok(_), Err(e)) | (Err(e), Ok(_)) => {
+                    panic!("batched/sequential disagreed on Ok/Err: {}", e);
+                }
+            }
+        }
+    }
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -14,6 +14,7 @@ mod block;
 mod class;
 pub mod dune;
 pub mod helpers;
+pub mod prices;
 mod search;
 mod transaction;
 pub mod voyager;
@@ -36,6 +37,7 @@ pub async fn run_network_task(
     dune_client: Option<Arc<dune::DuneClient>>,
     pf_client: Option<Arc<crate::data::pathfinder::PathfinderClient>>,
     voyager_client: Option<Arc<voyager::VoyagerClient>>,
+    price_client: Option<Arc<prices::PriceClient>>,
     mut action_rx: mpsc::UnboundedReceiver<Action>,
     response_tx: mpsc::UnboundedSender<Action>,
 ) {
@@ -47,6 +49,7 @@ pub async fn run_network_task(
         let dune = dune_client.clone();
         let pf = pf_client.clone();
         let voyager = voyager_client.clone();
+        let prices = price_client.clone();
         let tx = response_tx.clone();
 
         // Spawn each request as a separate task for concurrency
@@ -155,7 +158,7 @@ pub async fn run_network_task(
                                             match ds.get_receipt(*hash).await {
                                                 Ok(receipt) => {
                                                     transaction::decode_and_send_transaction(
-                                                        fetched_tx, receipt, &abi_reg, &tx,
+                                                        fetched_tx, receipt, &ds, &abi_reg, &tx,
                                                     )
                                                     .await;
                                                 }
@@ -255,6 +258,20 @@ pub async fn run_network_task(
                 }
                 Action::PersistAddressCalls { address, calls } => {
                     ds.save_address_calls(&address, &calls);
+                }
+                Action::FetchTokenPricesToday { tokens } => {
+                    if let Some(pc) = &prices {
+                        if pc.ensure_today(&tokens).await {
+                            let _ = tx.send(Action::PricesUpdated);
+                        }
+                    }
+                }
+                Action::FetchTokenPricesHistoric { requests } => {
+                    if let Some(pc) = &prices {
+                        if pc.ensure_historic(&requests).await {
+                            let _ = tx.send(Action::PricesUpdated);
+                        }
+                    }
                 }
                 // Response actions are not handled here
                 _ => {}

--- a/src/network/prices.rs
+++ b/src/network/prices.rs
@@ -1,0 +1,347 @@
+//! DefiLlama token price client with persistent SQLite cache.
+//!
+//! - Today's prices: refreshed at most once per `TODAY_REFRESH_SECS` (1 hour).
+//! - Historical prices: cached forever, keyed on UTC date (`YYYY-MM-DD`).
+//! - All `get_*` reads are sync cache lookups; `ensure_*` fetches and writes through.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::sync::{LazyLock, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use chrono::{DateTime, NaiveDate, Utc};
+use rusqlite::{Connection, params};
+use serde::Deserialize;
+use starknet::core::types::Felt;
+use tracing::{debug, info, warn};
+
+const DEFI_LLAMA_BASE: &str = "https://coins.llama.fi";
+const TODAY_REFRESH_SECS: u64 = 3_600;
+const TODAY_KEY: &str = "today";
+
+const TRACKED_TOKEN_HEX: &[&str] = &[
+    "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d", // STRK
+    "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7", // ETH
+    "0x0124aeb495b947201f5fac96fd1138e326ad86195b98df6dec9009158a533b49", // wBTC
+    "0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb", // USDC (native)
+    "0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8", // USDC (bridged)
+    "0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8", // USDT
+];
+
+/// The set of tokens we surface USD prices for. Mirrors the tokens fetched
+/// by `network::address::fetch_token_balances`.
+pub static TRACKED_TOKENS: LazyLock<Vec<Felt>> = LazyLock::new(|| {
+    TRACKED_TOKEN_HEX
+        .iter()
+        .filter_map(|h| Felt::from_hex(h).ok())
+        .collect()
+});
+
+/// True when `token` is one of the addresses we display USD prices for.
+pub fn is_tracked(token: &Felt) -> bool {
+    TRACKED_TOKENS.contains(token)
+}
+
+pub struct PriceClient {
+    client: reqwest::Client,
+    db: Mutex<Connection>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PriceResponse {
+    #[serde(default)]
+    coins: HashMap<String, CoinPrice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CoinPrice {
+    price: f64,
+}
+
+impl PriceClient {
+    pub fn new(cache_db_path: &Path) -> Result<Self, String> {
+        let db = Connection::open(cache_db_path)
+            .map_err(|e| format!("Failed to open price cache db: {e}"))?;
+
+        db.execute_batch("PRAGMA journal_mode=WAL;")
+            .map_err(|e| format!("Failed to set WAL mode: {e}"))?;
+
+        db.execute_batch(
+            "CREATE TABLE IF NOT EXISTS token_prices (
+                token_address TEXT NOT NULL,
+                date          TEXT NOT NULL,
+                price_usd     REAL NOT NULL,
+                fetched_at    INTEGER NOT NULL,
+                PRIMARY KEY (token_address, date)
+            );",
+        )
+        .map_err(|e| format!("Failed to init token_prices table: {e}"))?;
+
+        Ok(Self {
+            client: reqwest::Client::new(),
+            db: Mutex::new(db),
+        })
+    }
+
+    pub fn get_today_price(&self, token: &Felt) -> Option<f64> {
+        self.read_price(&token_key(token), TODAY_KEY)
+    }
+
+    pub fn get_historic_price(&self, token: &Felt, timestamp: u64) -> Option<f64> {
+        let date = date_key_for_timestamp(timestamp)?;
+        self.read_price(&token_key(token), &date)
+    }
+
+    /// Fetch missing/stale today prices. Returns true if the cache changed.
+    pub async fn ensure_today(&self, tokens: &[Felt]) -> bool {
+        let now = unix_now();
+        let stale_cutoff = now.saturating_sub(TODAY_REFRESH_SECS);
+
+        let to_fetch: Vec<Felt> = tokens
+            .iter()
+            .copied()
+            .filter(|t| !self.is_today_fresh(t, stale_cutoff))
+            .collect();
+        if to_fetch.is_empty() {
+            return false;
+        }
+
+        let url = format!(
+            "{}/prices/current/{}",
+            DEFI_LLAMA_BASE,
+            join_tokens(&to_fetch)
+        );
+
+        match self.fetch(&url).await {
+            Ok(prices) => {
+                if prices.is_empty() {
+                    debug!(
+                        count = to_fetch.len(),
+                        "DefiLlama returned no current prices"
+                    );
+                    return false;
+                }
+                for (addr, price) in &prices {
+                    self.write_price(addr, TODAY_KEY, *price, now);
+                }
+                info!(
+                    count = prices.len(),
+                    "Fetched current token prices from DefiLlama"
+                );
+                true
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed to fetch current token prices");
+                false
+            }
+        }
+    }
+
+    /// Fetch missing historic prices for `(token, timestamp)` pairs. Day granularity.
+    /// Distinct days are fetched concurrently.
+    pub async fn ensure_historic(&self, requests: &[(Felt, u64)]) -> bool {
+        let mut wanted: HashMap<String, HashSet<Felt>> = HashMap::new();
+        for (token, ts) in requests {
+            let Some(date) = date_key_for_timestamp(*ts) else {
+                continue;
+            };
+            if self.read_price(&token_key(token), &date).is_some() {
+                continue;
+            }
+            wanted.entry(date).or_default().insert(*token);
+        }
+        if wanted.is_empty() {
+            return false;
+        }
+
+        let now = unix_now();
+        let futs = wanted.into_iter().filter_map(|(date, tokens)| {
+            let day_ts = date_to_unix(&date)?;
+            let token_list: Vec<Felt> = tokens.into_iter().collect();
+            let url = format!(
+                "{}/prices/historical/{}/{}",
+                DEFI_LLAMA_BASE,
+                day_ts,
+                join_tokens(&token_list)
+            );
+            Some(async move { (date, self.fetch(&url).await) })
+        });
+        let results = futures::future::join_all(futs).await;
+
+        let mut updated = false;
+        for (date, res) in results {
+            match res {
+                Ok(prices) => {
+                    if prices.is_empty() {
+                        debug!(date = %date, "DefiLlama returned no historic prices");
+                        continue;
+                    }
+                    for (addr, price) in &prices {
+                        self.write_price(addr, &date, *price, now);
+                    }
+                    info!(
+                        date = %date,
+                        count = prices.len(),
+                        "Fetched historic token prices from DefiLlama"
+                    );
+                    updated = true;
+                }
+                Err(e) => {
+                    warn!(date = %date, error = %e, "Failed to fetch historic token prices");
+                }
+            }
+        }
+        updated
+    }
+
+    // --- private helpers ---
+
+    fn is_today_fresh(&self, token: &Felt, cutoff: u64) -> bool {
+        let Ok(db) = self.db.lock() else {
+            return false;
+        };
+        db.query_row(
+            "SELECT fetched_at FROM token_prices WHERE token_address = ?1 AND date = ?2",
+            params![token_key(token), TODAY_KEY],
+            |row| row.get::<_, i64>(0),
+        )
+        .ok()
+        .map(|fa| (fa as u64) >= cutoff)
+        .unwrap_or(false)
+    }
+
+    fn read_price(&self, token_key: &str, date: &str) -> Option<f64> {
+        let db = self.db.lock().ok()?;
+        db.query_row(
+            "SELECT price_usd FROM token_prices WHERE token_address = ?1 AND date = ?2",
+            params![token_key, date],
+            |row| row.get::<_, f64>(0),
+        )
+        .ok()
+    }
+
+    fn write_price(&self, token_key: &str, date: &str, price: f64, now: u64) {
+        let Ok(db) = self.db.lock() else { return };
+        let _ = db.execute(
+            "INSERT OR REPLACE INTO token_prices (token_address, date, price_usd, fetched_at) \
+             VALUES (?1, ?2, ?3, ?4)",
+            params![token_key, date, price, now as i64],
+        );
+    }
+
+    async fn fetch(&self, url: &str) -> Result<Vec<(String, f64)>, String> {
+        debug!(url = %url, "DefiLlama price request");
+        let resp = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| format!("request failed: {e}"))?;
+        let status = resp.status();
+        if !status.is_success() {
+            return Err(format!("HTTP {status}"));
+        }
+        let body: PriceResponse = resp
+            .json()
+            .await
+            .map_err(|e| format!("parse failed: {e}"))?;
+        Ok(body
+            .coins
+            .into_iter()
+            .filter_map(|(k, v)| {
+                let addr = k.strip_prefix("starknet:")?.to_string();
+                Some((addr, v.price))
+            })
+            .collect())
+    }
+}
+
+/// Canonical token key — must match the address format DefiLlama returns.
+fn token_key(token: &Felt) -> String {
+    format!("{:#x}", token)
+}
+
+fn join_tokens(tokens: &[Felt]) -> String {
+    tokens
+        .iter()
+        .map(|t| format!("starknet:{}", token_key(t)))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn date_key_for_timestamp(ts: u64) -> Option<String> {
+    if ts == 0 {
+        return None;
+    }
+    let dt = DateTime::<Utc>::from_timestamp(ts as i64, 0)?;
+    Some(dt.format("%Y-%m-%d").to_string())
+}
+
+fn date_to_unix(date: &str) -> Option<i64> {
+    let nd = NaiveDate::parse_from_str(date, "%Y-%m-%d").ok()?;
+    let dt = nd.and_hms_opt(0, 0, 0)?.and_utc();
+    Some(dt.timestamp())
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn date_key_round_trips() {
+        let ts = 1_700_000_000u64;
+        let key = date_key_for_timestamp(ts).unwrap();
+        assert_eq!(key, "2023-11-14");
+        let back = date_to_unix(&key).unwrap();
+        assert!(back <= ts as i64);
+    }
+
+    #[test]
+    fn zero_timestamp_returns_none() {
+        assert!(date_key_for_timestamp(0).is_none());
+    }
+
+    #[test]
+    fn token_key_is_lowercase_no_padding() {
+        let f =
+            Felt::from_hex("0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7")
+                .unwrap();
+        let k = token_key(&f);
+        assert!(k.starts_with("0x"));
+        assert_eq!(k, k.to_lowercase());
+    }
+
+    #[test]
+    fn cache_read_and_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.db");
+        let pc = PriceClient::new(&path).unwrap();
+        let token =
+            Felt::from_hex("0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7")
+                .unwrap();
+        assert!(pc.get_today_price(&token).is_none());
+        pc.write_price(&token_key(&token), TODAY_KEY, 1234.5, unix_now());
+        assert_eq!(pc.get_today_price(&token), Some(1234.5));
+
+        let ts = 1_700_000_000u64;
+        let date = date_key_for_timestamp(ts).unwrap();
+        pc.write_price(&token_key(&token), &date, 999.0, unix_now());
+        assert_eq!(pc.get_historic_price(&token, ts), Some(999.0));
+    }
+
+    #[test]
+    fn tracked_tokens_includes_known_addresses() {
+        assert!(is_tracked(
+            &Felt::from_hex("0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7")
+                .unwrap()
+        ));
+        assert!(!is_tracked(&Felt::from_hex("0x1").unwrap()));
+    }
+}

--- a/src/network/search.rs
+++ b/src/network/search.rs
@@ -55,8 +55,14 @@ pub(super) async fn resolve_search(
                 // Reuse the fetched transaction, only fetch receipt
                 match ds.get_receipt(felt).await {
                     Ok(receipt) => {
-                        transaction::decode_and_send_transaction(transaction, receipt, abi_reg, tx)
-                            .await;
+                        transaction::decode_and_send_transaction(
+                            transaction,
+                            receipt,
+                            ds,
+                            abi_reg,
+                            tx,
+                        )
+                        .await;
                     }
                     Err(err) => {
                         let _ = tx.send(Action::Error(format!(

--- a/src/network/transaction.rs
+++ b/src/network/transaction.rs
@@ -38,10 +38,11 @@ pub(super) async fn resolve_call_abis(
     }
 }
 
-/// Decode already-fetched tx+receipt and send `TransactionLoaded`. No IO.
+/// Decode already-fetched tx+receipt and send `TransactionLoaded`.
 pub(super) async fn decode_and_send_transaction(
     transaction: SnTransaction,
     receipt: crate::data::types::SnReceipt,
+    ds: &Arc<dyn DataSource>,
     abi_reg: &Arc<AbiRegistry>,
     action_tx: &mpsc::UnboundedSender<Action>,
 ) {
@@ -56,12 +57,28 @@ pub(super) async fn decode_and_send_transaction(
     };
     resolve_call_abis(&mut decoded_calls, abi_reg).await;
     let outside_executions = detect_and_resolve_outside_executions(&decoded_calls, abi_reg).await;
+
+    // Only pay for the block fetch when the tx touches a tracked token —
+    // we'd just discard the timestamp otherwise.
+    let needs_timestamp = decoded_events
+        .iter()
+        .any(|e| crate::network::prices::is_tracked(&e.contract_address));
+    let block_timestamp = if needs_timestamp {
+        ds.get_block(receipt.block_number)
+            .await
+            .ok()
+            .map(|b| b.timestamp)
+    } else {
+        None
+    };
+
     let _ = action_tx.send(Action::TransactionLoaded {
         transaction,
         receipt,
         decoded_events,
         decoded_calls,
         outside_executions,
+        block_timestamp,
     });
 }
 
@@ -120,7 +137,7 @@ pub(super) async fn fetch_and_send_transaction(
     match (tx_result, receipt_result) {
         (Ok(transaction), Ok(receipt)) => {
             info!(tx_hash = %hash_short, elapsed_ms = start.elapsed().as_millis(), "Transaction fetched, decoding");
-            decode_and_send_transaction(transaction, receipt, abi_reg, tx).await;
+            decode_and_send_transaction(transaction, receipt, ds, abi_reg, tx).await;
         }
         (Err(e), _) | (_, Err(e)) => {
             error!(tx_hash = %hash_short, elapsed_ms = start.elapsed().as_millis(), error = %e, "Failed to fetch transaction");

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -11,6 +11,7 @@ use crate::app::{AddressTab, App};
 use crate::data::types::TokenBalance;
 use crate::ui::theme;
 use crate::ui::widgets::hex_display::{format_fri, format_strk_u128, short_hash};
+use crate::ui::widgets::price;
 use crate::ui::widgets::{search_bar, status_bar};
 use crate::utils::{felt_to_u64, felt_to_u128};
 
@@ -545,7 +546,13 @@ fn draw_balances_tab(f: &mut Frame, app: &App, area: Rect) {
         None => return,
     };
 
-    if info.token_balances.is_empty() {
+    let nonzero: Vec<&TokenBalance> = info
+        .token_balances
+        .iter()
+        .filter(|b| felt_to_u128(&b.balance_raw) > 0)
+        .collect();
+
+    if nonzero.is_empty() {
         f.render_widget(
             Paragraph::new(" No token balances found")
                 .style(theme::SUGGESTION_STYLE)
@@ -559,16 +566,21 @@ fn draw_balances_tab(f: &mut Frame, app: &App, area: Rect) {
         return;
     }
 
-    let items: Vec<ListItem> = info
-        .token_balances
+    let items: Vec<ListItem> = nonzero
         .iter()
         .map(|bal| {
             let formatted = format_token_balance(bal);
-            let line = Line::from(vec![
+            let mut spans = vec![
                 Span::styled(format!(" {:<8}", bal.token_name), theme::LABEL_STYLE),
-                Span::styled(formatted, theme::NORMAL_STYLE),
-            ]);
-            ListItem::new(line)
+                Span::styled(format!("{:<24}", formatted), theme::NORMAL_STYLE),
+            ];
+            if let Some(usd) = balance_usd_value(app, bal) {
+                spans.push(Span::styled(
+                    format!("  {}", price::format_usd(usd)),
+                    theme::SUGGESTION_STYLE,
+                ));
+            }
+            ListItem::new(Line::from(spans))
         })
         .collect();
 
@@ -579,6 +591,16 @@ fn draw_balances_tab(f: &mut Frame, app: &App, area: Rect) {
             .title(Span::styled(" Token Balances ", theme::TITLE_STYLE)),
     );
     f.render_widget(list, area);
+}
+
+fn balance_usd_value(app: &App, bal: &TokenBalance) -> Option<f64> {
+    let price = app
+        .price_client
+        .as_ref()?
+        .get_today_price(&bal.token_address)?;
+    let raw = felt_to_u128(&bal.balance_raw) as f64;
+    let scale = 10f64.powi(bal.decimals as i32);
+    Some(raw / scale * price)
 }
 
 fn draw_events_tab(f: &mut Frame, app: &App, area: Rect) {

--- a/src/ui/views/tx_detail.rs
+++ b/src/ui/views/tx_detail.rs
@@ -14,7 +14,7 @@ use crate::decode::outside_execution;
 use crate::ui::theme;
 use crate::ui::widgets::address_color::AddressColorMap;
 use crate::ui::widgets::hex_display::{format_commas, format_fri, format_strk_u128};
-use crate::ui::widgets::{param_display, search_bar, status_bar};
+use crate::ui::widgets::{param_display, price, search_bar, status_bar};
 use crate::utils::felt_to_u128;
 
 pub fn draw(f: &mut Frame, app: &mut App) {
@@ -571,6 +571,10 @@ fn draw_scrollable_detail(
             ),
         ]));
 
+        // One price lookup per event contract — params share the same address.
+        let event_prices =
+            price::token_prices(app, &group.contract_address, app.tx_detail.block_timestamp);
+
         for (ei, event) in group.events.iter().enumerate() {
             let is_last = ei == group.events.len() - 1;
             let eb = if is_last { "└─" } else { "├─" };
@@ -614,6 +618,17 @@ fn draw_scrollable_detail(
                         &|a| app.format_address(a),
                     );
                     event_spans.append(&mut param_spans);
+                    let (today, historic) = event_prices;
+                    if today.is_some() || historic.is_some() {
+                        if let Some((amount, _)) =
+                            price::token_amount_from_param(p, &event.contract_address, registry)
+                        {
+                            event_spans.push(Span::styled(
+                                format_usd_pair(amount, today, historic),
+                                theme::SUGGESTION_STYLE,
+                            ));
+                        }
+                    }
                     if pi < all_params.len() - 1 {
                         event_spans.push(Span::raw(", "));
                     }
@@ -914,6 +929,17 @@ fn render_nested_value(
             }
         }
         _ => {} // Leaf values — nothing to nest
+    }
+}
+
+fn format_usd_pair(amount: f64, today: Option<f64>, historic: Option<f64>) -> String {
+    let today_str = today.map(|p| price::format_usd(amount * p));
+    let historic_str = historic.map(|p| price::format_usd(amount * p));
+    match (today_str, historic_str) {
+        (Some(t), Some(h)) => format!(" [{t} ({h})]"),
+        (Some(t), None) => format!(" [{t}]"),
+        (None, Some(h)) => format!(" [({h})]"),
+        (None, None) => String::new(),
     }
 }
 

--- a/src/ui/widgets/mod.rs
+++ b/src/ui/widgets/mod.rs
@@ -3,6 +3,7 @@ pub mod event_tree;
 pub mod help;
 pub mod hex_display;
 pub mod param_display;
+pub mod price;
 pub mod search_bar;
 pub mod stateful_list;
 pub mod status_bar;

--- a/src/ui/widgets/price.rs
+++ b/src/ui/widgets/price.rs
@@ -1,0 +1,81 @@
+//! Cache-first USD price helpers for the UI. All reads are sync — misses
+//! trigger an async fetch via `Action::FetchTokenPrices*` from the views.
+
+use starknet::core::types::Felt;
+
+use crate::app::App;
+use crate::decode::events::DecodedParam;
+use crate::registry::AddressRegistry;
+use crate::utils::felt_to_u128;
+
+/// Format a USD value like `$1,234.56`. Sub-cent values get extra precision
+/// so prices like `$0.0021` stay legible.
+pub fn format_usd(v: f64) -> String {
+    if !v.is_finite() {
+        return String::new();
+    }
+    if v.abs() < 0.01 {
+        return format!("${v:.4}");
+    }
+    let whole = v.trunc() as i64;
+    let cents = (v.fract().abs() * 100.0).round() as u64;
+    let mut whole_str = whole.abs().to_string();
+    let mut grouped = String::new();
+    while whole_str.len() > 3 {
+        let split = whole_str.len() - 3;
+        grouped = format!(",{}{}", &whole_str[split..], grouped);
+        whole_str.truncate(split);
+    }
+    grouped = format!("{}{}", whole_str, grouped);
+    let sign = if whole < 0 { "-" } else { "" };
+    format!("{sign}${grouped}.{cents:02}")
+}
+
+/// `(amount_as_f64, decimals)` for u256 amounts of known tokens, else `None`.
+/// Values above u128 are skipped — they're not meaningful as USD here.
+pub fn token_amount_from_param(
+    p: &DecodedParam,
+    contract_address: &Felt,
+    registry: Option<&AddressRegistry>,
+) -> Option<(f64, u8)> {
+    let type_name = p.type_name.as_deref().unwrap_or("");
+    if !type_name.contains("u256") {
+        return None;
+    }
+    let high = p.value_high.as_ref().map(felt_to_u128).unwrap_or(0);
+    if high != 0 {
+        return None;
+    }
+    let decimals = registry?.get_decimals(contract_address)?;
+    let low = felt_to_u128(&p.value);
+    let scale = 10f64.powi(decimals as i32);
+    Some((low as f64 / scale, decimals))
+}
+
+pub fn token_prices(app: &App, token: &Felt, ts: Option<u64>) -> (Option<f64>, Option<f64>) {
+    let Some(pc) = app.price_client.as_ref() else {
+        return (None, None);
+    };
+    let today = pc.get_today_price(token);
+    let historic = ts.and_then(|t| pc.get_historic_price(token, t));
+    (today, historic)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_usd_groups_thousands() {
+        assert_eq!(format_usd(1234567.891), "$1,234,567.89");
+        assert_eq!(format_usd(1234.5), "$1,234.50");
+        assert_eq!(format_usd(0.0021), "$0.0021");
+        assert_eq!(format_usd(-12.5), "-$12.50");
+    }
+
+    #[test]
+    fn format_usd_handles_non_finite() {
+        assert_eq!(format_usd(f64::NAN), "");
+        assert_eq!(format_usd(f64::INFINITY), "");
+    }
+}


### PR DESCRIPTION
Adds a DefiLlama price client with persistent SQLite caching and surfaces prices in two places:

- Balance view: USD value alongside each token balance, in a dimmed style. Zero balances are now hidden.
- Tx event view: u256 amounts of tracked tokens get a `[today (historic)]` USD annotation, where historic is the price at the tx's block date.

Today prices refresh at most once per hour; historic prices are keyed on UTC date and cached forever. All UI reads are sync cache lookups; misses trigger background fetches that emit `PricesUpdated` to drive a redraw. The block timestamp needed for historic lookups is fetched only when the tx contains tracked-token events.

https://claude.ai/code/session_01UKmx4eymnayEJX11CDJvRD