### PR TITLE
Unified events stream: cache-first address view, merged call sources, deferred decode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,15 +43,7 @@ jobs:
           profile: minimal
 
       - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+        uses: Swatinem/rust-cache@v2
 
       - name: Build
         run: cargo build --verbose

--- a/crates/pf-query/src/main.rs
+++ b/crates/pf-query/src/main.rs
@@ -193,6 +193,26 @@ struct ContractEventsResponse {
     continuation_token: Option<u64>,
 }
 
+/// Response for /contract-event-count — total-events probe used by clients
+/// to populate UI labels like "(N / total)". Uses the same bloom-walk as
+/// /contract-events but skips tx-hash/timestamp decoding.
+#[derive(Serialize)]
+struct ContractEventCountResponse {
+    /// Total matching events across the scanned range.
+    count: u64,
+    /// Oldest block with at least one matching event (None when count == 0).
+    min_block: Option<u64>,
+    /// Newest block with at least one matching event (None when count == 0).
+    max_block: Option<u64>,
+    /// True when the full requested range was scanned; false if we stopped
+    /// after the per-request candidate cap to bound latency.
+    complete: bool,
+    /// Inclusive lower bound actually scanned.
+    scanned_from: u64,
+    /// Inclusive upper bound actually scanned.
+    scanned_to: u64,
+}
+
 // =========================================================================
 // Query params
 // =========================================================================
@@ -244,6 +264,16 @@ struct ContractEventsParams {
     /// Pagination: inclusive upper bound for the next page (newest-first).
     /// Takes precedence over `to_block`.
     continuation_token: Option<u64>,
+}
+
+#[derive(Deserialize)]
+struct ContractEventCountParams {
+    /// Inclusive lower block bound. Default 0 (scan whole chain).
+    from_block: Option<u64>,
+    /// Inclusive upper block bound. Default = latest block.
+    to_block: Option<u64>,
+    /// Key filter — same syntax as /contract-events.
+    keys: Option<String>,
 }
 
 // =========================================================================
@@ -991,6 +1021,37 @@ fn process_candidate_block(
     }
 }
 
+/// Count matching events in a single block without materializing
+/// `ContractEvent` records. Used by the /contract-event-count probe, which
+/// walks the whole range and can't afford per-block tx-hash/timestamp
+/// decoding.
+fn count_candidate_block(
+    block_number: u64,
+    addr_bytes: &[u8],
+    keys_filter: &[Vec<[u8; 32]>],
+    events_stmt: &mut rusqlite::Statement<'_>,
+) -> u64 {
+    let events_blob: Option<Vec<u8>> = events_stmt
+        .query_row(rusqlite::params![block_number], |row| row.get(0))
+        .ok();
+    let Some(events_blob) = events_blob else {
+        return 0;
+    };
+    let tx_events = match decode::decode_events(&events_blob) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+    let mut n: u64 = 0;
+    for evs in tx_events.iter() {
+        for e in evs.iter() {
+            if e.from_address.0 == addr_bytes && event_keys_match(&e.keys, keys_filter) {
+                n += 1;
+            }
+        }
+    }
+    n
+}
+
 /// GET /contract-events/{address} — events emitted by a contract, accelerated by bloom filters.
 ///
 /// Pagination: newest-first. When more events may exist below the oldest returned
@@ -1195,6 +1256,169 @@ async fn handler_contract_events(
     }))
 }
 
+/// GET /contract-event-count/{address} — total count of events emitted by a
+/// contract over the requested range. Skips per-block tx-hash / timestamp
+/// decoding so it can afford to scan the whole chain in a single request.
+///
+/// Used by snbeat as an activity probe to populate labels like "(N / total)"
+/// without depending on Dune.
+async fn handler_contract_event_count(
+    Path(address): Path<String>,
+    Query(params): Query<ContractEventCountParams>,
+    State(state): State<AppState>,
+) -> ApiResult<ContractEventCountResponse> {
+    // Higher cap than /contract-events because the per-block cost is lower
+    // (no tx-hash / timestamp fetch) and the caller wants a full-range count.
+    // On dense contracts we still bail out rather than spin forever; the
+    // response's `complete=false` tells the caller the number is a lower bound.
+    const MAX_CANDIDATES: usize = 200_000;
+
+    let addr_bytes = parse_address(&address)
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid address: {e}")))?;
+
+    let addr_array: [u8; 32] = addr_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| (StatusCode::BAD_REQUEST, "Address must be 32 bytes".into()))?;
+
+    let keys_filter: Vec<Vec<[u8; 32]>> = match params.keys.as_deref() {
+        Some(raw) => parse_keys_filter(raw).map_err(|e| (StatusCode::BAD_REQUEST, e))?,
+        None => Vec::new(),
+    };
+
+    let conn = open_db(&state.db_path).map_err(db_err)?;
+
+    let latest_block: u64 = conn
+        .query_row(
+            "SELECT number FROM block_headers ORDER BY number DESC LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(db_err)?;
+
+    let from_block = params.from_block.unwrap_or(0);
+    let effective_to = params.to_block.unwrap_or(latest_block).min(latest_block);
+
+    if from_block > effective_to {
+        return Ok(Json(ContractEventCountResponse {
+            count: 0,
+            min_block: None,
+            max_block: None,
+            complete: true,
+            scanned_from: from_block,
+            scanned_to: effective_to,
+        }));
+    }
+
+    let max_bloom_covered: Option<u64> = conn
+        .query_row(
+            "SELECT MAX(to_block) FROM event_filters WHERE from_block <= ?1",
+            rusqlite::params![effective_to],
+            |row| row.get::<_, Option<u64>>(0),
+        )
+        .unwrap_or(None);
+
+    let brute_scan_start = max_bloom_covered
+        .map(|m| m.saturating_add(1).max(from_block))
+        .unwrap_or(from_block);
+
+    let mut events_stmt = conn
+        .prepare("SELECT events FROM transactions WHERE block_number = ?1")
+        .map_err(db_err)?;
+
+    let mut total: u64 = 0;
+    let mut min_block: Option<u64> = None;
+    let mut max_block: Option<u64> = None;
+    let mut candidates_processed: usize = 0;
+    let mut complete = true;
+
+    // Helper that updates the running totals for one candidate block.
+    let mut record = |b: u64, n: u64, min_block: &mut Option<u64>, max_block: &mut Option<u64>| {
+        if n == 0 {
+            return;
+        }
+        *min_block = Some(min_block.map_or(b, |m| m.min(b)));
+        *max_block = Some(max_block.map_or(b, |m| m.max(b)));
+    };
+
+    // Step 2a: Brute-scan blocks above the persisted bloom filter.
+    if brute_scan_start <= effective_to {
+        let mut b = effective_to;
+        loop {
+            if b < brute_scan_start {
+                break;
+            }
+            candidates_processed += 1;
+            let n = count_candidate_block(b, &addr_bytes, &keys_filter, &mut events_stmt);
+            total = total.saturating_add(n);
+            record(b, n, &mut min_block, &mut max_block);
+
+            if candidates_processed >= MAX_CANDIDATES {
+                complete = false;
+                break;
+            }
+            if b == 0 {
+                break;
+            }
+            b -= 1;
+        }
+    }
+
+    // Step 2b: Walk bloom chunks for blocks already covered by event_filters.
+    if complete {
+        let mut bloom_stmt = conn
+            .prepare(
+                "SELECT from_block, to_block, bitmap \
+                 FROM event_filters \
+                 WHERE to_block >= ?1 AND from_block <= ?2 \
+                 ORDER BY from_block DESC",
+            )
+            .map_err(db_err)?;
+
+        let mut bloom_rows = bloom_stmt
+            .query(rusqlite::params![from_block, effective_to])
+            .map_err(db_err)?;
+
+        'chunks: while let Some(row) = bloom_rows.next().map_err(db_err)? {
+            let bf_from: u64 = row.get(0).map_err(db_err)?;
+            let bf_to: u64 = row.get(1).map_err(db_err)?;
+            let compressed: Vec<u8> = row.get(2).map_err(db_err)?;
+
+            let agg = bloom::AggregateBloom::from_compressed(bf_from, bf_to, &compressed);
+            let mut blocks = agg.blocks_for_address(&addr_array);
+            blocks.retain(|&b| b >= from_block && b <= effective_to);
+            blocks.sort_unstable_by(|a, b| b.cmp(a));
+            blocks.dedup();
+
+            for block_number in blocks {
+                candidates_processed += 1;
+                let n = count_candidate_block(
+                    block_number,
+                    &addr_bytes,
+                    &keys_filter,
+                    &mut events_stmt,
+                );
+                total = total.saturating_add(n);
+                record(block_number, n, &mut min_block, &mut max_block);
+
+                if candidates_processed >= MAX_CANDIDATES {
+                    complete = false;
+                    break 'chunks;
+                }
+            }
+        }
+    }
+
+    Ok(Json(ContractEventCountResponse {
+        count: total,
+        min_block,
+        max_block,
+        complete,
+        scanned_from: from_block,
+        scanned_to: effective_to,
+    }))
+}
+
 // =========================================================================
 // Main
 // =========================================================================
@@ -1255,6 +1479,10 @@ async fn main() -> Result<()> {
         .route("/block-timestamps", get(handler_block_timestamps))
         .route("/sender-txs/{address}", get(handler_sender_txs))
         .route("/contract-events/{address}", get(handler_contract_events))
+        .route(
+            "/contract-event-count/{address}",
+            get(handler_contract_event_count),
+        )
         .with_state(state)
         .layer(TraceLayer::new_for_http());
 

--- a/crates/pf-query/src/main.rs
+++ b/crates/pf-query/src/main.rs
@@ -1085,141 +1085,85 @@ async fn handler_contract_events(
         None => Vec::new(),
     };
 
-    let conn = open_db(&state.db_path).map_err(db_err)?;
+    let db_path = Arc::clone(&state.db_path);
+    let from_block_param = params.from_block;
+    let to_block_param = params.to_block;
+    let continuation_token_param = params.continuation_token;
 
-    // Resolve block range.
-    let latest_block: u64 = conn
-        .query_row(
-            "SELECT number FROM block_headers ORDER BY number DESC LIMIT 1",
-            [],
-            |row| row.get(0),
-        )
-        .map_err(db_err)?;
+    // Entire body runs on a blocking thread so the rusqlite `Connection`
+    // (which is !Send) never crosses an async await point, and the bloom
+    // decompress + event decode hot path doesn't starve tokio workers.
+    let response = tokio::task::spawn_blocking(move || {
+        let conn = open_db(&db_path).map_err(db_err)?;
 
-    let from_block = params.from_block.unwrap_or(0);
-    // continuation_token takes precedence over to_block.
-    let requested_to = params
-        .continuation_token
-        .or(params.to_block)
-        .unwrap_or(latest_block);
-    let effective_to = requested_to.min(latest_block);
-
-    if from_block > effective_to {
-        return Ok(Json(ContractEventsResponse {
-            events: Vec::new(),
-            continuation_token: None,
-        }));
-    }
-
-    // Step 1: Discover max bloom coverage so we know where to brute-scan.
-    // Blocks above `max_bloom_covered` are in `running_event_filter` (not yet
-    // persisted into an `event_filters` row) and must be scanned directly.
-    let max_bloom_covered: Option<u64> = conn
-        .query_row(
-            "SELECT MAX(to_block) FROM event_filters WHERE from_block <= ?1",
-            rusqlite::params![effective_to],
-            |row| row.get::<_, Option<u64>>(0),
-        )
-        .unwrap_or(None);
-
-    let brute_scan_start = max_bloom_covered
-        .map(|m| m.saturating_add(1).max(from_block))
-        .unwrap_or(from_block);
-
-    // Statements used during per-block processing.
-    let mut events_stmt = conn
-        .prepare("SELECT events FROM transactions WHERE block_number = ?1")
-        .map_err(db_err)?;
-    let mut txs_stmt = conn
-        .prepare("SELECT transactions FROM transactions WHERE block_number = ?1")
-        .map_err(db_err)?;
-    let mut ts_stmt = conn
-        .prepare("SELECT timestamp FROM block_headers WHERE number = ?1")
-        .map_err(db_err)?;
-
-    // Inline closure-like helper: given a block number, decode events and push
-    // any matching ones into `results`. Returns true if the block contained at
-    // least one match (for telemetry; not used directly).
-    //
-    // We expand it as a macro-style block below since it borrows `results`,
-    // the addr bytes, the filter, and multiple prepared statements — inlining
-    // avoids lifetime gymnastics.
-    let mut results: Vec<ContractEvent> = Vec::new();
-    let mut last_processed: Option<u64> = None;
-    let mut candidates_processed: usize = 0;
-    let mut hit_limit = false;
-    let mut hit_candidate_cap = false;
-
-    // Step 2a: Brute-scan blocks above the persisted bloom filter, newest-first.
-    if brute_scan_start <= effective_to {
-        let mut b = effective_to;
-        loop {
-            if b < brute_scan_start {
-                break;
-            }
-            last_processed = Some(b);
-            candidates_processed += 1;
-
-            process_candidate_block(
-                b,
-                &addr_bytes,
-                &keys_filter,
-                &mut events_stmt,
-                &mut txs_stmt,
-                &mut ts_stmt,
-                &mut results,
-            );
-
-            if results.len() >= limit {
-                hit_limit = true;
-                break;
-            }
-            if candidates_processed >= MAX_CANDIDATES {
-                hit_candidate_cap = true;
-                break;
-            }
-            if b == 0 {
-                break;
-            }
-            b -= 1;
-        }
-    }
-
-    // Step 2b: Walk bloom chunks newest-first, decompressing one at a time.
-    // As soon as `limit` is reached we stop — the continuation token resumes
-    // the scan from (last_processed - 1) on the next call.
-    if !hit_limit && !hit_candidate_cap {
-        let mut bloom_stmt = conn
-            .prepare(
-                "SELECT from_block, to_block, bitmap \
-                 FROM event_filters \
-                 WHERE to_block >= ?1 AND from_block <= ?2 \
-                 ORDER BY from_block DESC",
+        // Resolve block range.
+        let latest_block: u64 = conn
+            .query_row(
+                "SELECT number FROM block_headers ORDER BY number DESC LIMIT 1",
+                [],
+                |row| row.get(0),
             )
             .map_err(db_err)?;
 
-        let mut bloom_rows = bloom_stmt
-            .query(rusqlite::params![from_block, effective_to])
+        let from_block = from_block_param.unwrap_or(0);
+        // continuation_token takes precedence over to_block.
+        let requested_to = continuation_token_param
+            .or(to_block_param)
+            .unwrap_or(latest_block);
+        let effective_to = requested_to.min(latest_block);
+
+        if from_block > effective_to {
+            return Ok::<ContractEventsResponse, (StatusCode, String)>(ContractEventsResponse {
+                events: Vec::new(),
+                continuation_token: None,
+            });
+        }
+
+        // Step 1: Discover max bloom coverage so we know where to brute-scan.
+        // Blocks above `max_bloom_covered` are in `running_event_filter` (not
+        // yet persisted into an `event_filters` row) and must be scanned
+        // directly.
+        let max_bloom_covered: Option<u64> = conn
+            .query_row(
+                "SELECT MAX(to_block) FROM event_filters WHERE from_block <= ?1",
+                rusqlite::params![effective_to],
+                |row| row.get::<_, Option<u64>>(0),
+            )
+            .unwrap_or(None);
+
+        let brute_scan_start = max_bloom_covered
+            .map(|m| m.saturating_add(1).max(from_block))
+            .unwrap_or(from_block);
+
+        // Statements used during per-block processing.
+        let mut events_stmt = conn
+            .prepare("SELECT events FROM transactions WHERE block_number = ?1")
+            .map_err(db_err)?;
+        let mut txs_stmt = conn
+            .prepare("SELECT transactions FROM transactions WHERE block_number = ?1")
+            .map_err(db_err)?;
+        let mut ts_stmt = conn
+            .prepare("SELECT timestamp FROM block_headers WHERE number = ?1")
             .map_err(db_err)?;
 
-        'chunks: while let Some(row) = bloom_rows.next().map_err(db_err)? {
-            let bf_from: u64 = row.get(0).map_err(db_err)?;
-            let bf_to: u64 = row.get(1).map_err(db_err)?;
-            let compressed: Vec<u8> = row.get(2).map_err(db_err)?;
+        let mut results: Vec<ContractEvent> = Vec::new();
+        let mut last_processed: Option<u64> = None;
+        let mut candidates_processed: usize = 0;
+        let mut hit_limit = false;
+        let mut hit_candidate_cap = false;
 
-            let agg = bloom::AggregateBloom::from_compressed(bf_from, bf_to, &compressed);
-            let mut blocks = agg.blocks_for_address(&addr_array);
-            blocks.retain(|&b| b >= from_block && b <= effective_to);
-            // Process within-chunk candidates newest-first.
-            blocks.sort_unstable_by(|a, b| b.cmp(a));
-            blocks.dedup();
-
-            for block_number in blocks {
-                last_processed = Some(block_number);
+        // Step 2a: Brute-scan blocks above the persisted bloom filter, newest-first.
+        if brute_scan_start <= effective_to {
+            let mut b = effective_to;
+            loop {
+                if b < brute_scan_start {
+                    break;
+                }
+                last_processed = Some(b);
                 candidates_processed += 1;
 
                 process_candidate_block(
-                    block_number,
+                    b,
                     &addr_bytes,
                     &keys_filter,
                     &mut events_stmt,
@@ -1230,30 +1174,93 @@ async fn handler_contract_events(
 
                 if results.len() >= limit {
                     hit_limit = true;
-                    break 'chunks;
+                    break;
                 }
                 if candidates_processed >= MAX_CANDIDATES {
                     hit_candidate_cap = true;
-                    break 'chunks;
+                    break;
+                }
+                if b == 0 {
+                    break;
+                }
+                b -= 1;
+            }
+        }
+
+        // Step 2b: Walk bloom chunks newest-first, decompressing one at a time.
+        // As soon as `limit` is reached we stop — the continuation token
+        // resumes the scan from (last_processed - 1) on the next call.
+        if !hit_limit && !hit_candidate_cap {
+            let mut bloom_stmt = conn
+                .prepare(
+                    "SELECT from_block, to_block, bitmap \
+                     FROM event_filters \
+                     WHERE to_block >= ?1 AND from_block <= ?2 \
+                     ORDER BY from_block DESC",
+                )
+                .map_err(db_err)?;
+
+            let mut bloom_rows = bloom_stmt
+                .query(rusqlite::params![from_block, effective_to])
+                .map_err(db_err)?;
+
+            'chunks: while let Some(row) = bloom_rows.next().map_err(db_err)? {
+                let bf_from: u64 = row.get(0).map_err(db_err)?;
+                let bf_to: u64 = row.get(1).map_err(db_err)?;
+                let compressed: Vec<u8> = row.get(2).map_err(db_err)?;
+
+                let agg = bloom::AggregateBloom::from_compressed(bf_from, bf_to, &compressed);
+                let mut blocks = agg.blocks_for_address(&addr_array);
+                blocks.retain(|&b| b >= from_block && b <= effective_to);
+                // Process within-chunk candidates newest-first.
+                blocks.sort_unstable_by(|a, b| b.cmp(a));
+                blocks.dedup();
+
+                for block_number in blocks {
+                    last_processed = Some(block_number);
+                    candidates_processed += 1;
+
+                    process_candidate_block(
+                        block_number,
+                        &addr_bytes,
+                        &keys_filter,
+                        &mut events_stmt,
+                        &mut txs_stmt,
+                        &mut ts_stmt,
+                        &mut results,
+                    );
+
+                    if results.len() >= limit {
+                        hit_limit = true;
+                        break 'chunks;
+                    }
+                    if candidates_processed >= MAX_CANDIDATES {
+                        hit_candidate_cap = true;
+                        break 'chunks;
+                    }
                 }
             }
         }
-    }
 
-    // Compute continuation token.
-    let continuation_token = if hit_limit || hit_candidate_cap {
-        // More to scan: next page should start at (last_processed - 1).
-        last_processed
-            .and_then(|b| b.checked_sub(1))
-            .filter(|&b| b >= from_block)
-    } else {
-        None
-    };
+        // Compute continuation token.
+        let continuation_token = if hit_limit || hit_candidate_cap {
+            // More to scan: next page should start at (last_processed - 1).
+            last_processed
+                .and_then(|b| b.checked_sub(1))
+                .filter(|&b| b >= from_block)
+        } else {
+            None
+        };
 
-    Ok(Json(ContractEventsResponse {
-        events: results,
-        continuation_token,
-    }))
+        Ok(ContractEventsResponse {
+            events: results,
+            continuation_token,
+        })
+    })
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))??;
+
+    Ok(Json(response))
 }
 
 /// GET /contract-event-count/{address} — total count of events emitted by a
@@ -1286,137 +1293,151 @@ async fn handler_contract_event_count(
         None => Vec::new(),
     };
 
-    let conn = open_db(&state.db_path).map_err(db_err)?;
+    let db_path = Arc::clone(&state.db_path);
+    let from_block_param = params.from_block;
+    let to_block_param = params.to_block;
 
-    let latest_block: u64 = conn
-        .query_row(
-            "SELECT number FROM block_headers ORDER BY number DESC LIMIT 1",
-            [],
-            |row| row.get(0),
-        )
-        .map_err(db_err)?;
+    // Entire body runs on a blocking thread so the rusqlite `Connection`
+    // (which is !Send) never crosses an async await point, and the
+    // bloom-decompress + event-decode hot path doesn't starve tokio workers.
+    let response = tokio::task::spawn_blocking(move || {
+        let conn = open_db(&db_path).map_err(db_err)?;
 
-    let from_block = params.from_block.unwrap_or(0);
-    let effective_to = params.to_block.unwrap_or(latest_block).min(latest_block);
-
-    if from_block > effective_to {
-        return Ok(Json(ContractEventCountResponse {
-            count: 0,
-            min_block: None,
-            max_block: None,
-            complete: true,
-            scanned_from: from_block,
-            scanned_to: effective_to,
-        }));
-    }
-
-    let max_bloom_covered: Option<u64> = conn
-        .query_row(
-            "SELECT MAX(to_block) FROM event_filters WHERE from_block <= ?1",
-            rusqlite::params![effective_to],
-            |row| row.get::<_, Option<u64>>(0),
-        )
-        .unwrap_or(None);
-
-    let brute_scan_start = max_bloom_covered
-        .map(|m| m.saturating_add(1).max(from_block))
-        .unwrap_or(from_block);
-
-    let mut events_stmt = conn
-        .prepare("SELECT events FROM transactions WHERE block_number = ?1")
-        .map_err(db_err)?;
-
-    let mut total: u64 = 0;
-    let mut min_block: Option<u64> = None;
-    let mut max_block: Option<u64> = None;
-    let mut candidates_processed: usize = 0;
-    let mut complete = true;
-
-    // Helper that updates the running totals for one candidate block.
-    let mut record = |b: u64, n: u64, min_block: &mut Option<u64>, max_block: &mut Option<u64>| {
-        if n == 0 {
-            return;
-        }
-        *min_block = Some(min_block.map_or(b, |m| m.min(b)));
-        *max_block = Some(max_block.map_or(b, |m| m.max(b)));
-    };
-
-    // Step 2a: Brute-scan blocks above the persisted bloom filter.
-    if brute_scan_start <= effective_to {
-        let mut b = effective_to;
-        loop {
-            if b < brute_scan_start {
-                break;
-            }
-            candidates_processed += 1;
-            let n = count_candidate_block(b, &addr_bytes, &keys_filter, &mut events_stmt);
-            total = total.saturating_add(n);
-            record(b, n, &mut min_block, &mut max_block);
-
-            if candidates_processed >= MAX_CANDIDATES {
-                complete = false;
-                break;
-            }
-            if b == 0 {
-                break;
-            }
-            b -= 1;
-        }
-    }
-
-    // Step 2b: Walk bloom chunks for blocks already covered by event_filters.
-    if complete {
-        let mut bloom_stmt = conn
-            .prepare(
-                "SELECT from_block, to_block, bitmap \
-                 FROM event_filters \
-                 WHERE to_block >= ?1 AND from_block <= ?2 \
-                 ORDER BY from_block DESC",
+        let latest_block: u64 = conn
+            .query_row(
+                "SELECT number FROM block_headers ORDER BY number DESC LIMIT 1",
+                [],
+                |row| row.get(0),
             )
             .map_err(db_err)?;
 
-        let mut bloom_rows = bloom_stmt
-            .query(rusqlite::params![from_block, effective_to])
+        let from_block = from_block_param.unwrap_or(0);
+        let effective_to = to_block_param.unwrap_or(latest_block).min(latest_block);
+
+        if from_block > effective_to {
+            return Ok::<ContractEventCountResponse, (StatusCode, String)>(ContractEventCountResponse {
+                count: 0,
+                min_block: None,
+                max_block: None,
+                complete: true,
+                scanned_from: from_block,
+                scanned_to: effective_to,
+            });
+        }
+
+        let max_bloom_covered: Option<u64> = conn
+            .query_row(
+                "SELECT MAX(to_block) FROM event_filters WHERE from_block <= ?1",
+                rusqlite::params![effective_to],
+                |row| row.get::<_, Option<u64>>(0),
+            )
+            .unwrap_or(None);
+
+        let brute_scan_start = max_bloom_covered
+            .map(|m| m.saturating_add(1).max(from_block))
+            .unwrap_or(from_block);
+
+        let mut events_stmt = conn
+            .prepare("SELECT events FROM transactions WHERE block_number = ?1")
             .map_err(db_err)?;
 
-        'chunks: while let Some(row) = bloom_rows.next().map_err(db_err)? {
-            let bf_from: u64 = row.get(0).map_err(db_err)?;
-            let bf_to: u64 = row.get(1).map_err(db_err)?;
-            let compressed: Vec<u8> = row.get(2).map_err(db_err)?;
+        let mut total: u64 = 0;
+        let mut min_block: Option<u64> = None;
+        let mut max_block: Option<u64> = None;
+        let mut candidates_processed: usize = 0;
+        let mut complete = true;
 
-            let agg = bloom::AggregateBloom::from_compressed(bf_from, bf_to, &compressed);
-            let mut blocks = agg.blocks_for_address(&addr_array);
-            blocks.retain(|&b| b >= from_block && b <= effective_to);
-            blocks.sort_unstable_by(|a, b| b.cmp(a));
-            blocks.dedup();
+        // Helper that updates the running totals for one candidate block.
+        let mut record =
+            |b: u64, n: u64, min_block: &mut Option<u64>, max_block: &mut Option<u64>| {
+                if n == 0 {
+                    return;
+                }
+                *min_block = Some(min_block.map_or(b, |m| m.min(b)));
+                *max_block = Some(max_block.map_or(b, |m| m.max(b)));
+            };
 
-            for block_number in blocks {
+        // Step 2a: Brute-scan blocks above the persisted bloom filter.
+        if brute_scan_start <= effective_to {
+            let mut b = effective_to;
+            loop {
+                if b < brute_scan_start {
+                    break;
+                }
                 candidates_processed += 1;
-                let n = count_candidate_block(
-                    block_number,
-                    &addr_bytes,
-                    &keys_filter,
-                    &mut events_stmt,
-                );
+                let n = count_candidate_block(b, &addr_bytes, &keys_filter, &mut events_stmt);
                 total = total.saturating_add(n);
-                record(block_number, n, &mut min_block, &mut max_block);
+                record(b, n, &mut min_block, &mut max_block);
 
                 if candidates_processed >= MAX_CANDIDATES {
                     complete = false;
-                    break 'chunks;
+                    break;
+                }
+                if b == 0 {
+                    break;
+                }
+                b -= 1;
+            }
+        }
+
+        // Step 2b: Walk bloom chunks for blocks already covered by event_filters.
+        if complete {
+            let mut bloom_stmt = conn
+                .prepare(
+                    "SELECT from_block, to_block, bitmap \
+                     FROM event_filters \
+                     WHERE to_block >= ?1 AND from_block <= ?2 \
+                     ORDER BY from_block DESC",
+                )
+                .map_err(db_err)?;
+
+            let mut bloom_rows = bloom_stmt
+                .query(rusqlite::params![from_block, effective_to])
+                .map_err(db_err)?;
+
+            'chunks: while let Some(row) = bloom_rows.next().map_err(db_err)? {
+                let bf_from: u64 = row.get(0).map_err(db_err)?;
+                let bf_to: u64 = row.get(1).map_err(db_err)?;
+                let compressed: Vec<u8> = row.get(2).map_err(db_err)?;
+
+                let agg = bloom::AggregateBloom::from_compressed(bf_from, bf_to, &compressed);
+                let mut blocks = agg.blocks_for_address(&addr_array);
+                blocks.retain(|&b| b >= from_block && b <= effective_to);
+                blocks.sort_unstable_by(|a, b| b.cmp(a));
+                blocks.dedup();
+
+                for block_number in blocks {
+                    candidates_processed += 1;
+                    let n = count_candidate_block(
+                        block_number,
+                        &addr_bytes,
+                        &keys_filter,
+                        &mut events_stmt,
+                    );
+                    total = total.saturating_add(n);
+                    record(block_number, n, &mut min_block, &mut max_block);
+
+                    if candidates_processed >= MAX_CANDIDATES {
+                        complete = false;
+                        break 'chunks;
+                    }
                 }
             }
         }
-    }
 
-    Ok(Json(ContractEventCountResponse {
-        count: total,
-        min_block,
-        max_block,
-        complete,
-        scanned_from: from_block,
-        scanned_to: effective_to,
-    }))
+        Ok(ContractEventCountResponse {
+            count: total,
+            min_block,
+            max_block,
+            complete,
+            scanned_from: from_block,
+            scanned_to: effective_to,
+        })
+    })
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))??;
+
+    Ok(Json(response))
 }
 
 // =========================================================================

--- a/crates/pf-query/src/main.rs
+++ b/crates/pf-query/src/main.rs
@@ -1258,7 +1258,12 @@ async fn handler_contract_events(
         })
     })
     .await
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))??;
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("join error: {e}"),
+        )
+    })??;
 
     Ok(Json(response))
 }
@@ -1315,14 +1320,16 @@ async fn handler_contract_event_count(
         let effective_to = to_block_param.unwrap_or(latest_block).min(latest_block);
 
         if from_block > effective_to {
-            return Ok::<ContractEventCountResponse, (StatusCode, String)>(ContractEventCountResponse {
-                count: 0,
-                min_block: None,
-                max_block: None,
-                complete: true,
-                scanned_from: from_block,
-                scanned_to: effective_to,
-            });
+            return Ok::<ContractEventCountResponse, (StatusCode, String)>(
+                ContractEventCountResponse {
+                    count: 0,
+                    min_block: None,
+                    max_block: None,
+                    complete: true,
+                    scanned_from: from_block,
+                    scanned_to: effective_to,
+                },
+            );
         }
 
         let max_bloom_covered: Option<u64> = conn
@@ -1435,7 +1442,12 @@ async fn handler_contract_event_count(
         })
     })
     .await
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))??;
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("join error: {e}"),
+        )
+    })??;
 
     Ok(Json(response))
 }

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -295,6 +295,14 @@ pub enum Action {
     LatestBlockNumber(u64),
     /// Update the loading status message shown in the status bar.
     LoadingStatus(String),
+    /// Per-query status registry update: `Some(label)` starts/updates an entry
+    /// for `key`, `None` removes it. Keys are opaque strings owned by the
+    /// dispatcher (e.g. `"meta:41420f"` for the MetaTxs scan on an address).
+    /// Rendered alongside `loading_detail` in the status bar.
+    SetActiveQuery {
+        key: String,
+        label: Option<String>,
+    },
     /// Navigate to class info view immediately (before data loads).
     NavigateToClassInfo {
         class_hash: Felt,

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -245,6 +245,14 @@ pub enum Action {
         address: Felt,
         decoded_event: DecodedEvent,
     },
+    /// Cached events decoded off the critical path. Emitted by a spawned task
+    /// after `AddressInfoLoaded` so the initial UI paint doesn't block on
+    /// per-event ABI fetches. Replaces the events list iff non-empty and the
+    /// address context still matches.
+    AddressEventsCacheLoaded {
+        address: Felt,
+        decoded_events: Vec<DecodedEvent>,
+    },
     /// Dune activity probe result delivered to UI for pagination window sizing.
     AddressProbeLoaded {
         address: Felt,

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -187,6 +187,17 @@ pub enum Action {
         address: Felt,
         calls: Vec<ContractCallSummary>,
     },
+    /// Supplementary Calls rows derived from a pf-query tx_rows scan (plan §2).
+    ///
+    /// The meta-tx keyed-event scan walks the same tx_rows the Calls tab needs
+    /// — every row is a tx that called this address via `execute_from_outside`.
+    /// Dune is still the completeness authority (LIMIT 500 after dedup), but
+    /// merging these rows closes the invariant gap where MetaTxs (keyed,
+    /// unbounded) could exceed Calls (Dune-only, capped).
+    AddressCallsMerged {
+        address: Felt,
+        calls: Vec<ContractCallSummary>,
+    },
     /// Older blocks loaded (appended to block list).
     OlderBlocksLoaded(Vec<SnBlock>),
     /// More address transactions loaded (appended to address tx list).

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -86,13 +86,16 @@ pub enum Action {
     /// the intender (issue #11). Paginates via pf-query's event continuation
     /// token — opaque u64 from the previous response, or `None` for first page.
     ///
-    /// `from_block` bounds the initial bloom scan range; without it, pf-query
-    /// walks from genesis and times out on accounts with long history. The
-    /// dispatcher sets this to the deploy block when known.
+    /// `from_block` is the absolute scan floor (typically deploy block); the
+    /// backend stops paginating once `min_searched <= from_block` so we don't
+    /// time out walking chunks older than the account. `window_size` is the
+    /// per-page ExtendDown block range, adapted across calls (double on empty,
+    /// halve on full) — see `event_window::suggest_next_window`.
     FetchAddressMetaTxs {
         address: Felt,
         from_block: u64,
         continuation_token: Option<u64>,
+        window_size: u64,
         limit: u32,
     },
     /// Classify a single tx as a potential meta-tx where `address` is the
@@ -192,6 +195,12 @@ pub enum Action {
         /// Opaque continuation token from pf-query, if more pages remain.
         /// Pass back via `FetchAddressMetaTxs::continuation_token` to resume.
         next_token: Option<u64>,
+        /// Adaptive next ExtendDown window size (blocks) suggested by the
+        /// backend based on this page's hit density. `None` when no further
+        /// paging is expected (we hit the floor) or on non-ExtendDown calls.
+        /// The UI persists this as `meta_tx_last_window` and feeds it into
+        /// the next `FetchAddressMetaTxs` dispatch.
+        next_window_size: Option<u64>,
     },
     /// Cached meta-tx rows delivered synchronously at tab-entry time. Merges
     /// into the visible list but does NOT touch the loading flag / cursor — a

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -107,6 +107,17 @@ pub enum Action {
         address: Felt,
         tx_hash: Felt,
     },
+    /// Decode a WS-received event using the ABI of its `from_address`, then
+    /// emit [`Action::AddressEventStreamed`] so the Events tab merges the
+    /// decoded row in real time. Dispatched from the `AddressWsEvent`
+    /// reducer — the reducer can't call the async ABI registry itself, so it
+    /// delegates here. A best-effort decode returns the raw event wrapped in
+    /// a [`DecodedEvent`] when no ABI is available, so the tab still reflects
+    /// live activity.
+    DecodeAddressWsEvent {
+        address: Felt,
+        event: SnEvent,
+    },
     /// Fetch class hash info (ABI, declaration, deployed contracts).
     FetchClassInfo {
         class_hash: Felt,
@@ -216,6 +227,13 @@ pub enum Action {
         address: Felt,
         summaries: Vec<MetaTxIntenderSummary>,
     },
+    /// Streaming single decoded event from the WS path (response to
+    /// [`Action::DecodeAddressWsEvent`]). Merges into the Events tab list
+    /// newest-first, deduping by `(tx_hash, event_index)`.
+    AddressEventStreamed {
+        address: Felt,
+        decoded_event: DecodedEvent,
+    },
     /// Dune activity probe result delivered to UI for pagination window sizing.
     AddressProbeLoaded {
         address: Felt,
@@ -245,11 +263,15 @@ pub enum Action {
         complete: bool,
     },
     /// Single broadcast of a WS-received event. Emitted once per event; the
-    /// reducer fans it out to the Calls tab (builds a `ContractCallSummary`
-    /// stub + dispatches `EnrichAddressCalls`) and, for `TRANSACTION_EXECUTED`
-    /// events, dispatches `ClassifyPotentialMetaTx` so live meta-tx detection
-    /// still reaches the MetaTxs tab. The event itself has already been
-    /// persisted into the address event cache in the WS handler.
+    /// reducer fans it out to:
+    ///   - the Events tab via [`Action::DecodeAddressWsEvent`] (async decode);
+    ///   - the Calls tab (builds a `ContractCallSummary` stub + dispatches
+    ///     `EnrichAddressCalls`);
+    ///   - the MetaTxs tab for `TRANSACTION_EXECUTED` events via
+    ///     `ClassifyPotentialMetaTx`.
+    ///
+    /// The event itself has already been persisted into the address event
+    /// cache in the WS handler.
     AddressWsEvent {
         address: Felt,
         event: SnEvent,

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -5,7 +5,7 @@ use crate::app::views::address_info::UnfilledGap;
 use crate::data::pathfinder::ClassHashEntry;
 use crate::data::types::{
     AddressTxSummary, ClassContractEntry, ClassDeclareInfo, ContractCallSummary,
-    MetaTxIntenderSummary, SnAddressInfo, SnBlock, SnReceipt, SnTransaction, TokenBalance,
+    MetaTxIntenderSummary, SnAddressInfo, SnBlock, SnEvent, SnReceipt, SnTransaction, TokenBalance,
     VoyagerLabelInfo,
 };
 use crate::decode::events::DecodedEvent;
@@ -217,6 +217,16 @@ pub enum Action {
         address: Felt,
         sources: Vec<Source>,
     },
+    /// Passive update of the shared event-window hint (min/max scanned block,
+    /// deferred gap) driven by `ensure_address_events_window`. Consumed by
+    /// the Calls / Events / MetaTxs tab titles to surface gap state. Fires
+    /// from every event-window fetch path so all three tabs stay aligned.
+    AddressEventWindowUpdated {
+        address: Felt,
+        min_searched: u64,
+        max_searched: u64,
+        deferred_gap: Option<(u64, u64)>,
+    },
     /// Streaming partial tx results from a specific data source (merges, never replaces).
     AddressTxsStreamed {
         address: Felt,
@@ -225,11 +235,15 @@ pub enum Action {
         /// When true, this source has delivered all its data.
         complete: bool,
     },
-    /// Streaming incoming calls (events emitted by the contract) from WS.
-    /// Goes to the Calls tab — separate from AddressTxsStreamed which populates the Txs tab.
-    AddressCallsStreamed {
+    /// Single broadcast of a WS-received event. Emitted once per event; the
+    /// reducer fans it out to the Calls tab (builds a `ContractCallSummary`
+    /// stub + dispatches `EnrichAddressCalls`) and, for `TRANSACTION_EXECUTED`
+    /// events, dispatches `ClassifyPotentialMetaTx` so live meta-tx detection
+    /// still reaches the MetaTxs tab. The event itself has already been
+    /// persisted into the address event cache in the WS handler.
+    AddressWsEvent {
         address: Felt,
-        calls: Vec<ContractCallSummary>,
+        event: SnEvent,
     },
     /// Token balances loaded for an address (sent early for accounts).
     AddressBalancesLoaded {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -499,10 +499,12 @@ fn maybe_dispatch_meta_txs_on_entry(app: &mut App) -> Option<Action> {
     app.address.fetching_meta_txs = true;
     app.address.meta_txs_dispatched = true;
     app.address.meta_tx_from_block = from_block;
+    let window_size = app.address.meta_tx_last_window;
     Some(Action::FetchAddressMetaTxs {
         address: addr,
         from_block,
         continuation_token: None,
+        window_size,
         limit: 50,
     })
 }
@@ -510,6 +512,16 @@ fn maybe_dispatch_meta_txs_on_entry(app: &mut App) -> Option<Action> {
 /// Cycle to the next/previous block or transaction depending on active view.
 fn handle_cycle(app: &mut App, direction: i64) -> Option<Action> {
     match app.current_view() {
+        View::Blocks => {
+            // Half-page-ish scroll through the blocks list.
+            // direction: +1 = Ctrl+U / PageUp (toward newest = lower index),
+            //           -1 = Ctrl+D / PageDown (toward older = higher index).
+            // Blocks are newest-first, so "up" = lower index.
+            const CHUNK: i64 = 10;
+            let delta = -direction * CHUNK;
+            app.blocks_scroll_by(delta);
+            None
+        }
         View::BlockDetail => {
             let current = app.block_detail.block.as_ref()?.number;
             let target = (current as i64 + direction).max(0) as u64;

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -603,7 +603,7 @@ fn handle_nonce_cycle(app: &mut App, direction: i64) -> Option<Action> {
     app.clear_tx_detail();
     Some(Action::FetchTxByNonce {
         sender,
-        current_nonce: current_nonce,
+        current_nonce,
         direction,
     })
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1159,26 +1159,25 @@ impl App {
                     }
                 }
                 self.address.fetching_meta_txs = false;
-                // Progressive fill: keep paging until the visible screen is
-                // full (~FIRST_PAINT_TARGET rows) OR we hit the safety cap
-                // (AUTO_PAGE_CAP). The cap prevents addresses with many events
-                // but zero classified meta-txs from walking their whole
-                // history in the background. Once either limit trips,
-                // pagination goes back to strictly on-demand via
-                // `maybe_fetch_more_meta_txs` on scroll.
-                use crate::app::views::address_info::{
-                    META_TX_AUTO_PAGE_CAP, META_TX_FIRST_PAINT_TARGET,
-                };
+                // Progressive fill: keep paging until the visible list has
+                // `AUTO_FILL_TARGET` rows, or pf-query runs out of blocks to
+                // scan (`meta_tx_has_more == false`), or the user navigates
+                // away (session-token cancellation tears down the in-flight
+                // fetch). No page-count cap — a sparse address with zero
+                // classified meta-txs will walk back to deploy block rather
+                // than silently under-report. Once auto-fill stops, further
+                // pagination is strictly on-demand via
+                // `maybe_fetch_more_meta_txs` on scroll-near-bottom, so the
+                // history-exhausted and user-continuation paths converge.
+                use crate::app::views::address_info::AUTO_FILL_TARGET;
                 if self.address.context == Some(address)
                     && self.address.meta_tx_has_more
-                    && self.address.meta_txs.items.len() < META_TX_FIRST_PAINT_TARGET
-                    && self.address.meta_tx_auto_pages < META_TX_AUTO_PAGE_CAP
+                    && self.address.meta_txs.items.len() < AUTO_FILL_TARGET
                 {
                     let next = self.address.meta_tx_cursor_block;
                     let from_block = self.address.meta_tx_from_block;
                     let window_size = self.address.meta_tx_last_window;
                     self.address.fetching_meta_txs = true;
-                    self.address.meta_tx_auto_pages += 1;
                     let _ = self.action_tx.send(Action::FetchAddressMetaTxs {
                         address,
                         from_block,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1211,6 +1211,21 @@ impl App {
                     self.address.sources_pending = sources.into_iter().collect();
                 }
             }
+            Action::AddressEventWindowUpdated {
+                address,
+                min_searched,
+                max_searched,
+                deferred_gap,
+            } => {
+                if self.address.context == Some(address) {
+                    self.address.event_window =
+                        Some(crate::app::views::address_info::EventWindowHint {
+                            min_searched,
+                            max_searched,
+                            deferred_gap,
+                        });
+                }
+            }
             Action::AddressTxsStreamed {
                 address,
                 source,
@@ -1312,31 +1327,39 @@ impl App {
                     )));
                 }
             }
-            Action::AddressCallsStreamed { address, calls } => {
+            Action::AddressWsEvent { address, event } => {
+                // Fan-out hub for WS-received events. The event has already
+                // been persisted to the per-address event cache in ws.rs; this
+                // reducer is purely about updating in-memory tab state and
+                // dispatching enrichment / classification follow-ups.
                 if self.address.context != Some(address) {
                     return;
                 }
-                if calls.is_empty() {
-                    return;
-                }
-                let existing: std::collections::HashSet<_> =
-                    self.address.calls.items.iter().map(|c| c.tx_hash).collect();
-                let new_calls: Vec<_> = calls
-                    .into_iter()
-                    .filter(|c| !existing.contains(&c.tx_hash))
-                    .collect();
-                if !new_calls.is_empty() {
-                    // Dispatch enrichment for the new stubs (fetch sender/function/fee/timestamp)
-                    let hashes_with_blocks: Vec<_> = new_calls
-                        .iter()
-                        .map(|c| (c.tx_hash, c.block_number))
-                        .collect();
+
+                // --- Calls tab: derive a stub summary and merge (dedupe by tx_hash).
+                let tx_hash = event.transaction_hash;
+                let block_number = event.block_number;
+                let already_present = self
+                    .address
+                    .calls
+                    .items
+                    .iter()
+                    .any(|c| c.tx_hash == tx_hash);
+                if !already_present {
+                    let stub = crate::data::types::ContractCallSummary {
+                        tx_hash,
+                        sender: Felt::ZERO, // filled in by EnrichAddressCalls
+                        function_name: String::new(),
+                        block_number,
+                        timestamp: 0,
+                        total_fee_fri: 0,
+                        status: "OK".to_string(), // events only fire for successful txs
+                    };
                     let _ = self.action_tx.send(Action::EnrichAddressCalls {
                         address,
-                        hashes_with_blocks,
+                        hashes_with_blocks: vec![(tx_hash, block_number)],
                     });
-
-                    self.address.calls.items.extend(new_calls);
+                    self.address.calls.items.push(stub);
                     self.address
                         .calls
                         .items
@@ -1352,6 +1375,20 @@ impl App {
                     {
                         self.address.tab = AddressTab::Calls;
                     }
+                }
+
+                // --- MetaTxs: for viewed accounts, any TRANSACTION_EXECUTED
+                // event might be an execute_from_outside. Dispatch the
+                // classifier to check and populate the MetaTxs tab live.
+                if event
+                    .keys
+                    .first()
+                    .map(|k| *k == crate::network::ws::tx_executed_selector())
+                    .unwrap_or(false)
+                {
+                    let _ = self
+                        .action_tx
+                        .send(Action::ClassifyPotentialMetaTx { address, tx_hash });
                 }
             }
             Action::AddressCallsEnriched { address, calls } => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -979,21 +979,29 @@ impl App {
                     );
                 }
 
-                // Update contract calls (merge, not replace)
+                // Update contract calls (merge across sources, not replace).
+                //
+                // Calls can arrive from two paths for the same tx_hash:
+                //   - Dune `starknet.calls` — authoritative and richer (resolved
+                //     function_name, accurate fee).
+                //   - pf-query shared window scan — supplementary, may arrive
+                //     first if Dune is slow/unavailable.
+                //
+                // Previously the reducer skipped any new row whose tx_hash was
+                // already present, which silently dropped Dune's richer data
+                // when pf-query arrived first. Route both sources through
+                // `deduplicate_contract_calls` which merges function_name
+                // (joined), fills missing fee/timestamp, and preserves the
+                // superset — so neither source can hide the other's data.
                 if !contract_calls.is_empty() {
-                    let existing_hashes: std::collections::HashSet<_> =
-                        self.address.calls.items.iter().map(|c| c.tx_hash).collect();
-                    let new_calls: Vec<_> = contract_calls
-                        .into_iter()
-                        .filter(|c| !existing_hashes.contains(&c.tx_hash))
-                        .collect();
-                    if !new_calls.is_empty() {
-                        self.address.calls.items.extend(new_calls);
-                        self.address
-                            .calls
-                            .items
-                            .sort_by(|a, b| b.block_number.cmp(&a.block_number));
-                    }
+                    let mut merged = std::mem::take(&mut self.address.calls.items);
+                    merged.extend(contract_calls);
+                    self.address.calls.items =
+                        crate::data::types::deduplicate_contract_calls(merged);
+                    self.address
+                        .calls
+                        .items
+                        .sort_by(|a, b| b.block_number.cmp(&a.block_number));
                     if self.address.calls.state.selected().is_none()
                         && !self.address.calls.items.is_empty()
                     {
@@ -1091,15 +1099,18 @@ impl App {
                 if self.address.context == Some(address) {
                     let tx_summaries = self.filter_deployment_txs(address, tx_summaries);
                     self.address.merge_tx_summaries(tx_summaries);
-                    // Merge contract calls
+                    // Merge contract calls across sources (Dune + pf-query).
+                    // See the AddressInfoLoaded handler above for the full
+                    // rationale — `deduplicate_contract_calls` does the
+                    // field-level merge so a later-arriving Dune row can
+                    // still contribute its richer function_name/fee data
+                    // to an already-rendered pf-query row with the same
+                    // tx_hash (and vice-versa).
                     if !contract_calls.is_empty() {
-                        let existing_hashes: std::collections::HashSet<_> =
-                            self.address.calls.items.iter().map(|c| c.tx_hash).collect();
-                        let new_calls: Vec<_> = contract_calls
-                            .into_iter()
-                            .filter(|c| !existing_hashes.contains(&c.tx_hash))
-                            .collect();
-                        self.address.calls.items.extend(new_calls);
+                        let mut merged = std::mem::take(&mut self.address.calls.items);
+                        merged.extend(contract_calls);
+                        self.address.calls.items =
+                            crate::data::types::deduplicate_contract_calls(merged);
                         self.address
                             .calls
                             .items

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -26,7 +26,7 @@ use crate::search::SearchEngine;
 use crate::ui::widgets::stateful_list::StatefulList;
 use actions::{Action, Source};
 use starknet::core::types::Felt;
-use state::{ConnectionStatus, DataSources, Focus, InputMode, NavTarget, View};
+use state::{ActiveQueries, ConnectionStatus, DataSources, Focus, InputMode, NavTarget, View};
 use views::{AddressInfoState, BlockDetailState, ClassInfoState, TxDetailState};
 
 /// Maximum number of blocks retained in the main blocks list.
@@ -86,6 +86,7 @@ pub struct App {
     pub connection_status: ConnectionStatus,
     pub error_message: Option<String>,
     pub data_sources: DataSources,
+    pub active_queries: ActiveQueries,
 
     // Pagination flags (prevent duplicate fetches)
     pub fetching_older_blocks: bool,
@@ -140,6 +141,7 @@ impl App {
             connection_status: ConnectionStatus::default(),
             error_message: None,
             data_sources: DataSources::default(),
+            active_queries: ActiveQueries::default(),
 
             fetching_older_blocks: false,
             pending_bottom_jump: false,
@@ -1597,6 +1599,10 @@ impl App {
                 self.is_loading = true;
                 self.loading_detail = Some(msg);
             }
+            Action::SetActiveQuery { key, label } => match label {
+                Some(l) => self.active_queries.set(&key, l),
+                None => self.active_queries.clear(&key),
+            },
             Action::SourceUpdate { source, status } => {
                 use crate::app::actions::Source;
                 let target = match source {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1427,6 +1427,14 @@ impl App {
                     return;
                 }
 
+                // --- Events tab: delegate decode to the network task (which
+                // owns the async ABI registry); the resulting
+                // `AddressEventStreamed` arm below merges the decoded row.
+                let _ = self.action_tx.send(Action::DecodeAddressWsEvent {
+                    address,
+                    event: event.clone(),
+                });
+
                 // --- Calls tab: derive a stub summary and merge (dedupe by tx_hash).
                 let tx_hash = event.transaction_hash;
                 let block_number = event.block_number;
@@ -1480,6 +1488,40 @@ impl App {
                     let _ = self
                         .action_tx
                         .send(Action::ClassifyPotentialMetaTx { address, tx_hash });
+                }
+            }
+            Action::AddressEventStreamed {
+                address,
+                decoded_event,
+            } => {
+                // Response arm for DecodeAddressWsEvent. Merge the decoded
+                // event into the Events tab list newest-first, dedup by
+                // `(tx_hash, event_index)` — the same key the cache uses. The
+                // event is already persisted (the WS handler called
+                // `merge_address_events` before broadcasting), so this is
+                // purely an in-memory refresh; a future cache reload will
+                // produce the same list via the cache path.
+                if self.address.context != Some(address) {
+                    return;
+                }
+                let key = (
+                    decoded_event.raw.transaction_hash,
+                    decoded_event.raw.event_index,
+                );
+                let already_present = self
+                    .address
+                    .events
+                    .items
+                    .iter()
+                    .any(|e| (e.raw.transaction_hash, e.raw.event_index) == key);
+                if already_present {
+                    return;
+                }
+                self.address.events.items.insert(0, decoded_event);
+                // `insert(0, …)` preserves newest-first ordering as long as
+                // WS events arrive in block order, which they do. No sort.
+                if self.address.events.state.selected().is_none() {
+                    self.address.events.select_first();
                 }
             }
             Action::AddressCallsEnriched { address, calls } => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -29,6 +29,11 @@ use starknet::core::types::Felt;
 use state::{ConnectionStatus, DataSources, Focus, InputMode, NavTarget, View};
 use views::{AddressInfoState, BlockDetailState, ClassInfoState, TxDetailState};
 
+/// Maximum number of blocks retained in the main blocks list.
+/// Applied consistently to both prepends (new blocks) and appends (older
+/// blocks paginated in) to keep the list stable while the user navigates.
+const MAX_BLOCKS: usize = 500;
+
 /// A saved navigation location for the forward/back jump list (Ctrl+o / Ctrl+i).
 #[derive(Debug, Clone)]
 pub enum NavEntry {
@@ -85,6 +90,11 @@ pub struct App {
     // Pagination flags (prevent duplicate fetches)
     pub fetching_older_blocks: bool,
 
+    /// Set when `G` on the blocks view triggers an older-blocks fetch, so
+    /// that once the fetch lands we re-snap the selection to the new last
+    /// item (without this, `G` stops 30 blocks short of the true bottom).
+    pub pending_bottom_jump: bool,
+
     /// Labels fetched from Voyager API at runtime (address → label info).
     /// Used as a fallback when neither user labels nor known addresses have an entry.
     pub voyager_labels: HashMap<starknet::core::types::Felt, VoyagerLabelInfo>,
@@ -132,6 +142,7 @@ impl App {
             data_sources: DataSources::default(),
 
             fetching_older_blocks: false,
+            pending_bottom_jump: false,
 
             voyager_labels: HashMap::new(),
 
@@ -387,6 +398,17 @@ impl App {
         }
     }
 
+    /// Scroll the main blocks list by a delta, triggering older-block
+    /// pagination when the new selection nears the tail. Used by Ctrl+D /
+    /// Ctrl+U on the Blocks view.
+    pub fn blocks_scroll_by(&mut self, delta: i64) {
+        if self.blocks.items.is_empty() {
+            return;
+        }
+        self.blocks.scroll_by(delta);
+        self.maybe_fetch_older_blocks();
+    }
+
     /// Dispatch the next MetaTxs page when the selection nears the end of the
     /// list and pf-query signaled more data. Idempotent: guarded by
     /// `fetching_meta_txs`.
@@ -405,11 +427,13 @@ impl App {
         };
         let token = self.address.meta_tx_cursor_block;
         let from_block = self.address.meta_tx_from_block;
+        let window_size = self.address.meta_tx_last_window;
         self.address.fetching_meta_txs = true;
         let _ = self.action_tx.send(Action::FetchAddressMetaTxs {
             address: addr,
             from_block,
             continuation_token: token,
+            window_size,
             limit: 50,
         });
     }
@@ -511,7 +535,14 @@ impl App {
         match self.current_view() {
             View::Blocks => {
                 self.blocks.select_last();
+                let was_fetching = self.fetching_older_blocks;
                 self.maybe_fetch_older_blocks();
+                // If G just kicked off an older-blocks fetch, remember that
+                // the user wanted the true bottom so we can re-snap once
+                // the paginated batch lands.
+                if !was_fetching && self.fetching_older_blocks {
+                    self.pending_bottom_jump = true;
+                }
             }
             View::BlockDetail => self.block_detail.txs.select_last(),
             View::TxDetail => {
@@ -731,31 +762,71 @@ impl App {
                 }
                 self.is_loading = false;
                 self.fetching_older_blocks = false;
+                self.pending_bottom_jump = false;
             }
             Action::OlderBlocksLoaded(blocks) => {
-                // Append older blocks to the end of the list (they are already sorted newest-first)
+                // Preserve selection by block NUMBER across the append +
+                // truncate — index-based tracking silently drifts the user
+                // onto a different block when the list grows or shrinks.
+                let selected_number = self.blocks.selected_item().map(|b| b.number);
                 self.blocks.items.extend(blocks);
-                // Keep list bounded to avoid unbounded memory growth
-                if self.blocks.items.len() > 500 {
-                    self.blocks.items.truncate(500);
+                if self.blocks.items.len() > MAX_BLOCKS {
+                    self.blocks.items.truncate(MAX_BLOCKS);
                 }
                 self.fetching_older_blocks = false;
+                if self.pending_bottom_jump {
+                    // `G` asked for the true bottom; snap to the new last
+                    // item now that pagination has landed.
+                    self.blocks.select_last();
+                    self.pending_bottom_jump = false;
+                } else if let Some(num) = selected_number
+                    && let Some(idx) = self.blocks.items.iter().position(|b| b.number == num)
+                {
+                    self.blocks.state.select(Some(idx));
+                }
             }
             Action::NewBlock(block) => {
                 self.latest_block_number = block.number;
-                // If the user has scrolled away from the top, keep focus on the
-                // same block by bumping the selection index.  When the selection
-                // is at 0 (the newest block) we leave it there so the list
-                // always tracks the latest block.
-                if let Some(sel) = self.blocks.state.selected() {
-                    if sel > 0 {
-                        self.blocks.state.select(Some(sel + 1));
-                    }
+                // Remember where the user was *before* mutating the list so
+                // we can either follow the tip (sel==0) or pin to the same
+                // block number (sel>0), robust against tail truncation.
+                let prior_sel = self.blocks.state.selected();
+                let selected_number = self.blocks.selected_item().map(|b| b.number);
+
+                // Deduplicate: if the head already has this block number
+                // (e.g. WS replay on reconnect), overwrite rather than
+                // insert a duplicate row.
+                if self.blocks.items.first().map(|b| b.number) == Some(block.number) {
+                    self.blocks.items[0] = block;
+                } else {
+                    self.blocks.items.insert(0, block);
                 }
-                self.blocks.items.insert(0, block);
-                // Keep list bounded
-                if self.blocks.items.len() > 200 {
-                    self.blocks.items.truncate(200);
+                if self.blocks.items.len() > MAX_BLOCKS {
+                    self.blocks.items.truncate(MAX_BLOCKS);
+                }
+
+                match prior_sel {
+                    // Follow the tip when unselected or already at the top.
+                    None | Some(0) => {
+                        if !self.blocks.items.is_empty() {
+                            self.blocks.state.select(Some(0));
+                        }
+                    }
+                    // Otherwise pin to the same block number so the user's
+                    // highlighted row does not silently change under them.
+                    Some(_) => {
+                        if let Some(num) = selected_number {
+                            if let Some(idx) =
+                                self.blocks.items.iter().position(|b| b.number == num)
+                            {
+                                self.blocks.state.select(Some(idx));
+                            } else {
+                                // Block fell off the tail during truncation;
+                                // clamp to the new last item.
+                                self.blocks.select_last();
+                            }
+                        }
+                    }
                 }
             }
             Action::BlockDetailLoaded {
@@ -1046,6 +1117,7 @@ impl App {
                 address,
                 summaries,
                 next_token,
+                next_window_size,
             } => {
                 if self.address.context == Some(address) {
                     // Merge by hash to avoid dupes across pages.
@@ -1068,6 +1140,12 @@ impl App {
                     }
                     self.address.meta_tx_cursor_block = next_token;
                     self.address.meta_tx_has_more = next_token.is_some();
+                    // Persist adapted window size so the next ExtendDown
+                    // dispatch (auto-page or user-scroll) picks up where this
+                    // page left off.
+                    if let Some(w) = next_window_size {
+                        self.address.meta_tx_last_window = w;
+                    }
                 }
                 self.address.fetching_meta_txs = false;
                 // Progressive fill: keep paging until the visible screen is
@@ -1087,12 +1165,14 @@ impl App {
                 {
                     let next = self.address.meta_tx_cursor_block;
                     let from_block = self.address.meta_tx_from_block;
+                    let window_size = self.address.meta_tx_last_window;
                     self.address.fetching_meta_txs = true;
                     self.address.meta_tx_auto_pages += 1;
                     let _ = self.action_tx.send(Action::FetchAddressMetaTxs {
                         address,
                         from_block,
                         continuation_token: next,
+                        window_size,
                         limit: 50,
                     });
                 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1476,7 +1476,7 @@ impl App {
                         timestamp: 0,
                         total_fee_fri: 0,
                         status: "OK".to_string(), // events only fire for successful txs
-                        nonce: None, // filled in by EnrichAddressCalls
+                        nonce: None,              // filled in by EnrichAddressCalls
                         tip: 0,
                     };
                     let _ = self.action_tx.send(Action::EnrichAddressCalls {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1193,9 +1193,9 @@ impl App {
                 if self.address.context == Some(address) {
                     let mut seen: std::collections::HashSet<_> =
                         self.address.meta_txs.items.iter().map(|m| m.hash).collect();
-                    for s in summaries {
+                    for s in &summaries {
                         if seen.insert(s.hash) {
-                            self.address.meta_txs.items.push(s);
+                            self.address.meta_txs.items.push(s.clone());
                         }
                     }
                     self.address.meta_txs.items.sort_by(|a, b| {
@@ -1210,6 +1210,30 @@ impl App {
                     }
                     // Keep fetching_meta_txs / cursor as-is: a live fetch may
                     // still be in-flight behind this cache delivery.
+
+                    // Plan §2 invariant: every cached MetaTx is also a Call on
+                    // this address. The live meta-tx scan already emits
+                    // `AddressCallsMerged` for freshly-seen pages, but on
+                    // re-entry the cached rows never pass through that path —
+                    // promote them here so the Calls list reflects the
+                    // MetaTxs ⊆ Calls invariant immediately from cache.
+                    let promoted: Vec<crate::data::types::ContractCallSummary> = summaries
+                        .into_iter()
+                        .map(|m| crate::data::types::ContractCallSummary {
+                            tx_hash: m.hash,
+                            sender: m.paymaster,
+                            function_name: String::new(),
+                            block_number: m.block_number,
+                            timestamp: m.timestamp,
+                            total_fee_fri: m.total_fee_fri,
+                            status: m.status,
+                        })
+                        .collect();
+                    if !promoted.is_empty() {
+                        let _ = self
+                            .action_tx
+                            .send(Action::AddressCallsMerged { address, calls: promoted });
+                    }
                 }
             }
             Action::AddressMetaTxsStreamed { address, summaries } => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
+use tracing::debug;
 
 use crate::data::types::{AddressTxSummary, SnBlock, VoyagerLabelInfo};
 use crate::network::prices::PriceClient;
@@ -269,7 +270,7 @@ impl App {
     pub fn go_to_root_or_quit(&mut self) {
         if self.view_stack.len() > 1 {
             // Unsubscribe from any active address WS subscription
-            if self.view_stack.iter().any(|v| *v == View::AddressInfo) {
+            if self.view_stack.contains(&View::AddressInfo) {
                 self.unsubscribe_current_address();
             }
             self.view_stack.truncate(1);
@@ -996,14 +997,7 @@ impl App {
                 // (joined), fills missing fee/timestamp, and preserves the
                 // superset — so neither source can hide the other's data.
                 if !contract_calls.is_empty() {
-                    let mut merged = std::mem::take(&mut self.address.calls.items);
-                    merged.extend(contract_calls);
-                    self.address.calls.items =
-                        crate::data::types::deduplicate_contract_calls(merged);
-                    self.address
-                        .calls
-                        .items
-                        .sort_by(|a, b| b.block_number.cmp(&a.block_number));
+                    self.address.merge_calls(contract_calls);
                     if self.address.calls.state.selected().is_none()
                         && !self.address.calls.items.is_empty()
                     {
@@ -1101,23 +1095,10 @@ impl App {
                 if self.address.context == Some(address) {
                     let tx_summaries = self.filter_deployment_txs(address, tx_summaries);
                     self.address.merge_tx_summaries(tx_summaries);
-                    // Merge contract calls across sources (Dune + pf-query).
-                    // See the AddressInfoLoaded handler above for the full
-                    // rationale — `deduplicate_contract_calls` does the
-                    // field-level merge so a later-arriving Dune row can
-                    // still contribute its richer function_name/fee data
-                    // to an already-rendered pf-query row with the same
-                    // tx_hash (and vice-versa).
-                    if !contract_calls.is_empty() {
-                        let mut merged = std::mem::take(&mut self.address.calls.items);
-                        merged.extend(contract_calls);
-                        self.address.calls.items =
-                            crate::data::types::deduplicate_contract_calls(merged);
-                        self.address
-                            .calls
-                            .items
-                            .sort_by(|a, b| b.block_number.cmp(&a.block_number));
-                    }
+                    // Merge contract calls across sources (Dune + pf-query) —
+                    // see `merge_calls` for why this is a field-level merge
+                    // rather than a hash-based replace.
+                    self.address.merge_calls(contract_calls);
                     self.address.oldest_event_block = Some(oldest_block);
                     self.address.dune_cursor_block = Some(oldest_block);
                     self.address.rpc_cursor_block = Some(oldest_block);
@@ -1227,12 +1208,15 @@ impl App {
                             timestamp: m.timestamp,
                             total_fee_fri: m.total_fee_fri,
                             status: m.status,
+                            nonce: None,
+                            tip: 0,
                         })
                         .collect();
                     if !promoted.is_empty() {
-                        let _ = self
-                            .action_tx
-                            .send(Action::AddressCallsMerged { address, calls: promoted });
+                        let _ = self.action_tx.send(Action::AddressCallsMerged {
+                            address,
+                            calls: promoted,
+                        });
                     }
                 }
             }
@@ -1349,6 +1333,14 @@ impl App {
                 complete,
             } => {
                 if self.address.context != Some(address) {
+                    debug!(
+                        address = %format!("{:#x}", address),
+                        source = ?source,
+                        tx_summaries = tx_summaries.len(),
+                        complete,
+                        current_context = ?self.address.context.map(|c| format!("{:#x}", c)),
+                        "AddressTxsStreamed dropped: stale context"
+                    );
                     return;
                 }
                 let old_deploy_hash = self.address.deployment.as_ref().map(|d| d.hash);
@@ -1413,6 +1405,12 @@ impl App {
                 // Track source completion
                 if complete {
                     self.address.sources_pending.remove(&source);
+                    debug!(
+                        address = %format!("{:#x}", address),
+                        source = ?source,
+                        sources_pending = ?self.address.sources_pending,
+                        "AddressTxsStreamed source completed"
+                    );
                     if self.address.sources_pending.is_empty() {
                         self.is_loading = false;
                         self.loading_detail = None;
@@ -1478,6 +1476,8 @@ impl App {
                         timestamp: 0,
                         total_fee_fri: 0,
                         status: "OK".to_string(), // events only fire for successful txs
+                        nonce: None, // filled in by EnrichAddressCalls
+                        tip: 0,
                     };
                     let _ = self.action_tx.send(Action::EnrichAddressCalls {
                         address,
@@ -1549,6 +1549,27 @@ impl App {
                     self.address.events.select_first();
                 }
             }
+            Action::AddressEventsCacheLoaded {
+                address,
+                decoded_events,
+            } => {
+                // Deferred decode pass for the events cached at entry time.
+                // `fetch_and_send_address_info` now sends `AddressInfoLoaded`
+                // immediately with empty `decoded_events` so the TUI can drop
+                // the "Fetching address info…" spinner while this expensive
+                // per-event ABI decode runs in a background task.
+                if self.address.context != Some(address) {
+                    return; // stale — user navigated away
+                }
+                if decoded_events.is_empty() {
+                    return;
+                }
+                let had_selection = self.address.events.state.selected().is_some();
+                self.address.events.items = decoded_events;
+                if !had_selection {
+                    self.address.events.select_first();
+                }
+            }
             Action::AddressCallsEnriched { address, calls } => {
                 if self.address.context != Some(address) {
                     return;
@@ -1577,6 +1598,12 @@ impl App {
                         if existing.status == "?" && enriched.status != "?" {
                             existing.status = enriched.status;
                         }
+                        if existing.nonce.is_none() && enriched.nonce.is_some() {
+                            existing.nonce = enriched.nonce;
+                        }
+                        if existing.tip == 0 && enriched.tip > 0 {
+                            existing.tip = enriched.tip;
+                        }
                     }
                 }
                 // Persist enriched calls to cache so they survive restarts
@@ -1597,14 +1624,7 @@ impl App {
                 if self.address.context != Some(address) || calls.is_empty() {
                     return;
                 }
-                let mut merged = std::mem::take(&mut self.address.calls.items);
-                merged.extend(calls);
-                self.address.calls.items =
-                    crate::data::types::deduplicate_contract_calls(merged);
-                self.address
-                    .calls
-                    .items
-                    .sort_by(|a, b| b.block_number.cmp(&a.block_number));
+                self.address.merge_calls(calls);
                 if self.address.calls.state.selected().is_none()
                     && !self.address.calls.items.is_empty()
                 {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1563,6 +1563,35 @@ impl App {
                     });
                 }
             }
+            Action::AddressCallsMerged { address, calls } => {
+                // Plan §2: pf-query tx_rows supplement Dune's capped Calls set.
+                // Dune's `starknet.calls` query is LIMIT 500 which collapses to
+                // far fewer unique tx_hashes after dedup for addresses with
+                // many multi-call txs (e.g. meta-tx-heavy accounts). The
+                // meta-tx scan already walks the right tx_rows — merge those
+                // rows so MetaTxs ⊆ Calls stays visible.
+                if self.address.context != Some(address) || calls.is_empty() {
+                    return;
+                }
+                let mut merged = std::mem::take(&mut self.address.calls.items);
+                merged.extend(calls);
+                self.address.calls.items =
+                    crate::data::types::deduplicate_contract_calls(merged);
+                self.address
+                    .calls
+                    .items
+                    .sort_by(|a, b| b.block_number.cmp(&a.block_number));
+                if self.address.calls.state.selected().is_none()
+                    && !self.address.calls.items.is_empty()
+                {
+                    self.address.calls.select_first();
+                }
+                // Persist the merged set so it survives restarts.
+                let _ = self.action_tx.send(Action::PersistAddressCalls {
+                    address,
+                    calls: self.address.calls.items.clone(),
+                });
+            }
             Action::AddressBalancesLoaded { address, balances } => {
                 if self.address.context == Some(address) {
                     // Balances can beat the nonce/class_hash fetch to the UI —

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -144,3 +144,94 @@ impl Default for DataSources {
         }
     }
 }
+
+/// Per-query status surface. Each in-flight background query registers a
+/// short, human-readable label keyed by (tab, address-prefix, ...). Labels
+/// are rendered in the status bar so the user can see what's fetching in
+/// each tab — a richer signal than the single-slot `loading_detail` string.
+///
+/// Keys are opaque strings (e.g. `"meta:41420f"`, `"calls:41420f"`), chosen
+/// by the dispatcher; the registry just stores the most recent label per key
+/// and drops the entry when the query finishes.
+#[derive(Debug, Default, Clone)]
+pub struct ActiveQueries {
+    entries: Vec<(String, String)>,
+}
+
+impl ActiveQueries {
+    pub fn set(&mut self, key: &str, label: String) {
+        if let Some(slot) = self.entries.iter_mut().find(|(k, _)| k == key) {
+            slot.1 = label;
+        } else {
+            self.entries.push((key.to_string(), label));
+        }
+    }
+
+    pub fn clear(&mut self, key: &str) {
+        self.entries.retain(|(k, _)| k != key);
+    }
+
+    /// Drop every entry whose key starts with `prefix`. Useful on address
+    /// navigation: `clear_prefix("addr:41420f")` removes every per-tab
+    /// registration tied to that address without listing each tab.
+    pub fn clear_prefix(&mut self, prefix: &str) {
+        self.entries.retain(|(k, _)| !k.starts_with(prefix));
+    }
+
+    pub fn labels(&self) -> impl Iterator<Item = &str> {
+        self.entries.iter().map(|(_, l)| l.as_str())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod active_queries_tests {
+    use super::ActiveQueries;
+
+    #[test]
+    fn set_inserts_and_updates_same_key_in_place() {
+        let mut q = ActiveQueries::default();
+        q.set("meta:41420f", "MetaTxs scan".into());
+        q.set("calls:41420f", "Calls fetch".into());
+        q.set("meta:41420f", "MetaTxs scan 6M→5M".into());
+
+        let labels: Vec<_> = q.labels().collect();
+        assert_eq!(labels, vec!["MetaTxs scan 6M→5M", "Calls fetch"]);
+    }
+
+    #[test]
+    fn clear_removes_only_matching_key() {
+        let mut q = ActiveQueries::default();
+        q.set("meta:41420f", "A".into());
+        q.set("calls:41420f", "B".into());
+        q.clear("meta:41420f");
+
+        let labels: Vec<_> = q.labels().collect();
+        assert_eq!(labels, vec!["B"]);
+    }
+
+    #[test]
+    fn clear_prefix_drops_every_entry_for_an_address() {
+        let mut q = ActiveQueries::default();
+        q.set("meta:41420f", "A".into());
+        q.set("calls:41420f", "B".into());
+        q.set("meta:deadbe", "C".into());
+        q.clear_prefix("meta:");
+
+        let labels: Vec<_> = q.labels().collect();
+        assert_eq!(labels, vec!["B"]);
+    }
+
+    #[test]
+    fn is_empty_tracks_lifecycle() {
+        let mut q = ActiveQueries::default();
+        assert!(q.is_empty());
+        q.set("k", "l".into());
+        assert!(!q.is_empty());
+        q.clear("k");
+        assert!(q.is_empty());
+    }
+}

--- a/src/app/views/address_info.rs
+++ b/src/app/views/address_info.rs
@@ -370,6 +370,24 @@ impl AddressInfoState {
         }
     }
 
+    /// Merge incoming contract calls into the existing list and sort by block
+    /// number descending. `deduplicate_contract_calls` does the field-level
+    /// merge so a later-arriving Dune row can still contribute richer
+    /// function_name/fee data to a pf-query row with the same tx_hash (and
+    /// vice-versa). Callers are responsible for follow-up work (selection,
+    /// cursor updates, persistence).
+    pub fn merge_calls(&mut self, incoming: Vec<ContractCallSummary>) {
+        if incoming.is_empty() {
+            return;
+        }
+        let mut merged = std::mem::take(&mut self.calls.items);
+        merged.extend(incoming);
+        self.calls.items = crate::data::types::deduplicate_contract_calls(merged);
+        self.calls
+            .items
+            .sort_by(|a, b| b.block_number.cmp(&a.block_number));
+    }
+
     /// Scan the current tx list for a "large" nonce gap that we want to defer
     /// filling until the user asks for it.
     ///

--- a/src/app/views/address_info.rs
+++ b/src/app/views/address_info.rs
@@ -129,11 +129,6 @@ pub struct AddressInfoState {
     /// Set to deploy block when known; bounds the scan range so pf-query
     /// doesn't time out walking chunks older than the account.
     pub meta_tx_from_block: u64,
-    /// Number of automatic (non-user-triggered) pages already fetched while
-    /// trying to fill the first screen of MetaTxs. Capped by
-    /// `META_TX_AUTO_PAGE_CAP` so an address with many events but zero
-    /// classified meta-txs doesn't walk the whole history in the background.
-    pub meta_tx_auto_pages: u32,
     /// Last ExtendDown window size (blocks) used for this address's MetaTxs
     /// fetch. Adapted across pages: doubles on empty windows (sparse
     /// addresses), halves on full pages (dense addresses, bloom cap hit).
@@ -145,18 +140,23 @@ pub struct AddressInfoState {
     pub event_window: Option<EventWindowHint>,
 }
 
-/// Maximum background auto-continue pages when filling the MetaTxs first
-/// screen. With adaptive windows, a single page can cover up to
-/// `EXTEND_DOWN_MAX_WINDOW` blocks on sparse addresses, so 40 pages is ample
-/// backstop without being an unbounded walk. Once hit, further pagination
-/// requires the user to scroll (strictly on-demand).
-pub const META_TX_AUTO_PAGE_CAP: u32 = 40;
-
-/// Target MetaTx row count for the first screen. Auto-continue keeps paging
-/// until either this target is reached, `next_token` exhausts, or the
-/// `META_TX_AUTO_PAGE_CAP` safety cap trips. Sized to comfortably fill the
-/// visible list on most terminals.
-pub const META_TX_FIRST_PAINT_TARGET: usize = 50;
+/// Auto-fill row target for the event-backed tabs (currently MetaTxs;
+/// extends to Calls / Events as those tabs migrate to the shared pipeline).
+///
+/// Stop conditions for the background auto-continue loop are exactly:
+///
+///   1. The visible list reaches `AUTO_FILL_TARGET` rows — stop.
+///   2. `has_more` drops (history exhausted: pf-query ran out of blocks
+///      to scan) — stop. The final count stands, no retry.
+///   3. The user navigates away — the session-token cancellation in the
+///      network task tears down any in-flight page fetch.
+///
+/// There is no page-count cap: a sparse address with zero classified
+/// meta-txs is allowed to walk back to its deploy block, because the
+/// alternative ("give up early") silently under-reports. Scrolling near
+/// the bottom re-arms auto-fill (see `maybe_fetch_more_meta_txs`), so
+/// history-exhaustion and user-initiated continuation share one path.
+pub const AUTO_FILL_TARGET: usize = 50;
 
 impl Default for AddressInfoState {
     fn default() -> Self {
@@ -191,7 +191,6 @@ impl Default for AddressInfoState {
             meta_tx_has_more: false,
             meta_txs_dispatched: false,
             meta_tx_from_block: 0,
-            meta_tx_auto_pages: 0,
             meta_tx_last_window: crate::network::event_window::EXTEND_DOWN_INITIAL_WINDOW,
             event_window: None,
         }
@@ -229,7 +228,6 @@ impl AddressInfoState {
         self.meta_tx_has_more = false;
         self.meta_txs_dispatched = false;
         self.meta_tx_from_block = 0;
-        self.meta_tx_auto_pages = 0;
         self.meta_tx_last_window = crate::network::event_window::EXTEND_DOWN_INITIAL_WINDOW;
         self.event_window = None;
     }

--- a/src/app/views/address_info.rs
+++ b/src/app/views/address_info.rs
@@ -134,6 +134,11 @@ pub struct AddressInfoState {
     /// `META_TX_AUTO_PAGE_CAP` so an address with many events but zero
     /// classified meta-txs doesn't walk the whole history in the background.
     pub meta_tx_auto_pages: u32,
+    /// Last ExtendDown window size (blocks) used for this address's MetaTxs
+    /// fetch. Adapted across pages: doubles on empty windows (sparse
+    /// addresses), halves on full pages (dense addresses, bloom cap hit).
+    /// Seeded with `EXTEND_DOWN_INITIAL_WINDOW` on tab entry.
+    pub meta_tx_last_window: u64,
     /// Shared event-window hint for the event-backed tabs (Calls / Events /
     /// MetaTxs). Updated whenever `ensure_address_events_window` runs.
     /// `None` before any fetch completes.
@@ -141,14 +146,17 @@ pub struct AddressInfoState {
 }
 
 /// Maximum background auto-continue pages when filling the MetaTxs first
-/// screen. Each page scans ~50 events, so 10 pages ≈ 500 events. Once hit,
-/// further pagination requires the user to scroll (strictly on-demand).
-pub const META_TX_AUTO_PAGE_CAP: u32 = 10;
+/// screen. With adaptive windows, a single page can cover up to
+/// `EXTEND_DOWN_MAX_WINDOW` blocks on sparse addresses, so 40 pages is ample
+/// backstop without being an unbounded walk. Once hit, further pagination
+/// requires the user to scroll (strictly on-demand).
+pub const META_TX_AUTO_PAGE_CAP: u32 = 40;
 
 /// Target MetaTx row count for the first screen. Auto-continue keeps paging
 /// until either this target is reached, `next_token` exhausts, or the
-/// `META_TX_AUTO_PAGE_CAP` safety cap trips.
-pub const META_TX_FIRST_PAINT_TARGET: usize = 20;
+/// `META_TX_AUTO_PAGE_CAP` safety cap trips. Sized to comfortably fill the
+/// visible list on most terminals.
+pub const META_TX_FIRST_PAINT_TARGET: usize = 50;
 
 impl Default for AddressInfoState {
     fn default() -> Self {
@@ -184,6 +192,7 @@ impl Default for AddressInfoState {
             meta_txs_dispatched: false,
             meta_tx_from_block: 0,
             meta_tx_auto_pages: 0,
+            meta_tx_last_window: crate::network::event_window::EXTEND_DOWN_INITIAL_WINDOW,
             event_window: None,
         }
     }
@@ -221,6 +230,7 @@ impl AddressInfoState {
         self.meta_txs_dispatched = false;
         self.meta_tx_from_block = 0;
         self.meta_tx_auto_pages = 0;
+        self.meta_tx_last_window = crate::network::event_window::EXTEND_DOWN_INITIAL_WINDOW;
         self.event_window = None;
     }
 

--- a/src/app/views/address_info.rs
+++ b/src/app/views/address_info.rs
@@ -21,6 +21,31 @@ use crate::ui::widgets::stateful_list::StatefulList;
 /// they stay aligned — drift between the two causes silent data loss.
 pub const SMALL_GAP_SPAN_BLOCKS: u64 = 50;
 
+/// Passive UI hint derived from the event-window helper's last fetch.
+/// Shared across the Calls / Events / MetaTxs tabs because all three
+/// project from the same `address_events` + `address_search_progress`
+/// cache. Surfaces whatever the helper already computed — no fill logic
+/// is wired to it yet (see task #7 scope: passive-only port).
+///
+/// - `deferred_gap = Some((lo, hi))` ⇒ helper deliberately skipped that
+///   block range because the TopDelta delta exceeded
+///   `EVENT_LARGE_GAP_THRESHOLD_BLOCKS`. Surfaced as a title suffix so
+///   users know the cached event set isn't contiguous.
+/// - `min_searched > 0` ⇒ older history exists below the cached floor
+///   (useful future signal for an interactive ExtendDown trigger).
+#[derive(Clone, Debug, Default)]
+pub struct EventWindowHint {
+    /// Lowest block ever scanned for this address. `0` ⇒ reached genesis
+    /// or never scanned.
+    pub min_searched: u64,
+    /// Highest block ever scanned. Anchors the "is there more tip to fetch"
+    /// question on the next TopDelta.
+    pub max_searched: u64,
+    /// Deliberately skipped block range from the last TopDelta fetch.
+    /// `Some((lo, hi))` where `lo..=hi` is unscanned.
+    pub deferred_gap: Option<(u64, u64)>,
+}
+
 /// A detected, unfilled nonce gap in the tx list that has been deferred
 /// for on-demand filling (issue #10). We do NOT auto-fill large gaps on
 /// address load; instead we wait until the user scrolls toward the gap
@@ -109,6 +134,10 @@ pub struct AddressInfoState {
     /// `META_TX_AUTO_PAGE_CAP` so an address with many events but zero
     /// classified meta-txs doesn't walk the whole history in the background.
     pub meta_tx_auto_pages: u32,
+    /// Shared event-window hint for the event-backed tabs (Calls / Events /
+    /// MetaTxs). Updated whenever `ensure_address_events_window` runs.
+    /// `None` before any fetch completes.
+    pub event_window: Option<EventWindowHint>,
 }
 
 /// Maximum background auto-continue pages when filling the MetaTxs first
@@ -155,6 +184,7 @@ impl Default for AddressInfoState {
             meta_txs_dispatched: false,
             meta_tx_from_block: 0,
             meta_tx_auto_pages: 0,
+            event_window: None,
         }
     }
 }
@@ -191,6 +221,7 @@ impl AddressInfoState {
         self.meta_txs_dispatched = false;
         self.meta_tx_from_block = 0;
         self.meta_tx_auto_pages = 0;
+        self.event_window = None;
     }
 
     /// Whether any source thinks there is more data to fetch.

--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -124,6 +124,10 @@ impl CachingDataSource {
                 max_searched_block INTEGER NOT NULL,
                 min_searched_block INTEGER NOT NULL DEFAULT 0
             );
+            CREATE TABLE IF NOT EXISTS address_activity_total (
+                address TEXT PRIMARY KEY,
+                total_known INTEGER NOT NULL
+            );
             CREATE TABLE IF NOT EXISTS contract_events (
                 address TEXT NOT NULL,
                 event_index INTEGER NOT NULL,
@@ -181,6 +185,20 @@ impl CachingDataSource {
             )
             .map_err(|e| SnbeatError::Config(format!("Migration v4 failed: {e}")))?;
             debug!("Migration v4: cleared tx/block/address caches");
+        }
+
+        if version < 5 {
+            // v5: introduce address_activity_total so we can persist the
+            // upstream event-count total (e.g. Dune probe) and render
+            // "(N / total)" labels across restarts. Kept in its own table so
+            // that seeding a total does not create a bogus (0,0) scan range
+            // on the address_search_progress row.
+            // The CREATE TABLE IF NOT EXISTS above is the DDL; nothing else to
+            // do for existing DBs — just bump the version.
+            db.execute("PRAGMA user_version = 5", []).map_err(|e| {
+                SnbeatError::Config(format!("Migration v5 version bump failed: {e}"))
+            })?;
+            debug!("Migration v5: added address_activity_total table");
         }
 
         Ok(Self {
@@ -285,7 +303,7 @@ impl CachingDataSource {
         }
     }
 
-    fn load_address_events(&self, address: &Felt) -> Vec<SnEvent> {
+    fn get_cached_address_events(&self, address: &Felt) -> Vec<SnEvent> {
         let db = match self.db.lock() {
             Ok(db) => db,
             Err(_) => return Vec::new(),
@@ -323,6 +341,32 @@ impl CachingDataSource {
                 }
             }
         }
+    }
+
+    /// Additive merge: dedupe `new_events` against what's already cached and
+    /// rewrite the combined list sorted newest-first. Unlike `save_address_events`
+    /// (which replaces everything), this preserves older cached events when a
+    /// caller only supplies a fresh top-of-tip window. Returns the merged list.
+    fn merge_address_events_impl(&self, address: &Felt, new_events: &[SnEvent]) -> Vec<SnEvent> {
+        let cached = self.get_cached_address_events(address);
+        let mut merged: Vec<SnEvent> = new_events.to_vec();
+        for event in cached {
+            let dup = merged.iter().any(|e| {
+                e.transaction_hash == event.transaction_hash
+                    && e.block_number == event.block_number
+                    && e.event_index == event.event_index
+            });
+            if !dup {
+                merged.push(event);
+            }
+        }
+        merged.sort_by(|a, b| {
+            b.block_number
+                .cmp(&a.block_number)
+                .then_with(|| b.event_index.cmp(&a.event_index))
+        });
+        self.save_address_events(address, &merged);
+        merged
     }
 
     fn get_cached_receipt(&self, hash: Felt) -> Option<SnReceipt> {
@@ -509,6 +553,27 @@ impl CachingDataSource {
             let _ = db.execute(
                 "INSERT OR REPLACE INTO address_search_progress (address, min_searched_block, max_searched_block) VALUES (?1, ?2, ?3)",
                 params![addr_hex, final_min as i64, final_max as i64],
+            );
+        }
+    }
+
+    fn get_cached_activity_total(&self, address: &Felt) -> Option<u64> {
+        let db = self.db.lock().ok()?;
+        let addr_hex = format!("{:#x}", address);
+        let mut stmt = db
+            .prepare("SELECT total_known FROM address_activity_total WHERE address = ?1")
+            .ok()?;
+        stmt.query_row(params![addr_hex], |row| row.get::<_, i64>(0))
+            .ok()
+            .map(|v| v as u64)
+    }
+
+    fn cache_activity_total(&self, address: &Felt, total: u64) {
+        if let Ok(db) = self.db.lock() {
+            let addr_hex = format!("{:#x}", address);
+            let _ = db.execute(
+                "INSERT OR REPLACE INTO address_activity_total (address, total_known) VALUES (?1, ?2)",
+                params![addr_hex, total as i64],
             );
         }
     }
@@ -731,7 +796,7 @@ impl DataSource for CachingDataSource {
         }
 
         // Load cached events
-        let cached = self.load_address_events(&address);
+        let cached = self.get_cached_address_events(&address);
 
         // Incremental: fetch events newer than our newest cached event
         let fetch_from = if !cached.is_empty() && from_block.is_none() {
@@ -1074,6 +1139,22 @@ impl DataSource for CachingDataSource {
         self.cache_search_progress(address, min_block, max_block);
     }
 
+    fn load_activity_total(&self, address: &Felt) -> Option<u64> {
+        self.get_cached_activity_total(address)
+    }
+
+    fn save_activity_total(&self, address: &Felt, total: u64) {
+        self.cache_activity_total(address, total);
+    }
+
+    fn load_address_events(&self, address: &Felt) -> Vec<SnEvent> {
+        self.get_cached_address_events(address)
+    }
+
+    fn merge_address_events(&self, address: &Felt, new_events: &[SnEvent]) -> Vec<SnEvent> {
+        self.merge_address_events_impl(address, new_events)
+    }
+
     async fn get_recent_blocks(&self, count: usize) -> Result<Vec<SnBlock>> {
         // Fetch from upstream (recent blocks change)
         let blocks = self.upstream.get_recent_blocks(count).await?;
@@ -1213,5 +1294,124 @@ impl DataSource for CachingDataSource {
                 warn!(error = %e, "save_class_contracts: commit failed");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::DataSource;
+    use crate::data::types::*;
+    use starknet::core::types::ContractClass;
+
+    /// Minimal upstream stub — the search_progress / activity_total tests only
+    /// touch sync cache-local SQL, so the async upstream methods never fire.
+    struct NullUpstream;
+
+    #[async_trait]
+    impl DataSource for NullUpstream {
+        async fn get_latest_block_number(&self) -> Result<u64> {
+            unimplemented!()
+        }
+        async fn get_block(&self, _number: u64) -> Result<SnBlock> {
+            unimplemented!()
+        }
+        async fn get_block_by_hash(&self, _hash: Felt) -> Result<u64> {
+            unimplemented!()
+        }
+        async fn get_block_with_txs(&self, _number: u64) -> Result<(SnBlock, Vec<SnTransaction>)> {
+            unimplemented!()
+        }
+        async fn get_transaction(&self, _hash: Felt) -> Result<SnTransaction> {
+            unimplemented!()
+        }
+        async fn get_receipt(&self, _hash: Felt) -> Result<SnReceipt> {
+            unimplemented!()
+        }
+        async fn get_nonce(&self, _address: Felt) -> Result<Felt> {
+            unimplemented!()
+        }
+        async fn get_class_hash(&self, _address: Felt) -> Result<Felt> {
+            unimplemented!()
+        }
+        async fn get_class(&self, _class_hash: Felt) -> Result<ContractClass> {
+            unimplemented!()
+        }
+        async fn get_recent_blocks(&self, _count: usize) -> Result<Vec<SnBlock>> {
+            unimplemented!()
+        }
+        async fn get_events_for_address(
+            &self,
+            _address: Felt,
+            _from_block: Option<u64>,
+            _to_block: Option<u64>,
+            _limit: usize,
+        ) -> Result<Vec<SnEvent>> {
+            unimplemented!()
+        }
+        async fn call_contract(
+            &self,
+            _contract_address: Felt,
+            _selector: Felt,
+            _calldata: Vec<Felt>,
+        ) -> Result<Vec<Felt>> {
+            unimplemented!()
+        }
+    }
+
+    fn new_cache() -> (CachingDataSource, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cache.db");
+        let ds = CachingDataSource::new(Arc::new(NullUpstream), &path).expect("open cache");
+        (ds, dir)
+    }
+
+    #[test]
+    fn activity_total_roundtrip() {
+        let (ds, _d) = new_cache();
+        let addr = Felt::from_hex("0x1234").unwrap();
+
+        assert_eq!(ds.load_activity_total(&addr), None);
+
+        ds.save_activity_total(&addr, 11400);
+        assert_eq!(ds.load_activity_total(&addr), Some(11400));
+
+        // Update is idempotent and overwrites.
+        ds.save_activity_total(&addr, 11450);
+        assert_eq!(ds.load_activity_total(&addr), Some(11450));
+    }
+
+    #[test]
+    fn save_search_progress_preserves_total_known() {
+        // Regression test: before this change, INSERT OR REPLACE in
+        // cache_search_progress would null out total_known when a later event
+        // scan extended the range. Now it must survive.
+        let (ds, _d) = new_cache();
+        let addr = Felt::from_hex("0xabcd").unwrap();
+
+        ds.save_activity_total(&addr, 11400);
+        // Seed an initial scanned range.
+        ds.save_search_progress(&addr, 3_000_000, 8_900_000);
+        assert_eq!(ds.load_activity_total(&addr), Some(11400));
+
+        // Extending the range (e.g. fetching newer events) must keep total_known.
+        ds.save_search_progress(&addr, 3_000_000, 8_941_000);
+        assert_eq!(ds.load_activity_total(&addr), Some(11400));
+        assert_eq!(ds.load_search_progress(&addr), Some((3_000_000, 8_941_000)));
+    }
+
+    #[test]
+    fn search_progress_merges_ranges() {
+        let (ds, _d) = new_cache();
+        let addr = Felt::from_hex("0xbeef").unwrap();
+
+        ds.save_search_progress(&addr, 100, 200);
+        ds.save_search_progress(&addr, 50, 150);
+        // Min shrinks, max doesn't regress.
+        assert_eq!(ds.load_search_progress(&addr), Some((50, 200)));
+
+        ds.save_search_progress(&addr, 300, 400);
+        // Max extends, min doesn't grow past the remembered floor.
+        assert_eq!(ds.load_search_progress(&addr), Some((50, 400)));
     }
 }

--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -1033,10 +1033,7 @@ impl DataSource for CachingDataSource {
         .ok()
     }
 
-    fn load_cached_activity_range_any_age(
-        &self,
-        address: &Felt,
-    ) -> Option<(u64, u64, u64)> {
+    fn load_cached_activity_range_any_age(&self, address: &Felt) -> Option<(u64, u64, u64)> {
         let db = self.db.lock().ok()?;
         let addr_hex = format!("{:#x}", address);
         let mut stmt = db

--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -11,9 +11,9 @@ use rusqlite::{Connection, params};
 use starknet::core::types::{ContractClass, Felt};
 use tracing::{debug, trace, warn};
 
-use super::DataSource;
 #[allow(unused_imports)]
 use super::types::*;
+use super::{DataSource, FilterKind};
 use crate::error::{Result, SnbeatError};
 
 /// Shared future output: errors are stringified so the future is `Clone`-able
@@ -120,9 +120,11 @@ impl CachingDataSource {
                 block_number INTEGER NOT NULL
             );
             CREATE TABLE IF NOT EXISTS address_search_progress (
-                address TEXT PRIMARY KEY,
+                address TEXT NOT NULL,
+                filter_kind TEXT NOT NULL DEFAULT 'unkeyed',
                 max_searched_block INTEGER NOT NULL,
-                min_searched_block INTEGER NOT NULL DEFAULT 0
+                min_searched_block INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (address, filter_kind)
             );
             CREATE TABLE IF NOT EXISTS address_activity_total (
                 address TEXT PRIMARY KEY,
@@ -199,6 +201,35 @@ impl CachingDataSource {
                 SnbeatError::Config(format!("Migration v5 version bump failed: {e}"))
             })?;
             debug!("Migration v5: added address_activity_total table");
+        }
+
+        if version < 6 {
+            // v6: split address_search_progress by filter_kind. Legacy rows
+            // can't be attributed to a specific kind after the fact
+            // (TASK C wrote either Account/keyed or Contract/unkeyed
+            // scans here indiscriminately), so migrate them as `unkeyed`.
+            // Consequence: accounts revisited post-upgrade will pay for
+            // one keyed re-scan of the previously-covered range. Safe and
+            // acceptably small.
+            db.execute_batch(
+                "CREATE TABLE address_search_progress_v6 (
+                     address TEXT NOT NULL,
+                     filter_kind TEXT NOT NULL DEFAULT 'unkeyed',
+                     max_searched_block INTEGER NOT NULL,
+                     min_searched_block INTEGER NOT NULL DEFAULT 0,
+                     PRIMARY KEY (address, filter_kind)
+                 );
+                 INSERT INTO address_search_progress_v6
+                     (address, filter_kind, max_searched_block, min_searched_block)
+                     SELECT address, 'unkeyed', max_searched_block, min_searched_block
+                     FROM address_search_progress;
+                 DROP TABLE address_search_progress;
+                 ALTER TABLE address_search_progress_v6
+                     RENAME TO address_search_progress;
+                 PRAGMA user_version = 6;",
+            )
+            .map_err(|e| SnbeatError::Config(format!("Migration v6 failed: {e}")))?;
+            debug!("Migration v6: split address_search_progress by filter_kind");
         }
 
         Ok(Self {
@@ -516,13 +547,20 @@ impl CachingDataSource {
 
     // --- search progress cache ---
 
-    fn get_cached_search_progress(&self, address: &Felt) -> Option<(u64, u64)> {
+    fn get_cached_search_progress(
+        &self,
+        address: &Felt,
+        filter_kind: FilterKind,
+    ) -> Option<(u64, u64)> {
         let db = self.db.lock().ok()?;
         let addr_hex = format!("{:#x}", address);
         let mut stmt = db
-            .prepare("SELECT min_searched_block, max_searched_block FROM address_search_progress WHERE address = ?1")
+            .prepare(
+                "SELECT min_searched_block, max_searched_block FROM address_search_progress \
+                 WHERE address = ?1 AND filter_kind = ?2",
+            )
             .ok()?;
-        stmt.query_row(params![addr_hex], |row| {
+        stmt.query_row(params![addr_hex, filter_kind.as_str()], |row| {
             let min: i64 = row.get(0)?;
             let max: i64 = row.get(1)?;
             Ok((min as u64, max as u64))
@@ -530,15 +568,24 @@ impl CachingDataSource {
         .ok()
     }
 
-    fn cache_search_progress(&self, address: &Felt, min_block: u64, max_block: u64) {
+    fn cache_search_progress(
+        &self,
+        address: &Felt,
+        filter_kind: FilterKind,
+        min_block: u64,
+        max_block: u64,
+    ) {
         if let Ok(db) = self.db.lock() {
             let addr_hex = format!("{:#x}", address);
-            // Merge: expand existing range
+            // Merge: expand existing range for this (address, filter_kind) row.
             let existing = db
-                .prepare("SELECT min_searched_block, max_searched_block FROM address_search_progress WHERE address = ?1")
+                .prepare(
+                    "SELECT min_searched_block, max_searched_block FROM address_search_progress \
+                     WHERE address = ?1 AND filter_kind = ?2",
+                )
                 .ok()
                 .and_then(|mut s| {
-                    s.query_row(params![addr_hex], |row| {
+                    s.query_row(params![addr_hex, filter_kind.as_str()], |row| {
                         let min: i64 = row.get(0)?;
                         let max: i64 = row.get(1)?;
                         Ok((min as u64, max as u64))
@@ -551,8 +598,15 @@ impl CachingDataSource {
                 (min_block, max_block)
             };
             let _ = db.execute(
-                "INSERT OR REPLACE INTO address_search_progress (address, min_searched_block, max_searched_block) VALUES (?1, ?2, ?3)",
-                params![addr_hex, final_min as i64, final_max as i64],
+                "INSERT OR REPLACE INTO address_search_progress \
+                 (address, filter_kind, min_searched_block, max_searched_block) \
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    addr_hex,
+                    filter_kind.as_str(),
+                    final_min as i64,
+                    final_max as i64
+                ],
             );
         }
     }
@@ -1131,12 +1185,18 @@ impl DataSource for CachingDataSource {
         self.cache_nonce_info(address, nonce, block);
     }
 
-    fn load_search_progress(&self, address: &Felt) -> Option<(u64, u64)> {
-        self.get_cached_search_progress(address)
+    fn load_search_progress(&self, address: &Felt, filter_kind: FilterKind) -> Option<(u64, u64)> {
+        self.get_cached_search_progress(address, filter_kind)
     }
 
-    fn save_search_progress(&self, address: &Felt, min_block: u64, max_block: u64) {
-        self.cache_search_progress(address, min_block, max_block);
+    fn save_search_progress(
+        &self,
+        address: &Felt,
+        filter_kind: FilterKind,
+        min_block: u64,
+        max_block: u64,
+    ) {
+        self.cache_search_progress(address, filter_kind, min_block, max_block);
     }
 
     fn load_activity_total(&self, address: &Felt) -> Option<u64> {
@@ -1391,13 +1451,16 @@ mod tests {
 
         ds.save_activity_total(&addr, 11400);
         // Seed an initial scanned range.
-        ds.save_search_progress(&addr, 3_000_000, 8_900_000);
+        ds.save_search_progress(&addr, FilterKind::Unkeyed, 3_000_000, 8_900_000);
         assert_eq!(ds.load_activity_total(&addr), Some(11400));
 
         // Extending the range (e.g. fetching newer events) must keep total_known.
-        ds.save_search_progress(&addr, 3_000_000, 8_941_000);
+        ds.save_search_progress(&addr, FilterKind::Unkeyed, 3_000_000, 8_941_000);
         assert_eq!(ds.load_activity_total(&addr), Some(11400));
-        assert_eq!(ds.load_search_progress(&addr), Some((3_000_000, 8_941_000)));
+        assert_eq!(
+            ds.load_search_progress(&addr, FilterKind::Unkeyed),
+            Some((3_000_000, 8_941_000))
+        );
     }
 
     #[test]
@@ -1405,13 +1468,49 @@ mod tests {
         let (ds, _d) = new_cache();
         let addr = Felt::from_hex("0xbeef").unwrap();
 
-        ds.save_search_progress(&addr, 100, 200);
-        ds.save_search_progress(&addr, 50, 150);
+        ds.save_search_progress(&addr, FilterKind::Unkeyed, 100, 200);
+        ds.save_search_progress(&addr, FilterKind::Unkeyed, 50, 150);
         // Min shrinks, max doesn't regress.
-        assert_eq!(ds.load_search_progress(&addr), Some((50, 200)));
+        assert_eq!(
+            ds.load_search_progress(&addr, FilterKind::Unkeyed),
+            Some((50, 200))
+        );
 
-        ds.save_search_progress(&addr, 300, 400);
+        ds.save_search_progress(&addr, FilterKind::Unkeyed, 300, 400);
         // Max extends, min doesn't grow past the remembered floor.
-        assert_eq!(ds.load_search_progress(&addr), Some((50, 400)));
+        assert_eq!(
+            ds.load_search_progress(&addr, FilterKind::Unkeyed),
+            Some((50, 400))
+        );
+    }
+
+    #[test]
+    fn search_progress_split_by_filter_kind() {
+        // Regression test for v6 migration: keyed and unkeyed coverage are
+        // tracked independently. A keyed scan must not appear to cover the
+        // unkeyed region (which would be a lie — keyed scans miss non-
+        // TRANSACTION_EXECUTED events).
+        let (ds, _d) = new_cache();
+        let addr = Felt::from_hex("0xface").unwrap();
+
+        // Record a wide keyed scan.
+        ds.save_search_progress(&addr, FilterKind::Keyed, 1_000_000, 9_000_000);
+        assert_eq!(
+            ds.load_search_progress(&addr, FilterKind::Keyed),
+            Some((1_000_000, 9_000_000))
+        );
+        // Unkeyed is still unrecorded — not satisfied by the keyed scan.
+        assert_eq!(ds.load_search_progress(&addr, FilterKind::Unkeyed), None);
+
+        // Recording an unkeyed scan does not disturb the keyed row.
+        ds.save_search_progress(&addr, FilterKind::Unkeyed, 8_000_000, 9_000_000);
+        assert_eq!(
+            ds.load_search_progress(&addr, FilterKind::Unkeyed),
+            Some((8_000_000, 9_000_000))
+        );
+        assert_eq!(
+            ds.load_search_progress(&addr, FilterKind::Keyed),
+            Some((1_000_000, 9_000_000))
+        );
     }
 }

--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -1033,6 +1033,27 @@ impl DataSource for CachingDataSource {
         .ok()
     }
 
+    fn load_cached_activity_range_any_age(
+        &self,
+        address: &Felt,
+    ) -> Option<(u64, u64, u64)> {
+        let db = self.db.lock().ok()?;
+        let addr_hex = format!("{:#x}", address);
+        let mut stmt = db
+            .prepare(
+                "SELECT min_block, max_block, event_count FROM address_activity \
+                 WHERE address = ?1",
+            )
+            .ok()?;
+        stmt.query_row(params![addr_hex], |row| {
+            let min: i64 = row.get(0)?;
+            let max: i64 = row.get(1)?;
+            let count: i64 = row.get(2)?;
+            Ok((min as u64, max as u64, count as u64))
+        })
+        .ok()
+    }
+
     fn save_activity_range(&self, address: &Felt, min_block: u64, max_block: u64) {
         self.save_activity_range_with_count(address, min_block, max_block, 0);
     }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -158,6 +158,31 @@ pub trait DataSource: Send + Sync {
     /// Save search progress for an address.
     fn save_search_progress(&self, _address: &Felt, _min_block: u64, _max_block: u64) {}
 
+    /// Load the last-known upstream event-count total (e.g. Dune probe) for
+    /// an address. `None` means "never probed" — not "zero activity".
+    fn load_activity_total(&self, _address: &Felt) -> Option<u64> {
+        None
+    }
+    /// Persist the upstream event-count total. Survives restarts so that UI
+    /// labels like "(204 / 11400)" don't regress to "(204)" on revisit.
+    fn save_activity_total(&self, _address: &Felt, _total: u64) {}
+
+    /// Load all cached events for an address (newest-first when persisted
+    /// through the merge path). Empty vec if nothing cached.
+    fn load_address_events(&self, _address: &Felt) -> Vec<SnEvent> {
+        Vec::new()
+    }
+
+    /// Additive merge of `new_events` into the per-address event cache. Dedupes
+    /// on (tx_hash, block, event_index), sorts newest-first, persists, and
+    /// returns the merged list.
+    ///
+    /// Use this instead of `save_address_events` when appending a top-of-tip
+    /// or bottom-extension window — it preserves older cached events.
+    fn merge_address_events(&self, _address: &Felt, new_events: &[SnEvent]) -> Vec<SnEvent> {
+        new_events.to_vec()
+    }
+
     // --- Class declaration cache ---
     /// Load cached declare info for a class hash. Declarations are immutable
     /// (a class's declaration block/tx never changes), so there is no TTL.

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -14,6 +14,36 @@ use types::{
     MetaTxIntenderSummary, SnBlock, SnEvent, SnReceipt, SnTransaction,
 };
 
+/// What kind of event filter a scan applied. Used as a secondary key in
+/// `address_search_progress` so that a narrower (keyed) scan doesn't
+/// falsely mark the broader (unkeyed) region as "covered". Scans record
+/// coverage under the kind they used; callers query the kind they need.
+///
+/// - [`FilterKind::Unkeyed`] — all events emitted by the address
+///   (pf-query `from_address` filter, no key filter). Equivalent to the
+///   Events-tab source. Strictly a superset of `Keyed` data over the
+///   same block range, so an unkeyed-covered range satisfies keyed
+///   queries too (though we don't currently exploit that — see §3 of
+///   the address-view revamp plan).
+/// - [`FilterKind::Keyed`] — events with a specific key filter
+///   (currently only `TRANSACTION_EXECUTED`, used by the MetaTxs tab).
+///   Narrower than `Unkeyed`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FilterKind {
+    Unkeyed,
+    Keyed,
+}
+
+impl FilterKind {
+    /// Stable string identifier persisted in the SQLite `filter_kind` column.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FilterKind::Unkeyed => "unkeyed",
+            FilterKind::Keyed => "keyed",
+        }
+    }
+}
+
 /// Abstraction over different Starknet data sources (RPC, Pathfinder DB).
 #[async_trait]
 pub trait DataSource: Send + Sync {
@@ -151,12 +181,26 @@ pub trait DataSource: Send + Sync {
     fn save_cached_nonce(&self, _address: &Felt, _nonce: &Felt, _block: u64) {}
 
     // --- Search progress cache ---
-    /// Load cached search progress (min_searched_block, max_searched_block).
-    fn load_search_progress(&self, _address: &Felt) -> Option<(u64, u64)> {
+    /// Load cached search progress `(min_searched_block, max_searched_block)`
+    /// for `(address, filter_kind)`. `None` ⇒ no scan of that kind recorded.
+    fn load_search_progress(
+        &self,
+        _address: &Felt,
+        _filter_kind: FilterKind,
+    ) -> Option<(u64, u64)> {
         None
     }
-    /// Save search progress for an address.
-    fn save_search_progress(&self, _address: &Felt, _min_block: u64, _max_block: u64) {}
+    /// Save (merge-expand) search progress for `(address, filter_kind)`.
+    /// The SQLite impl extends the existing min/max range rather than
+    /// replacing, so repeated windowed scans accumulate coverage.
+    fn save_search_progress(
+        &self,
+        _address: &Felt,
+        _filter_kind: FilterKind,
+        _min_block: u64,
+        _max_block: u64,
+    ) {
+    }
 
     /// Load the last-known upstream event-count total (e.g. Dune probe) for
     /// an address. `None` means "never probed" — not "zero activity".

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -107,10 +107,7 @@ pub trait DataSource: Send + Sync {
     /// (the deploy/first-activity floor never regresses), so we can avoid
     /// re-probing the entire history and only extend `max_block` + count
     /// from the cached high-water mark.
-    fn load_cached_activity_range_any_age(
-        &self,
-        _address: &Felt,
-    ) -> Option<(u64, u64, u64)> {
+    fn load_cached_activity_range_any_age(&self, _address: &Felt) -> Option<(u64, u64, u64)> {
         None
     }
     /// Save discovered activity range for an address.

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -102,6 +102,17 @@ pub trait DataSource: Send + Sync {
     fn load_cached_activity_range_with_count(&self, _address: &Felt) -> Option<(u64, u64, u64)> {
         None
     }
+    /// Load cached activity range ignoring freshness. Used by the probe
+    /// TopDelta path: a stale but present row still has a valid `min_block`
+    /// (the deploy/first-activity floor never regresses), so we can avoid
+    /// re-probing the entire history and only extend `max_block` + count
+    /// from the cached high-water mark.
+    fn load_cached_activity_range_any_age(
+        &self,
+        _address: &Felt,
+    ) -> Option<(u64, u64, u64)> {
+        None
+    }
     /// Save discovered activity range for an address.
     fn save_activity_range(&self, _address: &Felt, _min_block: u64, _max_block: u64) {
         // Default: no-op. CachingDataSource overrides.

--- a/src/data/pathfinder.rs
+++ b/src/data/pathfinder.rs
@@ -126,6 +126,23 @@ struct PfContractEventsResponse {
     continuation_token: Option<u64>,
 }
 
+/// Full-range event-count probe result returned by pf-query's
+/// `/contract-event-count` endpoint. Used to populate activity labels like
+/// "(N / total)" without depending on Dune.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContractEventCount {
+    pub count: u64,
+    pub min_block: Option<u64>,
+    pub max_block: Option<u64>,
+    /// False when pf-query stopped at its internal candidate cap; treat
+    /// `count` as a lower bound in that case.
+    pub complete: bool,
+    #[allow(dead_code)]
+    pub scanned_from: u64,
+    #[allow(dead_code)]
+    pub scanned_to: u64,
+}
+
 /// Serialize a positional key filter as pf-query expects:
 /// groups separated by `;`, OR-keys within a group by `,`.
 /// Empty groups => wildcard at that position.
@@ -396,6 +413,51 @@ impl PathfinderClient {
             .map(PfContractEvent::into_sn_event)
             .collect::<anyhow::Result<Vec<_>>>()?;
         Ok((events, resp.continuation_token))
+    }
+
+    /// Probe the total event count for a contract over a block range.
+    ///
+    /// Server-side this reuses the bloom+brute scan from `/contract-events`
+    /// but counts matches rather than collecting them, so it can afford to
+    /// walk the whole chain in a single request. Returns a `ContractEventCount`
+    /// whose `complete` flag is `false` if the server bailed out at its
+    /// internal candidate cap (in which case `count` is a lower bound).
+    pub async fn get_contract_event_count(
+        &self,
+        address: Felt,
+        from_block: Option<u64>,
+        to_block: Option<u64>,
+        keys: &[Vec<Felt>],
+    ) -> anyhow::Result<ContractEventCount> {
+        let addr_hex = format!("{:#x}", address);
+        let mut url = format!("{}/contract-event-count/{}", self.base_url, addr_hex);
+        let mut first = true;
+        let mut add = |param: String| {
+            url.push(if first { '?' } else { '&' });
+            url.push_str(&param);
+            first = false;
+        };
+        if let Some(from) = from_block {
+            add(format!("from_block={from}"));
+        }
+        if let Some(to) = to_block {
+            add(format!("to_block={to}"));
+        }
+        if let Some(k) = encode_keys_filter(keys) {
+            let encoded = k.replace(';', "%3B");
+            add(format!("keys={encoded}"));
+        }
+
+        debug!(url = %url, "Probing contract event count from pf-query");
+        let resp: ContractEventCount = self
+            .client
+            .get(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(resp)
     }
 
     /// Convenience: fetch account-emitted `transaction_executed` events for an address.

--- a/src/data/types.rs
+++ b/src/data/types.rs
@@ -318,6 +318,13 @@ pub struct ContractCallSummary {
     pub timestamp: u64,
     pub total_fee_fri: u128,
     pub status: String,
+    /// Sender tx nonce. `None` from Dune-sourced rows (not in `starknet.calls`);
+    /// populated from RPC/pf-query rows and merged in by `deduplicate_contract_calls`.
+    #[serde(default)]
+    pub nonce: Option<u64>,
+    /// Sender tip (FRI). `0` from Dune-sourced rows and stubs; filled by RPC/pf path.
+    #[serde(default)]
+    pub tip: u64,
 }
 
 /// Label information fetched from Voyager for a contract/account address.
@@ -376,6 +383,12 @@ pub fn deduplicate_contract_calls(calls: Vec<ContractCallSummary>) -> Vec<Contra
             }
             if existing.timestamp == 0 && call.timestamp > 0 {
                 existing.timestamp = call.timestamp;
+            }
+            if existing.nonce.is_none() && call.nonce.is_some() {
+                existing.nonce = call.nonce;
+            }
+            if existing.tip == 0 && call.tip > 0 {
+                existing.tip = call.tip;
             }
         } else {
             seen.insert(call.tx_hash, result.len());

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -560,7 +560,14 @@ pub(super) async fn build_contract_calls_from_hashes(
     pf: Option<&Arc<crate::data::pathfinder::PathfinderClient>>,
     abi_reg: &Arc<AbiRegistry>,
 ) -> Vec<crate::data::types::ContractCallSummary> {
-    // Pre-fetch ABI for the target contract so selector→name lookups succeed.
+    // Pre-warm ABIs for every top-level call target in the batch so the
+    // selector→name lookups below all hit a warm registry. We don't filter
+    // these multicalls by `address` — the Calls row's `function_name` column
+    // mirrors what the block and tx detail views show for the same tx, i.e.
+    // the entire top-level endpoint list (see `helpers::format_endpoint_names`).
+    // For contracts called only internally (e.g. Ekubo Core via an aggregator)
+    // this surfaces the aggregator's outer function name, which is consistent
+    // with the rest of the UI and avoids needing `starknet_traceTransaction`.
     helpers::prewarm_abis([address], abi_reg).await;
 
     let mut calls_list = Vec::new();
@@ -580,6 +587,20 @@ pub(super) async fn build_contract_calls_from_hashes(
             .collect();
         let results = futures::future::join_all(futs).await;
 
+        // Prewarm the ABIs for the top-level call targets we're about to
+        // format, otherwise `format_endpoint_names` would hit a cold registry
+        // for the aggregator/router contracts and fall back to hex.
+        let prewarm_targets: std::collections::HashSet<_> = results
+            .iter()
+            .filter_map(|(_, _, tx_r, _)| tx_r.as_ref().ok())
+            .flat_map(|tx| match tx {
+                crate::data::types::SnTransaction::Invoke(i) => parse_multicall(&i.calldata),
+                _ => Vec::new(),
+            })
+            .map(|c| c.contract_address)
+            .collect();
+        helpers::prewarm_abis(prewarm_targets, abi_reg).await;
+
         for (hash, block_num, tx_r, rx_r) in results {
             if let Ok(fetched_tx) = tx_r {
                 let receipt = rx_r.ok();
@@ -596,15 +617,7 @@ pub(super) async fn build_contract_calls_from_hashes(
                     })
                     .unwrap_or("?")
                     .to_string();
-                let function_name = match &fetched_tx {
-                    crate::data::types::SnTransaction::Invoke(i) => parse_multicall(&i.calldata)
-                        .iter()
-                        .filter(|c| c.contract_address == address)
-                        .map(|c| helpers::format_selector_name_or_hex(&c.selector, abi_reg))
-                        .collect::<Vec<_>>()
-                        .join(", "),
-                    _ => String::new(),
-                };
+                let function_name = helpers::format_endpoint_names(&fetched_tx, abi_reg);
                 calls_list.push(crate::data::types::ContractCallSummary {
                     tx_hash: hash,
                     sender: fetched_tx.sender(),
@@ -635,8 +648,25 @@ pub(super) async fn build_contract_calls_from_pf_rows(
 ) -> Vec<crate::data::types::ContractCallSummary> {
     use starknet::core::types::Felt;
 
-    // Pre-warm ABI for the target contract so selector→name lookups succeed.
-    helpers::prewarm_abis([address], abi_reg).await;
+    // Pre-warm ABIs: the Calls row's `function_name` mirrors the block/tx
+    // detail views (see `helpers::format_endpoint_names`) and lists every
+    // top-level call in the multicall, so we prewarm each call target's ABI
+    // — not just `address` — to keep hex fallbacks out of the common case.
+    let prewarm_targets: std::collections::HashSet<Felt> = tx_rows
+        .iter()
+        .filter(|r| helpers::normalize_pf_tx_type(&r.tx_type) == "INVOKE")
+        .flat_map(|r| {
+            let calldata: Vec<Felt> = r
+                .calldata
+                .iter()
+                .filter_map(|h| Felt::from_hex(h).ok())
+                .collect();
+            parse_multicall(&calldata)
+        })
+        .map(|c| c.contract_address)
+        .chain(std::iter::once(address))
+        .collect();
+    helpers::prewarm_abis(prewarm_targets, abi_reg).await;
 
     let mut calls_list: Vec<crate::data::types::ContractCallSummary> =
         Vec::with_capacity(tx_rows.len());
@@ -656,12 +686,10 @@ pub(super) async fn build_contract_calls_from_pf_rows(
                 .iter()
                 .filter_map(|h| Felt::from_hex(h).ok())
                 .collect();
-            parse_multicall(&calldata)
-                .iter()
-                .filter(|c| c.contract_address == address)
-                .map(|c| helpers::format_selector_name_or_hex(&c.selector, abi_reg))
-                .collect::<Vec<_>>()
-                .join(", ")
+            helpers::format_selector_names(
+                parse_multicall(&calldata).iter().map(|c| c.selector),
+                abi_reg,
+            )
         } else {
             String::new()
         };
@@ -877,6 +905,15 @@ pub(super) async fn fetch_and_send_address_info(
         // populates callee activity only. Sender tx totals come from the
         // on-chain nonce in the address info path; leave sender_* at 0.
         probe.callee_call_count = event_count;
+        // Publish to both the UI reducer (so the Calls tab can show its
+        // `shown / known+` fragment on re-entry from cache) AND the watch
+        // channel (for downstream task window sizing). Previously only the
+        // watch channel got it, so the UI regressed to a bare `Calls(N)`
+        // count whenever re-entry hit the fresh-cache fast path.
+        let _ = tx.send(Action::AddressProbeLoaded {
+            address,
+            probe: probe.clone(),
+        });
         let _ = probe_watch_tx.send(Some(probe));
     } else {
         // No fresh cache. Two paths from here:
@@ -923,6 +960,22 @@ pub(super) async fn fetch_and_send_address_info(
             if let Some(dune_c) = dune_probe.as_ref() {
                 match stale_cached {
                     Some((cached_min, cached_max, cached_count)) => {
+                        // Publish the stale cached probe to the UI immediately
+                        // — the count we learned last time is a valid
+                        // lower bound right now, and we'd rather show
+                        // `shown / cached_count+` during the delta probe than
+                        // regress to a bare `Calls(N)` for the seconds it
+                        // takes Dune to respond (or forever, if Dune fails).
+                        let mut stale_probe = dune::AddressActivityProbe::default();
+                        stale_probe.callee_min_block = cached_min;
+                        stale_probe.callee_max_block = cached_max;
+                        stale_probe.callee_call_count = cached_count;
+                        let _ = tx_probe.send(Action::AddressProbeLoaded {
+                            address,
+                            probe: stale_probe.clone(),
+                        });
+                        let _ = probe_watch_tx_c.send(Some(stale_probe));
+
                         // TopDelta: only probe blocks > cached_max and merge.
                         let _ = tx_probe.send(Action::LoadingStatus(format!(
                             "Dune: extending activity probe (>{} block)...",
@@ -951,13 +1004,10 @@ pub(super) async fn fetch_and_send_address_info(
                                     "Dune probe failed: {}",
                                     e
                                 )));
-                                // Fall back: still publish the cached range so
-                                // downstream tasks can size their windows.
-                                let mut fallback = dune::AddressActivityProbe::default();
-                                fallback.callee_min_block = cached_min;
-                                fallback.callee_max_block = cached_max;
-                                fallback.callee_call_count = cached_count;
-                                let _ = probe_watch_tx_c.send(Some(fallback));
+                                // The stale probe was already published to
+                                // the UI + watch at the top of this branch,
+                                // so the Calls tab keeps its `/ cached+`
+                                // hint. Nothing more to do here.
                             }
                         }
                     }
@@ -2513,8 +2563,12 @@ pub(super) async fn fetch_more_address_txs(
         };
         let dune_to = before_block.saturating_sub(1);
         if is_contract {
+            // Pagination walks backward from `before_block`; we don't keep a
+            // reliable timestamp for arbitrary historical windows, so skip the
+            // `block_date` hint here. The narrower LIMIT (100) and user-capped
+            // `window_size` keep Dune's scan bounded in practice.
             match dune_client
-                .query_contract_calls_windowed(address, from_block, dune_to, 100)
+                .query_contract_calls_windowed(address, from_block, dune_to, 100, None)
                 .await
             {
                 Ok(calls) => (Vec::new(), calls),
@@ -3267,17 +3321,33 @@ pub(super) async fn fetch_address_contract_calls(
     // for blocks strictly newer than the highest block we've seen. Cold cache
     // still falls back to the unwindowed "500 most recent" fetch so first open
     // on a long-lived contract stays cheap.
-    let max_cached_block = ds
-        .load_cached_address_calls(&address)
+    //
+    // We also pull the timestamp of that newest-cached row and feed it to the
+    // windowed query as a `block_date` partition hint — `starknet.calls` is
+    // partitioned by date, so without it Dune scans every partition to resolve
+    // the `block_number BETWEEN` range and fails with QUERY_STATE_FAILED on
+    // dense contracts. A 1-day UTC cushion guards against the cached row
+    // sitting right before a day boundary.
+    let cached_calls = ds.load_cached_address_calls(&address);
+    let newest_cached = cached_calls
         .iter()
-        .map(|c| c.block_number)
-        .filter(|&b| b > 0)
-        .max();
+        .filter(|c| c.block_number > 0)
+        .max_by_key(|c| c.block_number);
 
-    let dune_calls_result = match max_cached_block {
-        Some(from) => {
+    let dune_calls_result = match newest_cached {
+        Some(c) => {
+            let min_date = (c.timestamp > 0)
+                .then(|| chrono::DateTime::from_timestamp(c.timestamp as i64, 0))
+                .flatten()
+                .map(|dt| dt.date_naive() - chrono::Duration::days(1));
             dune_client
-                .query_contract_calls_windowed(address, from + 1, u64::MAX, CONTRACT_CALL_LIMIT)
+                .query_contract_calls_windowed(
+                    address,
+                    c.block_number + 1,
+                    u64::MAX,
+                    CONTRACT_CALL_LIMIT,
+                    min_date,
+                )
                 .await
         }
         None => {
@@ -3307,8 +3377,16 @@ pub(super) async fn fetch_address_contract_calls(
         "Calls: Dune contract calls complete"
     );
 
+    // Merge the freshly fetched rows with whatever we already had cached before
+    // persisting. The windowed TopDelta path only returns rows newer than the
+    // previously seen tip, so writing just `calls` would clobber the bulk of
+    // the cache. Cold-cache path still works: `cached_calls` is empty there,
+    // and `deduplicate_contract_calls` returns the full 500-row set unchanged.
     if !calls.is_empty() {
-        ds.save_address_calls(&address, &calls);
+        let mut merged = cached_calls;
+        merged.extend(calls.iter().cloned());
+        let merged = crate::data::types::deduplicate_contract_calls(merged);
+        ds.save_address_calls(&address, &merged);
     }
 
     // Emit using the same merge path the Dune bulk fetch used. An empty
@@ -3598,12 +3676,16 @@ mod shared_pipeline_tests {
         );
     }
 
-    /// `build_contract_calls_from_pf_rows` must filter multicall entries by
-    /// the `address` argument. Given a 3-call multicall where only the
-    /// middle call targets `address`, the produced summary's
-    /// `function_name` must reflect exactly one inner call (no comma).
+    /// `build_contract_calls_from_pf_rows` lists every top-level multicall
+    /// entry in `function_name`, matching what the block/tx detail views
+    /// show via `helpers::format_endpoint_names`. Given a 3-call multicall
+    /// (where only the middle call actually targets `address`), the summary
+    /// must list all three selectors — the Calls row mirrors the outer tx's
+    /// endpoint set, not the subset that happens to touch `address` at the
+    /// top level. This is what makes function names appear for contracts
+    /// invoked only internally (e.g. Ekubo Core via an aggregator).
     #[tokio::test]
-    async fn build_contract_calls_filters_by_target_in_multicall() {
+    async fn build_contract_calls_lists_all_multicall_endpoints() {
         let target =
             Felt::from_hex("0x3a496b92d292386ad70dab94ae181a06d289440e3b632a2435721b4280874c4")
                 .unwrap();
@@ -3640,11 +3722,14 @@ mod shared_pipeline_tests {
         assert_eq!(c.status, "OK");
         assert!(
             !c.function_name.is_empty(),
-            "function_name must reflect the one targeting call"
+            "function_name must reflect the full top-level multicall"
         );
-        assert!(
-            !c.function_name.contains(','),
-            "only one inner call targets `address`, function_name should not list multiple: {:?}",
+        // Three top-level calls → at least two commas in the joined output
+        // (`format_selector_names` joins with ", ").
+        assert_eq!(
+            c.function_name.matches(',').count(),
+            2,
+            "all three top-level calls should be listed, got: {:?}",
             c.function_name
         );
     }

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -879,10 +879,14 @@ pub(super) async fn fetch_and_send_address_info(
         probe.callee_call_count = event_count;
         let _ = probe_watch_tx.send(Some(probe));
     } else {
-        // No fresh cache — run the Dune activity probe if Dune is configured.
-        // Otherwise the watch channel stays `None` and downstream tasks fall
-        // back to their own default windows. See the outer comment for why
-        // pf-query is no longer a probe source.
+        // No fresh cache. Two paths from here:
+        //   - Any cached row (stale or fresh) exists → TopDelta probe:
+        //     cheap `block_number > cached_max` query, merged into cache.
+        //   - No cached row at all → full probe (cold path).
+        // Either way, the watch channel stays `None` if Dune isn't configured
+        // and downstream tasks fall back to their own default windows. See the
+        // outer comment for why pf-query is no longer a probe source.
+        let stale_cached = ds.load_cached_activity_range_any_age(&address);
         let dune_probe: Option<Arc<dune::DuneClient>> = dune.as_ref().map(Arc::clone);
         let ds_probe = Arc::clone(ds);
         let tx_probe = tx.clone();
@@ -917,16 +921,61 @@ pub(super) async fn fetch_and_send_address_info(
             };
 
             if let Some(dune_c) = dune_probe.as_ref() {
-                let _ = tx_probe.send(Action::LoadingStatus(
-                    "Dune: probing activity range (events)...".into(),
-                ));
-                match dune_c.probe_address_activity(address).await {
-                    Ok(probe) => publish(probe, "Dune probe"),
-                    Err(e) => {
-                        warn!(error = %e, "Dune activity probe failed");
-                        let _ = tx_probe
-                            .send(Action::LoadingStatus(format!("Dune probe failed: {}", e)));
-                        // Leave watch at None — tasks will use default windows.
+                match stale_cached {
+                    Some((cached_min, cached_max, cached_count)) => {
+                        // TopDelta: only probe blocks > cached_max and merge.
+                        let _ = tx_probe.send(Action::LoadingStatus(format!(
+                            "Dune: extending activity probe (>{} block)...",
+                            cached_max
+                        )));
+                        match dune_c
+                            .probe_address_activity_delta(address, cached_max)
+                            .await
+                        {
+                            Ok(delta) => {
+                                // Merge delta into cached: min stays, max
+                                // expands, count sums. `save_activity_range_with_count`
+                                // also merges at the DB layer, but we need a
+                                // fully-populated probe to publish to the UI.
+                                let mut merged = dune::AddressActivityProbe::default();
+                                merged.callee_min_block = cached_min;
+                                merged.callee_max_block =
+                                    delta.callee_max_block.max(cached_max);
+                                merged.callee_call_count =
+                                    cached_count.saturating_add(delta.callee_call_count);
+                                publish(merged, "Dune probe (delta)");
+                            }
+                            Err(e) => {
+                                warn!(error = %e, "Dune delta activity probe failed");
+                                let _ = tx_probe.send(Action::LoadingStatus(format!(
+                                    "Dune probe failed: {}",
+                                    e
+                                )));
+                                // Fall back: still publish the cached range so
+                                // downstream tasks can size their windows.
+                                let mut fallback = dune::AddressActivityProbe::default();
+                                fallback.callee_min_block = cached_min;
+                                fallback.callee_max_block = cached_max;
+                                fallback.callee_call_count = cached_count;
+                                let _ = probe_watch_tx_c.send(Some(fallback));
+                            }
+                        }
+                    }
+                    None => {
+                        let _ = tx_probe.send(Action::LoadingStatus(
+                            "Dune: probing activity range (events)...".into(),
+                        ));
+                        match dune_c.probe_address_activity(address).await {
+                            Ok(probe) => publish(probe, "Dune probe"),
+                            Err(e) => {
+                                warn!(error = %e, "Dune activity probe failed");
+                                let _ = tx_probe.send(Action::LoadingStatus(format!(
+                                    "Dune probe failed: {}",
+                                    e
+                                )));
+                                // Leave watch at None — tasks will use default windows.
+                            }
+                        }
                     }
                 }
             }

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -751,15 +751,25 @@ pub(super) async fn fetch_and_send_address_info(
     });
 
     // Send partial info immediately (cached txs seed the UI)
+    // Decode cached events so the Events tab renders instantly on revisit,
+    // mirroring the cache-first behaviour already in place for Txs/Calls.
+    // Live fetches downstream will emit AddressEventsStreamed with newer
+    // events; decoded_events here is the starting set the reducer can merge on.
+    let cached_events = ds.load_address_events(&address);
+    let mut cached_decoded = Vec::with_capacity(cached_events.len());
+    for event in &cached_events {
+        let abi = abi_reg.get_abi_for_address(&event.from_address).await;
+        cached_decoded.push(decode_event(event, abi.as_deref()));
+    }
     let _ = tx.send(Action::AddressInfoLoaded {
         info: crate::data::types::SnAddressInfo {
             address,
             nonce,
             class_hash,
-            recent_events: Vec::new(),
+            recent_events: cached_events,
             token_balances: Vec::new(),
         },
-        decoded_events: Vec::new(),
+        decoded_events: cached_decoded,
         tx_summaries: ds.load_cached_address_txs(&address),
         contract_calls: ds.load_cached_address_calls(&address),
     });

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -764,6 +764,20 @@ pub(super) async fn fetch_and_send_address_info(
         contract_calls: ds.load_cached_address_calls(&address),
     });
 
+    // Seed the MetaTxs tab count from cache up-front, like `tx_summaries` /
+    // `contract_calls` above. Previously the cache was only loaded when the
+    // user tabbed to MetaTxs (via `FetchAddressMetaTxs`), so the tab label
+    // read "(0)" on address entry even when cached classifications existed.
+    // The reducer doesn't flip `meta_txs_dispatched` for this action — a
+    // live pf-query fetch still fires when the user actually enters the tab.
+    let cached_meta_txs = ds.load_cached_meta_txs(&address);
+    if !cached_meta_txs.is_empty() {
+        let _ = tx.send(Action::AddressMetaTxsCacheLoaded {
+            address,
+            summaries: cached_meta_txs,
+        });
+    }
+
     // Check cached activity range — if fresh, skip Dune probe entirely.
     let cached_range = ds.load_cached_activity_range(&address);
     if let Some((min_b, max_b)) = cached_range {
@@ -845,13 +859,36 @@ pub(super) async fn fetch_and_send_address_info(
                 let _ = probe_watch_tx_c.send(Some(probe));
             };
 
-            // 1. Try pf-query first.
-            if let Some(pf_c) = pf_probe.as_ref() {
-                let _ = tx_probe.send(Action::LoadingStatus(
-                    "PF: probing activity range (events)...".into(),
-                ));
+            // 1. Try pf-query first — but only with a `from_block` bound.
+            // Unbounded probes walk from genesis via bloom filters, which on
+            // busy accounts exceeds the 30s client timeout and causes Dune
+            // fallback for every single probe (observed 2026-04-19: 8/8 PF
+            // probes timed out). Resolve a hint from cached deploy info, or
+            // by querying class history (cheap PF nonce-table lookup).
+            let deploy_hint: Option<u64> =
+                if let Some((_, b, _)) = ds_probe.load_cached_deploy_info(&address) {
+                    Some(b)
+                } else if let Some(pf_c) = pf_probe.as_ref() {
+                    match pf_c.get_class_history(address).await {
+                        Ok(entries) => entries.last().map(|e| e.block_number),
+                        Err(e) => {
+                            debug!(
+                                error = %e,
+                                "PF class-history lookup for probe from_block hint failed"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+
+            if let (Some(pf_c), Some(from_block)) = (pf_probe.as_ref(), deploy_hint) {
+                let _ = tx_probe.send(Action::LoadingStatus(format!(
+                    "PF: probing activity range (events, from block {from_block})..."
+                )));
                 match pf_c
-                    .get_contract_event_count(address, None, None, &[])
+                    .get_contract_event_count(address, Some(from_block), None, &[])
                     .await
                 {
                     Ok(count) => {
@@ -878,6 +915,11 @@ pub(super) async fn fetch_and_send_address_info(
                         )));
                     }
                 }
+            } else if pf_probe.is_some() {
+                debug!(
+                    addr = %format!("{:#x}", address),
+                    "Skipping PF probe: no deploy-block hint available (would scan from genesis)"
+                );
             }
 
             // 2. Fall back to Dune.
@@ -971,24 +1013,24 @@ pub(super) async fn fetch_and_send_address_info(
     }
 
     // =====================================================================
-    // TASK B1: Contract calls — pf-query primary, RPC fallback, always runs
-    // for contracts regardless of Dune availability. The prior Dune-backed
-    // bulk fetch was replaced by the unified event_window path so all three
-    // event-derived tabs share one cursor + additive cache.
+    // TASK B1: Contract calls — Dune-backed. Event-based fetches miss txs
+    // that called the contract without emitting events (reverted calls, pure
+    // setters, nested multicall targets), so this tab uses Dune's trace-indexed
+    // `starknet.calls` table. The Events tab (TASK C) stays on pf-query.
     // =====================================================================
     if is_contract {
         let ds_b = Arc::clone(ds);
         let tx_b = tx.clone();
         let abi_b = Arc::clone(abi_reg);
-        let pf_b = pf.as_ref().map(Arc::clone);
+        let dune_b = dune.as_ref().map(Arc::clone);
         tokio::spawn(async move {
             let _ = tx_b.send(Action::LoadingStatus(
-                "Calls: fetching via event window...".into(),
+                "Calls: fetching from Dune...".into(),
             ));
             fetch_address_contract_calls(
                 address,
                 &ds_b,
-                pf_b.as_ref(),
+                dune_b.as_ref(),
                 &abi_b,
                 &tx_b,
                 nonce,
@@ -1208,7 +1250,10 @@ pub(super) async fn fetch_and_send_address_info(
                 "RPC: scanning {}k blocks for events...",
                 (window_size + 999) / 1000
             )));
-            let phase1_limit = if is_contract { 500 } else { 100 };
+            // Phase 1 page limit is now managed inside the event_window helper
+            // (`EVENT_PAGE_LIMIT` in event_window.rs). The old per-caller
+            // phase1_limit value is dead — left here as a comment so the
+            // history of Phase 1's contract-vs-account heuristics is findable.
 
             let kind = if is_contract {
                 EventQueryKind::Contract
@@ -1216,67 +1261,67 @@ pub(super) async fn fetch_and_send_address_info(
                 EventQueryKind::Account
             };
 
-            // Fast path: when pf is available, fetch events AND unique tx rows
-            // in one shared pipeline. The MetaTxs tab can derive from the same
-            // page (emitted alongside below), avoiding a second event scan +
-            // /txs-by-hash round trip.
-            let pf_page: Option<AddressActivityPage> = if let Some(pf) = pf_c.as_ref() {
-                match fetch_address_activity(
-                    address,
-                    kind,
-                    from_block,
-                    None,
-                    phase1_limit as u32,
-                    pf,
-                )
-                .await
-                {
-                    Ok(p) => Some(p),
-                    Err(e) => {
-                        warn!(
-                            error = %e,
-                            address = %format!("{:#x}", address),
-                            "Shared activity fetch failed, falling back to RPC path"
-                        );
-                        None
-                    }
+            // Route through the shared event-window helper. Benefits over the
+            // previous direct `fetch_address_activity`/`fetch_events_routed`
+            // branching:
+            //   - `address_search_progress` cursor is advanced automatically,
+            //     so subsequent tab loads (Calls/MetaTxs via the same helper)
+            //     short-circuit instead of re-fetching the same window.
+            //   - Events are persisted via `merge_address_events` for free.
+            //   - Works whether pf-query is available (fast pf path with
+            //     tx_rows) or not (RPC fallback via `fetch_events_routed`).
+            //
+            // The helper picks its own `from_block` via `resolve_top_delta`,
+            // so TASK C's custom `from_block` (derived from nonce_delta /
+            // search_progress above) is now only used for the fast-skip
+            // short-circuit and the loading-status banner — not for the fetch.
+            let ds_dyn: Arc<dyn crate::data::DataSource> = ds_c.clone();
+            let pf_page: Option<AddressActivityPage> = match crate::network::event_window::ensure_address_events_window(
+                address,
+                kind,
+                crate::network::event_window::EventWindowPolicy::TopDelta,
+                pf_c.as_ref(),
+                &ds_dyn,
+                latest_block,
+            )
+            .await
+            {
+                Ok(o) => {
+                    let _ = tx_c.send(Action::AddressEventWindowUpdated {
+                        address,
+                        min_searched: o.min_searched,
+                        max_searched: o.max_searched,
+                        deferred_gap: o.deferred_gap,
+                    });
+                    Some(o.page)
                 }
-            } else {
-                None
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        address = %format!("{:#x}", address),
+                        "event_window fetch failed in TASK C"
+                    );
+                    let _ = tx_c.send(Action::LoadingStatus(format!(
+                        "Event fetch failed: {}",
+                        e
+                    )));
+                    let _ = tx_c.send(Action::SourceUpdate {
+                        source: Source::Rpc,
+                        status: crate::app::state::SourceStatus::FetchError(e.to_string()),
+                    });
+                    None
+                }
             };
 
-            // Events: take from the shared page when available, else fall
-            // back to the legacy RPC/PF routed fetch (keeps behaviour when
-            // pf-query is unavailable).
-            let events = if let Some(page) = &pf_page {
-                page.events.clone()
-            } else {
-                let events_result = fetch_events_routed(
-                    kind,
-                    pf_c.as_ref(),
-                    &ds_c,
-                    address,
-                    Some(from_block),
-                    None,
-                    phase1_limit,
-                )
-                .await;
-                match events_result {
-                    Ok(evts) => evts,
-                    Err(e) => {
-                        warn!(error = %e, address = %format!("{:#x}", address), "RPC event fetch failed");
-                        let _ = tx_c.send(Action::LoadingStatus(format!(
-                            "RPC: event fetch failed: {}",
-                            e
-                        )));
-                        let _ = tx_c.send(Action::SourceUpdate {
-                            source: Source::Rpc,
-                            status: crate::app::state::SourceStatus::FetchError(e.to_string()),
-                        });
-                        Vec::new()
-                    }
-                }
-            };
+            let events = pf_page
+                .as_ref()
+                .map(|p| p.events.clone())
+                .unwrap_or_default();
+            // On the RPC fallback path `tx_rows` is empty. Treat that as "no
+            // pf page available" so the downstream derivations hash-scan RPC
+            // like before; the `pf_page.is_some()` branches check `tx_rows`
+            // implicitly by using the shared helpers.
+            let pf_page: Option<AddressActivityPage> = pf_page.filter(|p| !p.tx_rows.is_empty());
 
             let events_count = events.len();
             debug!(
@@ -2915,6 +2960,13 @@ pub(super) async fn fetch_address_meta_txs(
         }
     };
 
+    let _ = action_tx.send(Action::AddressEventWindowUpdated {
+        address,
+        min_searched: outcome.min_searched,
+        max_searched: outcome.max_searched,
+        deferred_gap: outcome.deferred_gap,
+    });
+
     // `ExtendDown` past genesis returns an empty page — still emit an empty
     // response so the UI clears its loading flag and flips has_more=false.
     if outcome.page.events.is_empty() {
@@ -2968,91 +3020,67 @@ pub(super) async fn fetch_address_meta_txs(
     });
 }
 
-/// Fetch a window of contract events for `address` and emit the resulting
+/// Fetch calls-to-contract for `address` via Dune and emit the resulting
 /// [`ContractCallSummary`](crate::data::types::ContractCallSummary) rows as
 /// `AddressInfoLoaded { contract_calls, .. }`.
 ///
-/// Mirrors [`fetch_address_meta_txs`] but for the Calls tab. Works with or
-/// without pf-query:
-/// - **pf available** → `ensure_address_events_window` bulk-fetches tx rows
-///   alongside events, and we build summaries directly via
-///   [`build_contract_calls_from_pf_rows`] (no per-tx RPC).
-/// - **pf absent** → the window helper returns events with empty `tx_rows`;
-///   we fall back to [`build_contract_calls_from_hashes`] which fetches tx
-///   + receipt per hash through the [`DataSource`].
+/// Uses Dune's `starknet.calls` table (trace-indexed) rather than
+/// events-emitted-by-address, because the latter misses txs that called the
+/// contract without triggering an event (reverted calls, pure setters,
+/// nested multicall targets that don't emit). Event-based fetches are still
+/// used for accounts (where `TRANSACTION_EXECUTED` is always emitted) and
+/// for the contract's Events tab.
 ///
-/// Emission uses the same `AddressInfoLoaded` merge path that the legacy
-/// Dune bulk fetch used, so the UI reducer in the app state machine needs
-/// no changes.
+/// No-op when Dune is not configured — the tab falls back to whatever was
+/// loaded from cache on address entry.
 pub(super) async fn fetch_address_contract_calls(
     address: starknet::core::types::Felt,
     ds: &Arc<dyn crate::data::DataSource>,
-    pf: Option<&Arc<crate::data::pathfinder::PathfinderClient>>,
+    dune: Option<&Arc<dune::DuneClient>>,
     abi_reg: &Arc<AbiRegistry>,
     action_tx: &mpsc::UnboundedSender<Action>,
     nonce: starknet::core::types::Felt,
     class_hash: Option<starknet::core::types::Felt>,
 ) {
-    use crate::network::event_window::{EventWindowPolicy, ensure_address_events_window};
+    const CONTRACT_CALL_LIMIT: u32 = 500;
 
-    let latest_block = match ds.get_latest_block_number().await {
-        Ok(b) => b,
-        Err(e) => {
-            warn!(addr = %format!("{:#x}", address), error = %e, "Calls: latest block fetch failed");
-            return;
-        }
-    };
-
-    let ds_dyn: Arc<dyn crate::data::DataSource> = ds.clone();
-    let outcome = match ensure_address_events_window(
-        address,
-        EventQueryKind::Contract,
-        EventWindowPolicy::TopDelta,
-        pf,
-        &ds_dyn,
-        latest_block,
-    )
-    .await
-    {
-        Ok(o) => o,
-        Err(e) => {
-            warn!(addr = %format!("{:#x}", address), error = %e, "Calls: event window fetch failed");
-            return;
-        }
-    };
-
-    if outcome.page.events.is_empty() {
+    let Some(dune_client) = dune else {
         debug!(
             addr = %format!("{:#x}", address),
-            min_searched = outcome.min_searched,
-            max_searched = outcome.max_searched,
-            "Calls: no new events in this window"
+            "Calls: Dune not configured; skipping contract calls fetch"
         );
         return;
+    };
+
+    let mut calls = match dune_client
+        .query_contract_calls(address, CONTRACT_CALL_LIMIT)
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(addr = %format!("{:#x}", address), error = %e, "Calls: Dune contract calls fetch failed");
+            return;
+        }
+    };
+
+    // Dune returns the entry_point_selector as hex in `function_name`; resolve
+    // it through the ABI registry so the UI shows readable names.
+    helpers::prewarm_abis([address], abi_reg).await;
+    for c in &mut calls {
+        if let Ok(sel) = starknet::core::types::Felt::from_hex(&c.function_name) {
+            c.function_name = helpers::format_selector_name_or_hex(&sel, abi_reg);
+        }
     }
 
-    // pf path: tx_rows already populated. RPC fallback: derive from (hash, block).
-    let calls = if !outcome.page.tx_rows.is_empty() {
-        build_contract_calls_from_pf_rows(address, &outcome.page.tx_rows, abi_reg).await
-    } else {
-        let hashes_with_blocks: Vec<_> = outcome
-            .page
-            .unique_hashes
-            .iter()
-            .map(|h| (*h, *outcome.page.tx_block_map.get(h).unwrap_or(&0)))
-            .collect();
-        build_contract_calls_from_hashes(address, &hashes_with_blocks, ds, pf, abi_reg).await
-    };
+    // A single tx can call the same contract multiple times (multicall, nested
+    // calls). Dune returns one row per call, so merge them into one entry per
+    // tx with function names joined in Dune's trace order.
+    let calls = crate::data::types::deduplicate_contract_calls(calls);
 
     info!(
         addr = %format!("{:#x}", address),
-        events = outcome.page.events.len(),
         calls = calls.len(),
-        min_searched = outcome.min_searched,
-        max_searched = outcome.max_searched,
-        deferred_gap = ?outcome.deferred_gap,
-        via_pf = pf.is_some(),
-        "Calls: window fetch complete"
+        "Calls: Dune contract calls complete"
     );
 
     if !calls.is_empty() {

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -39,7 +39,7 @@ const UDC_CONTRACT_DEPLOYED: &str =
 /// selector key filter; contracts fetch everything the contract emitted) and
 /// the preferred primary data source — see [`fetch_events_routed`].
 #[derive(Debug, Clone, Copy)]
-pub(super) enum EventQueryKind {
+pub(crate) enum EventQueryKind {
     /// Account address — we want one event per invoke (`transaction_executed`).
     Account,
     /// Contract address — we want all events emitted by the contract.
@@ -167,8 +167,8 @@ pub(super) async fn fetch_events_routed(
 /// MetaTxs). Hoisting the common fetch here avoids running
 /// `get_events_for_address` + `get_txs_by_hash` twice — MetaTxs are a classified
 /// subset of the same tx rows the calls/txs tab needs.
-#[derive(Debug)]
-pub(super) struct AddressActivityPage {
+#[derive(Debug, Clone)]
+pub(crate) struct AddressActivityPage {
     /// Raw events for the address (TRANSACTION_EXECUTED for accounts,
     /// from_address filter for contracts).
     pub events: Vec<crate::data::types::SnEvent>,
@@ -201,7 +201,7 @@ pub(super) struct AddressActivityPage {
 /// the returned page and live in their own helpers.
 ///
 /// pf-query-only by design — the RPC fallback keeps the legacy per-tx flow.
-pub(super) async fn fetch_address_activity(
+pub(crate) async fn fetch_address_activity(
     address: starknet::core::types::Felt,
     kind: EventQueryKind,
     from_block: u64,
@@ -805,48 +805,94 @@ pub(super) async fn fetch_and_send_address_info(
         // on-chain nonce in the address info path; leave sender_* at 0.
         probe.callee_call_count = event_count;
         let _ = probe_watch_tx.send(Some(probe));
-    } else if let Some(dune_client) = dune {
-        let dune_p = Arc::clone(dune_client);
+    } else {
+        // No fresh cache — try pf-query first (when available), fall back to
+        // Dune if pf-query is absent or errors. pf-query's count endpoint
+        // walks the full range via bloom filters, so it matches Dune's
+        // activity-probe semantics without the external dependency.
+        let pf_probe: Option<Arc<crate::data::pathfinder::PathfinderClient>> =
+            pf.as_ref().map(Arc::clone);
+        let dune_probe: Option<Arc<dune::DuneClient>> = dune.as_ref().map(Arc::clone);
         let ds_probe = Arc::clone(ds);
         let tx_probe = tx.clone();
+        let probe_watch_tx_c = probe_watch_tx.clone();
         tokio::spawn(async move {
-            let _ = tx_probe.send(Action::LoadingStatus(
-                "Dune: probing activity range (events)...".into(),
-            ));
-            match dune_p.probe_address_activity(address).await {
-                Ok(probe) => {
-                    if probe.has_activity() {
-                        let _ = tx_probe.send(Action::LoadingStatus(format!(
-                            "Dune probe: {} events, blocks {}..{}",
-                            probe.callee_call_count,
-                            probe.min_block(),
-                            probe.max_block(),
-                        )));
-                        // Cache the discovered range + event count for next time.
-                        let total_events = probe.callee_call_count;
-                        ds_probe.save_activity_range_with_count(
-                            &address,
-                            probe.min_block(),
-                            probe.max_block(),
-                            total_events,
-                        );
-                    } else {
-                        let _ = tx_probe.send(Action::LoadingStatus(
-                            "Dune probe: no activity found".into(),
-                        ));
-                    }
-                    // Send probe to UI for pagination window sizing.
-                    let _ = tx_probe.send(Action::AddressProbeLoaded {
-                        address,
-                        probe: probe.clone(),
-                    });
-                    let _ = probe_watch_tx.send(Some(probe));
-                }
-                Err(e) => {
-                    warn!(error = %e, "Dune activity probe failed");
+            // Common post-success step: cache the discovered range, emit the
+            // UI action, and publish on the watch channel so downstream tasks
+            // can size their windows.
+            let publish = |probe: dune::AddressActivityProbe, label: &str| {
+                if probe.has_activity() {
+                    let _ = tx_probe.send(Action::LoadingStatus(format!(
+                        "{label}: {} events, blocks {}..{}",
+                        probe.callee_call_count,
+                        probe.min_block(),
+                        probe.max_block(),
+                    )));
+                    ds_probe.save_activity_range_with_count(
+                        &address,
+                        probe.min_block(),
+                        probe.max_block(),
+                        probe.callee_call_count,
+                    );
+                } else {
                     let _ =
-                        tx_probe.send(Action::LoadingStatus(format!("Dune probe failed: {}", e)));
-                    // Leave watch at None — tasks will use default windows.
+                        tx_probe.send(Action::LoadingStatus(format!("{label}: no activity found")));
+                }
+                let _ = tx_probe.send(Action::AddressProbeLoaded {
+                    address,
+                    probe: probe.clone(),
+                });
+                let _ = probe_watch_tx_c.send(Some(probe));
+            };
+
+            // 1. Try pf-query first.
+            if let Some(pf_c) = pf_probe.as_ref() {
+                let _ = tx_probe.send(Action::LoadingStatus(
+                    "PF: probing activity range (events)...".into(),
+                ));
+                match pf_c
+                    .get_contract_event_count(address, None, None, &[])
+                    .await
+                {
+                    Ok(count) => {
+                        let probe = dune::AddressActivityProbe {
+                            callee_call_count: count.count,
+                            callee_min_block: count.min_block.unwrap_or(0),
+                            callee_max_block: count.max_block.unwrap_or(0),
+                            ..Default::default()
+                        };
+                        if !count.complete {
+                            warn!(
+                                "pf-query event-count hit candidate cap; count={} is a lower bound",
+                                count.count
+                            );
+                        }
+                        publish(probe, "PF probe");
+                        return;
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "pf-query activity probe failed, falling back to Dune");
+                        let _ = tx_probe.send(Action::LoadingStatus(format!(
+                            "PF probe failed ({}); trying Dune...",
+                            e
+                        )));
+                    }
+                }
+            }
+
+            // 2. Fall back to Dune.
+            if let Some(dune_c) = dune_probe.as_ref() {
+                let _ = tx_probe.send(Action::LoadingStatus(
+                    "Dune: probing activity range (events)...".into(),
+                ));
+                match dune_c.probe_address_activity(address).await {
+                    Ok(probe) => publish(probe, "Dune probe"),
+                    Err(e) => {
+                        warn!(error = %e, "Dune activity probe failed");
+                        let _ = tx_probe
+                            .send(Action::LoadingStatus(format!("Dune probe failed: {}", e)));
+                        // Leave watch at None — tasks will use default windows.
+                    }
                 }
             }
         });
@@ -925,276 +971,135 @@ pub(super) async fn fetch_and_send_address_info(
     }
 
     // =====================================================================
-    // TASK B: Dune query — narrow windowed fetch for fast initial display
+    // TASK B1: Contract calls — pf-query primary, RPC fallback, always runs
+    // for contracts regardless of Dune availability. The prior Dune-backed
+    // bulk fetch was replaced by the unified event_window path so all three
+    // event-derived tabs share one cursor + additive cache.
     // =====================================================================
-    if let Some(dune_client) = dune {
-        let dune_c = Arc::clone(dune_client);
+    if is_contract {
+        let ds_b = Arc::clone(ds);
         let tx_b = tx.clone();
         let abi_b = Arc::clone(abi_reg);
-        let ds_b = Arc::clone(ds);
         let pf_b = pf.as_ref().map(Arc::clone);
+        tokio::spawn(async move {
+            let _ = tx_b.send(Action::LoadingStatus(
+                "Calls: fetching via event window...".into(),
+            ));
+            fetch_address_contract_calls(
+                address,
+                &ds_b,
+                pf_b.as_ref(),
+                &abi_b,
+                &tx_b,
+                nonce,
+                class_hash,
+            )
+            .await;
+            // Stream completion marker so source tracking clears the loading
+            // flag; tx_summaries is empty because Calls populate via
+            // AddressInfoLoaded.contract_calls, not via AddressTxsStreamed.
+            let _ = tx_b.send(Action::AddressTxsStreamed {
+                address,
+                source: Source::Dune,
+                tx_summaries: Vec::new(),
+                complete: true,
+            });
+        });
+    }
+
+    // =====================================================================
+    // TASK B2: Dune windowed account-tx fetch — unchanged, still opt-in on
+    // Dune availability. Accounts fall back to Dune for the sender-tx tab
+    // when pf-query is unavailable; this is orthogonal to the Calls tab.
+    // =====================================================================
+    if !is_contract && let Some(dune_client) = dune {
+        let dune_c = Arc::clone(dune_client);
+        let tx_b = tx.clone();
+        let ds_b = Arc::clone(ds);
         let mut probe_rx_b = probe_watch_rx.clone();
         const DUNE_PAGE_LIMIT: u32 = 100;
         const INITIAL_WINDOW: u64 = 5_000;
 
-        if is_contract {
-            tokio::spawn(async move {
-                let _ = tx_b.send(Action::LoadingStatus(
-                    "Dune: fetching recent contract calls...".into(),
-                ));
-                let latest_block = ds_b.get_latest_block_number().await.unwrap_or(0);
-                let from = latest_block.saturating_sub(INITIAL_WINDOW);
+        // Account: windowed tx fetch
+        tokio::spawn(async move {
+            let _ = tx_b.send(Action::LoadingStatus(
+                "Dune: fetching recent account txs...".into(),
+            ));
+            let latest_block = ds_b.get_latest_block_number().await.unwrap_or(0);
+            let from = latest_block.saturating_sub(INITIAL_WINDOW);
 
-                let result = dune_c
-                    .query_contract_calls_windowed(address, from, latest_block, DUNE_PAGE_LIMIT)
-                    .await;
+            let result = dune_c
+                .query_account_txs_windowed(address, from, latest_block, DUNE_PAGE_LIMIT)
+                .await;
 
-                match result {
-                    Ok(calls) if !calls.is_empty() => {
-                        let _ =
-                            tx_b.send(dune_source_update(crate::app::state::SourceStatus::Live));
-                        let count = calls.len();
-                        info!(calls = count, "Dune windowed contract calls complete");
-
-                        let dune_calls =
-                            enrich_dune_calls(address, calls, &abi_b, &ds_b, pf_b.as_ref(), &tx_b)
-                                .await;
-
-                        if !dune_calls.is_empty() {
-                            let min_b = dune_calls.last().map(|c| c.block_number).unwrap_or(0);
-                            let max_b = dune_calls.first().map(|c| c.block_number).unwrap_or(0);
-                            let _ = tx_b.send(Action::LoadingStatus(format!(
-                                "Dune: {} calls, blocks {}..{}",
-                                dune_calls.len(),
-                                min_b,
-                                max_b
-                            )));
-                            // Cache calls for next visit
-                            ds_b.save_address_calls(&address, &dune_calls);
-                        }
-
-                        let _ = tx_b.send(Action::AddressInfoLoaded {
-                            info: crate::data::types::SnAddressInfo {
-                                address,
-                                nonce,
-                                class_hash,
-                                recent_events: Vec::new(),
-                                token_balances: Vec::new(),
-                            },
-                            decoded_events: Vec::new(),
-                            tx_summaries: Vec::new(),
-                            contract_calls: dune_calls,
-                        });
-
-                        let _ = tx_b.send(Action::AddressTxsStreamed {
-                            address,
-                            source: Source::Dune,
-                            tx_summaries: Vec::new(),
-                            complete: true,
-                        });
-                    }
-                    Ok(_) | Err(_) => {
-                        if let Err(ref e) = result {
-                            warn!(error = %e, "Dune windowed contract calls failed");
-                        }
-                        // Initial window empty — wait for probe, retry with probe-guided window
-                        let probe = tokio::time::timeout(
-                            tokio::time::Duration::from_secs(10),
-                            probe_rx_b.wait_for(|p| p.is_some()),
-                        )
-                        .await
-                        .ok()
-                        .and_then(|r| r.ok())
-                        .and_then(|p| p.clone());
-
-                        if let Some(p) = probe {
-                            if p.has_activity() {
-                                let window = p.recommended_window();
-                                let probe_from = p.max_block().saturating_sub(window);
-                                let probe_to = p.max_block();
-                                let _ = tx_b.send(Action::LoadingStatus(format!(
-                                    "Dune: retrying blocks {}..{} (probe-guided)...",
-                                    probe_from, probe_to
-                                )));
-                                match dune_c
-                                    .query_contract_calls_windowed(
-                                        address,
-                                        probe_from,
-                                        probe_to,
-                                        DUNE_PAGE_LIMIT,
-                                    )
-                                    .await
-                                {
-                                    Ok(calls) if !calls.is_empty() => {
-                                        let _ = tx_b.send(dune_source_update(
-                                            crate::app::state::SourceStatus::Live,
-                                        ));
-                                        let dune_calls = enrich_dune_calls(
-                                            address,
-                                            calls,
-                                            &abi_b,
-                                            &ds_b,
-                                            pf_b.as_ref(),
-                                            &tx_b,
-                                        )
-                                        .await;
-                                        if !dune_calls.is_empty() {
-                                            let min_b = dune_calls
-                                                .last()
-                                                .map(|c| c.block_number)
-                                                .unwrap_or(0);
-                                            let max_b = dune_calls
-                                                .first()
-                                                .map(|c| c.block_number)
-                                                .unwrap_or(0);
-                                            let _ = tx_b.send(Action::LoadingStatus(format!(
-                                                "Dune: {} calls, blocks {}..{}",
-                                                dune_calls.len(),
-                                                min_b,
-                                                max_b
-                                            )));
-                                            ds_b.save_address_calls(&address, &dune_calls);
-                                        }
-                                        let _ = tx_b.send(Action::AddressInfoLoaded {
-                                            info: crate::data::types::SnAddressInfo {
-                                                address,
-                                                nonce,
-                                                class_hash,
-                                                recent_events: Vec::new(),
-                                                token_balances: Vec::new(),
-                                            },
-                                            decoded_events: Vec::new(),
-                                            tx_summaries: Vec::new(),
-                                            contract_calls: dune_calls,
-                                        });
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
-
-                        let _ = tx_b.send(Action::AddressTxsStreamed {
-                            address,
-                            source: Source::Dune,
-                            tx_summaries: Vec::new(),
-                            complete: true,
-                        });
-                    }
+            match result {
+                Ok(dune_txs) if !dune_txs.is_empty() => {
+                    let _ = tx_b.send(dune_source_update(crate::app::state::SourceStatus::Live));
+                    info!(
+                        dune_txs = dune_txs.len(),
+                        "Dune windowed account txs complete"
+                    );
+                    let min_b = dune_txs.iter().map(|t| t.block_number).min().unwrap_or(0);
+                    let max_b = dune_txs.iter().map(|t| t.block_number).max().unwrap_or(0);
+                    let _ = tx_b.send(Action::LoadingStatus(format!(
+                        "Dune: {} txs, blocks {}..{}",
+                        dune_txs.len(),
+                        min_b,
+                        max_b
+                    )));
+                    let _ = tx_b.send(Action::AddressTxsStreamed {
+                        address,
+                        source: Source::Dune,
+                        tx_summaries: dune_txs,
+                        complete: true,
+                    });
                 }
-            });
-        } else {
-            // Account: windowed tx fetch
-            tokio::spawn(async move {
-                let _ = tx_b.send(Action::LoadingStatus(
-                    "Dune: fetching recent account txs...".into(),
-                ));
-                let latest_block = ds_b.get_latest_block_number().await.unwrap_or(0);
-                let from = latest_block.saturating_sub(INITIAL_WINDOW);
-
-                let result = dune_c
-                    .query_account_txs_windowed(address, from, latest_block, DUNE_PAGE_LIMIT)
-                    .await;
-
-                match result {
-                    Ok(dune_txs) if !dune_txs.is_empty() => {
-                        let _ =
-                            tx_b.send(dune_source_update(crate::app::state::SourceStatus::Live));
-                        info!(
-                            dune_txs = dune_txs.len(),
-                            "Dune windowed account txs complete"
-                        );
-                        let min_b = dune_txs.iter().map(|t| t.block_number).min().unwrap_or(0);
-                        let max_b = dune_txs.iter().map(|t| t.block_number).max().unwrap_or(0);
-                        let _ = tx_b.send(Action::LoadingStatus(format!(
-                            "Dune: {} txs, blocks {}..{}",
-                            dune_txs.len(),
-                            min_b,
-                            max_b
-                        )));
-                        let _ = tx_b.send(Action::AddressTxsStreamed {
-                            address,
-                            source: Source::Dune,
-                            tx_summaries: dune_txs,
-                            complete: true,
-                        });
+                Ok(_) | Err(_) => {
+                    if let Err(ref e) = result {
+                        warn!(error = %e, "Dune windowed account txs failed");
                     }
-                    Ok(_) | Err(_) => {
-                        if let Err(ref e) = result {
-                            warn!(error = %e, "Dune windowed account txs failed");
-                        }
-                        // Initial window empty — wait for probe, retry with probe-guided window
-                        let probe = tokio::time::timeout(
-                            tokio::time::Duration::from_secs(10),
-                            probe_rx_b.wait_for(|p| p.is_some()),
-                        )
-                        .await
-                        .ok()
-                        .and_then(|r| r.ok())
-                        .and_then(|p| p.clone());
+                    // Initial window empty — wait for probe, retry with probe-guided window
+                    let probe = tokio::time::timeout(
+                        tokio::time::Duration::from_secs(10),
+                        probe_rx_b.wait_for(|p| p.is_some()),
+                    )
+                    .await
+                    .ok()
+                    .and_then(|r| r.ok())
+                    .and_then(|p| p.clone());
 
-                        if let Some(p) = probe {
-                            if p.has_activity() {
-                                let window = p.recommended_window();
-                                let probe_from = p.max_block().saturating_sub(window);
-                                let probe_to = p.max_block();
-                                let _ = tx_b.send(Action::LoadingStatus(format!(
-                                    "Dune: retrying blocks {}..{} (probe-guided)...",
-                                    probe_from, probe_to
-                                )));
-                                match dune_c
-                                    .query_account_txs_windowed(
-                                        address,
-                                        probe_from,
-                                        probe_to,
-                                        DUNE_PAGE_LIMIT,
-                                    )
-                                    .await
-                                {
-                                    Ok(txs) if !txs.is_empty() => {
-                                        let _ = tx_b.send(dune_source_update(
-                                            crate::app::state::SourceStatus::Live,
-                                        ));
-                                        let min_b =
-                                            txs.iter().map(|t| t.block_number).min().unwrap_or(0);
-                                        let max_b =
-                                            txs.iter().map(|t| t.block_number).max().unwrap_or(0);
-                                        let _ = tx_b.send(Action::LoadingStatus(format!(
-                                            "Dune: {} txs, blocks {}..{}",
-                                            txs.len(),
-                                            min_b,
-                                            max_b
-                                        )));
-                                        let _ = tx_b.send(Action::AddressTxsStreamed {
-                                            address,
-                                            source: Source::Dune,
-                                            tx_summaries: txs,
-                                            complete: true,
-                                        });
-                                    }
-                                    _ => {
-                                        let _ = tx_b.send(Action::AddressTxsStreamed {
-                                            address,
-                                            source: Source::Dune,
-                                            tx_summaries: Vec::new(),
-                                            complete: true,
-                                        });
-                                    }
-                                }
-                            } else {
-                                let _ = tx_b.send(Action::AddressTxsStreamed {
+                    if let Some(p) = probe {
+                        if p.has_activity() {
+                            let window = p.recommended_window();
+                            let probe_from = p.max_block().saturating_sub(window);
+                            let probe_to = p.max_block();
+                            let _ = tx_b.send(Action::LoadingStatus(format!(
+                                "Dune: retrying blocks {}..{} (probe-guided)...",
+                                probe_from, probe_to
+                            )));
+                            match dune_c
+                                .query_account_txs_windowed(
                                     address,
-                                    source: Source::Dune,
-                                    tx_summaries: Vec::new(),
-                                    complete: true,
-                                });
-                            }
-                        } else {
-                            // No probe available — fall back to unwindowed query with tight limit
-                            match dune_c.query_account_txs(address, DUNE_PAGE_LIMIT).await {
-                                Ok(txs) => {
+                                    probe_from,
+                                    probe_to,
+                                    DUNE_PAGE_LIMIT,
+                                )
+                                .await
+                            {
+                                Ok(txs) if !txs.is_empty() => {
                                     let _ = tx_b.send(dune_source_update(
                                         crate::app::state::SourceStatus::Live,
                                     ));
+                                    let min_b =
+                                        txs.iter().map(|t| t.block_number).min().unwrap_or(0);
+                                    let max_b =
+                                        txs.iter().map(|t| t.block_number).max().unwrap_or(0);
+                                    let _ = tx_b.send(Action::LoadingStatus(format!(
+                                        "Dune: {} txs, blocks {}..{}",
+                                        txs.len(),
+                                        min_b,
+                                        max_b
+                                    )));
                                     let _ = tx_b.send(Action::AddressTxsStreamed {
                                         address,
                                         source: Source::Dune,
@@ -1202,11 +1107,7 @@ pub(super) async fn fetch_and_send_address_info(
                                         complete: true,
                                     });
                                 }
-                                Err(e) => {
-                                    warn!(error = %e, "Dune account txs fallback failed");
-                                    let _ = tx_b.send(dune_source_update(
-                                        crate::app::state::SourceStatus::FetchError(e.to_string()),
-                                    ));
+                                _ => {
                                     let _ = tx_b.send(Action::AddressTxsStreamed {
                                         address,
                                         source: Source::Dune,
@@ -1215,11 +1116,45 @@ pub(super) async fn fetch_and_send_address_info(
                                     });
                                 }
                             }
+                        } else {
+                            let _ = tx_b.send(Action::AddressTxsStreamed {
+                                address,
+                                source: Source::Dune,
+                                tx_summaries: Vec::new(),
+                                complete: true,
+                            });
+                        }
+                    } else {
+                        // No probe available — fall back to unwindowed query with tight limit
+                        match dune_c.query_account_txs(address, DUNE_PAGE_LIMIT).await {
+                            Ok(txs) => {
+                                let _ = tx_b.send(dune_source_update(
+                                    crate::app::state::SourceStatus::Live,
+                                ));
+                                let _ = tx_b.send(Action::AddressTxsStreamed {
+                                    address,
+                                    source: Source::Dune,
+                                    tx_summaries: txs,
+                                    complete: true,
+                                });
+                            }
+                            Err(e) => {
+                                warn!(error = %e, "Dune account txs fallback failed");
+                                let _ = tx_b.send(dune_source_update(
+                                    crate::app::state::SourceStatus::FetchError(e.to_string()),
+                                ));
+                                let _ = tx_b.send(Action::AddressTxsStreamed {
+                                    address,
+                                    source: Source::Dune,
+                                    tx_summaries: Vec::new(),
+                                    complete: true,
+                                });
+                            }
                         }
                     }
                 }
-            });
-        }
+            }
+        });
     }
 
     // =====================================================================
@@ -2912,22 +2847,32 @@ pub(super) async fn derive_meta_txs_from_page(
 
 /// Fetch meta-transactions where `address` is the intender (issue #11).
 ///
-/// Thin wrapper over the shared `fetch_address_activity` pipeline plus the
-/// MetaTx-specific `derive_meta_txs_from_page` derivation. Used when the
-/// dispatcher hasn't already produced a shared page for another tab.
+/// Backed by [`crate::network::event_window::ensure_address_events_window`] so
+/// events flow through a single persistent cache shared with the Calls/Events
+/// tabs. The `continuation_token` input is repurposed as a "fetch older" flag:
 ///
-/// Sends `Action::AddressMetaTxsLoaded` when done. On pf-query failures, sends
-/// an empty result so the UI clears its "loading" state rather than hanging.
+/// - `None`           → [`EventWindowPolicy::TopDelta`] (tip-of-chain, cold or delta)
+/// - `Some(_)`        → [`EventWindowPolicy::ExtendDown`] (scan below cached floor)
+///
+/// The returned `next_token` carries `min_searched` when more older events
+/// remain, or `None` when we've reached genesis. The UI treats it as
+/// opaque — whatever lands in the response gets echoed back on the next call.
+///
+/// `from_block` / `limit` are currently ignored; kept in the Action schema
+/// until all three event-derived tabs are on the helper and we can cleanly
+/// collapse the Action surface.
 pub(super) async fn fetch_address_meta_txs(
     address: starknet::core::types::Felt,
-    from_block: u64,
+    _from_block: u64,
     continuation_token: Option<u64>,
-    limit: u32,
+    _limit: u32,
     ds: &Arc<dyn crate::data::DataSource>,
     pf: &Arc<crate::data::pathfinder::PathfinderClient>,
     abi_reg: &Arc<AbiRegistry>,
     action_tx: &mpsc::UnboundedSender<Action>,
 ) {
+    use crate::network::event_window::{EventWindowPolicy, ensure_address_events_window};
+
     let send_empty = || {
         let _ = action_tx.send(Action::AddressMetaTxsLoaded {
             address,
@@ -2936,50 +2881,198 @@ pub(super) async fn fetch_address_meta_txs(
         });
     };
 
-    let page = match fetch_address_activity(
-        address,
-        EventQueryKind::Account,
-        from_block,
-        continuation_token,
-        limit,
-        pf,
-    )
-    .await
-    {
-        Ok(p) => p,
+    // Latest block anchors the TopDelta window and all gap math.
+    let latest_block = match ds.get_latest_block_number().await {
+        Ok(b) => b,
         Err(e) => {
-            warn!(addr = %format!("{:#x}", address), error = %e, "MetaTxs: activity fetch failed");
+            warn!(addr = %format!("{:#x}", address), error = %e, "MetaTxs: latest block fetch failed");
             send_empty();
             return;
         }
     };
 
-    if page.events.is_empty() {
-        debug!(addr = %format!("{:#x}", address), "MetaTxs: no events returned");
-        send_empty();
+    let policy = match continuation_token {
+        None => EventWindowPolicy::TopDelta,
+        Some(_) => EventWindowPolicy::ExtendDown,
+    };
+
+    let ds_dyn: Arc<dyn crate::data::DataSource> = ds.clone();
+    let outcome = match ensure_address_events_window(
+        address,
+        EventQueryKind::Account,
+        policy,
+        Some(pf),
+        &ds_dyn,
+        latest_block,
+    )
+    .await
+    {
+        Ok(o) => o,
+        Err(e) => {
+            warn!(addr = %format!("{:#x}", address), error = %e, "MetaTxs: event window fetch failed");
+            send_empty();
+            return;
+        }
+    };
+
+    // `ExtendDown` past genesis returns an empty page — still emit an empty
+    // response so the UI clears its loading flag and flips has_more=false.
+    if outcome.page.events.is_empty() {
+        debug!(
+            addr = %format!("{:#x}", address),
+            min_searched = outcome.min_searched,
+            max_searched = outcome.max_searched,
+            "MetaTxs: no new events in this window"
+        );
+        let _ = action_tx.send(Action::AddressMetaTxsLoaded {
+            address,
+            summaries: Vec::new(),
+            next_token: if outcome.min_searched > 0 {
+                Some(outcome.min_searched)
+            } else {
+                None
+            },
+        });
         return;
     }
 
-    let summaries = derive_meta_txs_from_page(address, &page, abi_reg).await;
+    let summaries = derive_meta_txs_from_page(address, &outcome.page, abi_reg).await;
 
     info!(
         addr = %format!("{:#x}", address),
-        events = page.events.len(),
-        candidates = page.tx_rows.len(),
+        events = outcome.page.events.len(),
+        candidates = outcome.page.tx_rows.len(),
         meta_txs = summaries.len(),
-        has_more = page.next_token.is_some(),
+        min_searched = outcome.min_searched,
+        max_searched = outcome.max_searched,
+        deferred_gap = ?outcome.deferred_gap,
         "MetaTxs: classified"
     );
 
-    // Persist so the next tab entry can render instantly from cache.
     if !summaries.is_empty() {
         ds.save_meta_txs(&address, &summaries);
     }
 
+    // Signal "has more older" via Some(min_searched). The UI doesn't interpret
+    // the value — it just checks is_some and echoes it back on the next call.
+    let next_token = if outcome.min_searched > 0 {
+        Some(outcome.min_searched)
+    } else {
+        None
+    };
+
     let _ = action_tx.send(Action::AddressMetaTxsLoaded {
         address,
         summaries,
-        next_token: page.next_token,
+        next_token,
+    });
+}
+
+/// Fetch a window of contract events for `address` and emit the resulting
+/// [`ContractCallSummary`](crate::data::types::ContractCallSummary) rows as
+/// `AddressInfoLoaded { contract_calls, .. }`.
+///
+/// Mirrors [`fetch_address_meta_txs`] but for the Calls tab. Works with or
+/// without pf-query:
+/// - **pf available** → `ensure_address_events_window` bulk-fetches tx rows
+///   alongside events, and we build summaries directly via
+///   [`build_contract_calls_from_pf_rows`] (no per-tx RPC).
+/// - **pf absent** → the window helper returns events with empty `tx_rows`;
+///   we fall back to [`build_contract_calls_from_hashes`] which fetches tx
+///   + receipt per hash through the [`DataSource`].
+///
+/// Emission uses the same `AddressInfoLoaded` merge path that the legacy
+/// Dune bulk fetch used, so the UI reducer in the app state machine needs
+/// no changes.
+pub(super) async fn fetch_address_contract_calls(
+    address: starknet::core::types::Felt,
+    ds: &Arc<dyn crate::data::DataSource>,
+    pf: Option<&Arc<crate::data::pathfinder::PathfinderClient>>,
+    abi_reg: &Arc<AbiRegistry>,
+    action_tx: &mpsc::UnboundedSender<Action>,
+    nonce: starknet::core::types::Felt,
+    class_hash: Option<starknet::core::types::Felt>,
+) {
+    use crate::network::event_window::{EventWindowPolicy, ensure_address_events_window};
+
+    let latest_block = match ds.get_latest_block_number().await {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(addr = %format!("{:#x}", address), error = %e, "Calls: latest block fetch failed");
+            return;
+        }
+    };
+
+    let ds_dyn: Arc<dyn crate::data::DataSource> = ds.clone();
+    let outcome = match ensure_address_events_window(
+        address,
+        EventQueryKind::Contract,
+        EventWindowPolicy::TopDelta,
+        pf,
+        &ds_dyn,
+        latest_block,
+    )
+    .await
+    {
+        Ok(o) => o,
+        Err(e) => {
+            warn!(addr = %format!("{:#x}", address), error = %e, "Calls: event window fetch failed");
+            return;
+        }
+    };
+
+    if outcome.page.events.is_empty() {
+        debug!(
+            addr = %format!("{:#x}", address),
+            min_searched = outcome.min_searched,
+            max_searched = outcome.max_searched,
+            "Calls: no new events in this window"
+        );
+        return;
+    }
+
+    // pf path: tx_rows already populated. RPC fallback: derive from (hash, block).
+    let calls = if !outcome.page.tx_rows.is_empty() {
+        build_contract_calls_from_pf_rows(address, &outcome.page.tx_rows, abi_reg).await
+    } else {
+        let hashes_with_blocks: Vec<_> = outcome
+            .page
+            .unique_hashes
+            .iter()
+            .map(|h| (*h, *outcome.page.tx_block_map.get(h).unwrap_or(&0)))
+            .collect();
+        build_contract_calls_from_hashes(address, &hashes_with_blocks, ds, pf, abi_reg).await
+    };
+
+    info!(
+        addr = %format!("{:#x}", address),
+        events = outcome.page.events.len(),
+        calls = calls.len(),
+        min_searched = outcome.min_searched,
+        max_searched = outcome.max_searched,
+        deferred_gap = ?outcome.deferred_gap,
+        via_pf = pf.is_some(),
+        "Calls: window fetch complete"
+    );
+
+    if !calls.is_empty() {
+        ds.save_address_calls(&address, &calls);
+    }
+
+    // Emit using the same merge path the Dune bulk fetch used. An empty
+    // SnAddressInfo stub keeps the `AddressInfoLoaded` reducer happy without
+    // disturbing the nonce/class_hash that arrived via the primary info fetch.
+    let _ = action_tx.send(Action::AddressInfoLoaded {
+        info: crate::data::types::SnAddressInfo {
+            address,
+            nonce,
+            class_hash,
+            recent_events: Vec::new(),
+            token_balances: Vec::new(),
+        },
+        decoded_events: Vec::new(),
+        tx_summaries: Vec::new(),
+        contract_calls: calls,
     });
 }
 

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -3133,10 +3133,31 @@ pub(super) async fn fetch_address_contract_calls(
         return;
     };
 
-    let dune_calls = match dune_client
-        .query_contract_calls(address, CONTRACT_CALL_LIMIT)
-        .await
-    {
+    // TopDelta: if we've already cached rows for this address, only ask Dune
+    // for blocks strictly newer than the highest block we've seen. Cold cache
+    // still falls back to the unwindowed "500 most recent" fetch so first open
+    // on a long-lived contract stays cheap.
+    let max_cached_block = ds
+        .load_cached_address_calls(&address)
+        .iter()
+        .map(|c| c.block_number)
+        .filter(|&b| b > 0)
+        .max();
+
+    let dune_calls_result = match max_cached_block {
+        Some(from) => {
+            dune_client
+                .query_contract_calls_windowed(address, from + 1, u64::MAX, CONTRACT_CALL_LIMIT)
+                .await
+        }
+        None => {
+            dune_client
+                .query_contract_calls(address, CONTRACT_CALL_LIMIT)
+                .await
+        }
+    };
+
+    let dune_calls = match dune_calls_result {
         Ok(v) => v,
         Err(e) => {
             warn!(addr = %format!("{:#x}", address), error = %e, "Calls: Dune contract calls fetch failed");

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -792,8 +792,14 @@ pub(super) async fn fetch_and_send_address_info(
         )));
     }
 
-    // Spawn Dune activity probe — used by TASK B and TASK C to target the right block range.
-    // Uses starknet.events (3-4x cheaper than the old UNION ALL approach).
+    // Spawn activity probe — used by TASK B and TASK C to target the right block range.
+    // Source of truth is Dune's starknet.events (3-4x cheaper than the old UNION ALL approach).
+    // We intentionally no longer probe pf-query here: `/contract-event-count` over the full
+    // `deploy..tip` range is an unkeyed bloom-scan whose cost grows with chain age, and on
+    // long-lived contracts it exceeds the 30s client deadline — it also blocks the concurrent
+    // event-window fetch on the same pf-query server. Counts for the Calls tab are grown
+    // from the scroll-backed `address_events` cache; see `call_count_fragment` in
+    // ui/views/address_info.rs.
     // watch channel so both TASK B (Dune) and TASK C (RPC) can observe the probe result.
     let (probe_watch_tx, probe_watch_rx) =
         tokio::sync::watch::channel::<Option<dune::AddressActivityProbe>>(None);
@@ -820,12 +826,10 @@ pub(super) async fn fetch_and_send_address_info(
         probe.callee_call_count = event_count;
         let _ = probe_watch_tx.send(Some(probe));
     } else {
-        // No fresh cache — try pf-query first (when available), fall back to
-        // Dune if pf-query is absent or errors. pf-query's count endpoint
-        // walks the full range via bloom filters, so it matches Dune's
-        // activity-probe semantics without the external dependency.
-        let pf_probe: Option<Arc<crate::data::pathfinder::PathfinderClient>> =
-            pf.as_ref().map(Arc::clone);
+        // No fresh cache — run the Dune activity probe if Dune is configured.
+        // Otherwise the watch channel stays `None` and downstream tasks fall
+        // back to their own default windows. See the outer comment for why
+        // pf-query is no longer a probe source.
         let dune_probe: Option<Arc<dune::DuneClient>> = dune.as_ref().map(Arc::clone);
         let ds_probe = Arc::clone(ds);
         let tx_probe = tx.clone();
@@ -859,70 +863,6 @@ pub(super) async fn fetch_and_send_address_info(
                 let _ = probe_watch_tx_c.send(Some(probe));
             };
 
-            // 1. Try pf-query first — but only with a `from_block` bound.
-            // Unbounded probes walk from genesis via bloom filters, which on
-            // busy accounts exceeds the 30s client timeout and causes Dune
-            // fallback for every single probe (observed 2026-04-19: 8/8 PF
-            // probes timed out). Resolve a hint from cached deploy info, or
-            // by querying class history (cheap PF nonce-table lookup).
-            let deploy_hint: Option<u64> =
-                if let Some((_, b, _)) = ds_probe.load_cached_deploy_info(&address) {
-                    Some(b)
-                } else if let Some(pf_c) = pf_probe.as_ref() {
-                    match pf_c.get_class_history(address).await {
-                        Ok(entries) => entries.last().map(|e| e.block_number),
-                        Err(e) => {
-                            debug!(
-                                error = %e,
-                                "PF class-history lookup for probe from_block hint failed"
-                            );
-                            None
-                        }
-                    }
-                } else {
-                    None
-                };
-
-            if let (Some(pf_c), Some(from_block)) = (pf_probe.as_ref(), deploy_hint) {
-                let _ = tx_probe.send(Action::LoadingStatus(format!(
-                    "PF: probing activity range (events, from block {from_block})..."
-                )));
-                match pf_c
-                    .get_contract_event_count(address, Some(from_block), None, &[])
-                    .await
-                {
-                    Ok(count) => {
-                        let probe = dune::AddressActivityProbe {
-                            callee_call_count: count.count,
-                            callee_min_block: count.min_block.unwrap_or(0),
-                            callee_max_block: count.max_block.unwrap_or(0),
-                            ..Default::default()
-                        };
-                        if !count.complete {
-                            warn!(
-                                "pf-query event-count hit candidate cap; count={} is a lower bound",
-                                count.count
-                            );
-                        }
-                        publish(probe, "PF probe");
-                        return;
-                    }
-                    Err(e) => {
-                        warn!(error = %e, "pf-query activity probe failed, falling back to Dune");
-                        let _ = tx_probe.send(Action::LoadingStatus(format!(
-                            "PF probe failed ({}); trying Dune...",
-                            e
-                        )));
-                    }
-                }
-            } else if pf_probe.is_some() {
-                debug!(
-                    addr = %format!("{:#x}", address),
-                    "Skipping PF probe: no deploy-block hint available (would scan from genesis)"
-                );
-            }
-
-            // 2. Fall back to Dune.
             if let Some(dune_c) = dune_probe.as_ref() {
                 let _ = tx_probe.send(Action::LoadingStatus(
                     "Dune: probing activity range (events)...".into(),
@@ -1023,6 +963,7 @@ pub(super) async fn fetch_and_send_address_info(
         let tx_b = tx.clone();
         let abi_b = Arc::clone(abi_reg);
         let dune_b = dune.as_ref().map(Arc::clone);
+        let pf_b = pf.as_ref().map(Arc::clone);
         tokio::spawn(async move {
             let _ = tx_b.send(Action::LoadingStatus(
                 "Calls: fetching from Dune...".into(),
@@ -1031,6 +972,7 @@ pub(super) async fn fetch_and_send_address_info(
                 address,
                 &ds_b,
                 dune_b.as_ref(),
+                pf_b.as_ref(),
                 &abi_b,
                 &tx_b,
                 nonce,
@@ -1283,6 +1225,7 @@ pub(super) async fn fetch_and_send_address_info(
                 pf_c.as_ref(),
                 &ds_dyn,
                 latest_block,
+                0, // TopDelta doesn't scan old history; floor is unused.
             )
             .await
             {
@@ -2897,32 +2840,45 @@ pub(super) async fn derive_meta_txs_from_page(
 /// tabs. The `continuation_token` input is repurposed as a "fetch older" flag:
 ///
 /// - `None`           → [`EventWindowPolicy::TopDelta`] (tip-of-chain, cold or delta)
-/// - `Some(_)`        → [`EventWindowPolicy::ExtendDown`] (scan below cached floor)
+/// - `Some(_)`        → [`EventWindowPolicy::ExtendDown { window_size }`]
+///   (scan below cached floor, adaptive window size)
+///
+/// `from_block` is the absolute scan floor (typically deploy block) — the
+/// helper won't scan below it. When `min_searched <= from_block` we return
+/// `next_token = None` to signal "reached floor, stop paginating".
+///
+/// `window_size` is the block range size for the next ExtendDown page; the
+/// caller tracks it across calls (`meta_tx_last_window`) and the helper
+/// returns a suggested next size adapted to the observed hit density.
 ///
 /// The returned `next_token` carries `min_searched` when more older events
-/// remain, or `None` when we've reached genesis. The UI treats it as
+/// remain, or `None` when we've reached the floor. The UI treats it as
 /// opaque — whatever lands in the response gets echoed back on the next call.
 ///
-/// `from_block` / `limit` are currently ignored; kept in the Action schema
-/// until all three event-derived tabs are on the helper and we can cleanly
-/// collapse the Action surface.
+/// `limit` is currently ignored; kept in the Action schema until all three
+/// event-derived tabs are on the helper and we can cleanly collapse the
+/// Action surface.
 pub(super) async fn fetch_address_meta_txs(
     address: starknet::core::types::Felt,
-    _from_block: u64,
+    from_block: u64,
     continuation_token: Option<u64>,
+    window_size: u64,
     _limit: u32,
     ds: &Arc<dyn crate::data::DataSource>,
     pf: &Arc<crate::data::pathfinder::PathfinderClient>,
     abi_reg: &Arc<AbiRegistry>,
     action_tx: &mpsc::UnboundedSender<Action>,
 ) {
-    use crate::network::event_window::{EventWindowPolicy, ensure_address_events_window};
+    use crate::network::event_window::{
+        EXTEND_DOWN_INITIAL_WINDOW, EventWindowPolicy, ensure_address_events_window,
+    };
 
     let send_empty = || {
         let _ = action_tx.send(Action::AddressMetaTxsLoaded {
             address,
             summaries: Vec::new(),
             next_token: None,
+            next_window_size: None,
         });
     };
 
@@ -2936,9 +2892,18 @@ pub(super) async fn fetch_address_meta_txs(
         }
     };
 
+    // Guard against a 0 coming in from state defaults: use the initial window.
+    let effective_window = if window_size == 0 {
+        EXTEND_DOWN_INITIAL_WINDOW
+    } else {
+        window_size
+    };
+
     let policy = match continuation_token {
         None => EventWindowPolicy::TopDelta,
-        Some(_) => EventWindowPolicy::ExtendDown,
+        Some(_) => EventWindowPolicy::ExtendDown {
+            window_size: effective_window,
+        },
     };
 
     let ds_dyn: Arc<dyn crate::data::DataSource> = ds.clone();
@@ -2949,6 +2914,7 @@ pub(super) async fn fetch_address_meta_txs(
         Some(pf),
         &ds_dyn,
         latest_block,
+        from_block,
     )
     .await
     {
@@ -2967,20 +2933,30 @@ pub(super) async fn fetch_address_meta_txs(
         deferred_gap: outcome.deferred_gap,
     });
 
-    // `ExtendDown` past genesis returns an empty page — still emit an empty
+    // Stop paginating once we've scanned down to (or past) the deploy-block
+    // floor. The UI uses `next_token = None` as the "done" signal.
+    let has_more_below = outcome.min_searched > from_block;
+
+    // `ExtendDown` past floor returns an empty page — still emit an empty
     // response so the UI clears its loading flag and flips has_more=false.
     if outcome.page.events.is_empty() {
         debug!(
             addr = %format!("{:#x}", address),
             min_searched = outcome.min_searched,
             max_searched = outcome.max_searched,
+            floor = from_block,
             "MetaTxs: no new events in this window"
         );
         let _ = action_tx.send(Action::AddressMetaTxsLoaded {
             address,
             summaries: Vec::new(),
-            next_token: if outcome.min_searched > 0 {
+            next_token: if has_more_below {
                 Some(outcome.min_searched)
+            } else {
+                None
+            },
+            next_window_size: if has_more_below {
+                outcome.suggested_next_window
             } else {
                 None
             },
@@ -2997,6 +2973,8 @@ pub(super) async fn fetch_address_meta_txs(
         meta_txs = summaries.len(),
         min_searched = outcome.min_searched,
         max_searched = outcome.max_searched,
+        floor = from_block,
+        suggested_next_window = ?outcome.suggested_next_window,
         deferred_gap = ?outcome.deferred_gap,
         "MetaTxs: classified"
     );
@@ -3007,8 +2985,13 @@ pub(super) async fn fetch_address_meta_txs(
 
     // Signal "has more older" via Some(min_searched). The UI doesn't interpret
     // the value — it just checks is_some and echoes it back on the next call.
-    let next_token = if outcome.min_searched > 0 {
+    let next_token = if has_more_below {
         Some(outcome.min_searched)
+    } else {
+        None
+    };
+    let next_window_size = if has_more_below {
+        outcome.suggested_next_window
     } else {
         None
     };
@@ -3017,6 +3000,7 @@ pub(super) async fn fetch_address_meta_txs(
         address,
         summaries,
         next_token,
+        next_window_size,
     });
 }
 
@@ -3037,6 +3021,7 @@ pub(super) async fn fetch_address_contract_calls(
     address: starknet::core::types::Felt,
     ds: &Arc<dyn crate::data::DataSource>,
     dune: Option<&Arc<dune::DuneClient>>,
+    pf: Option<&Arc<crate::data::pathfinder::PathfinderClient>>,
     abi_reg: &Arc<AbiRegistry>,
     action_tx: &mpsc::UnboundedSender<Action>,
     nonce: starknet::core::types::Felt,
@@ -3052,7 +3037,7 @@ pub(super) async fn fetch_address_contract_calls(
         return;
     };
 
-    let mut calls = match dune_client
+    let dune_calls = match dune_client
         .query_contract_calls(address, CONTRACT_CALL_LIMIT)
         .await
     {
@@ -3063,19 +3048,11 @@ pub(super) async fn fetch_address_contract_calls(
         }
     };
 
-    // Dune returns the entry_point_selector as hex in `function_name`; resolve
-    // it through the ABI registry so the UI shows readable names.
-    helpers::prewarm_abis([address], abi_reg).await;
-    for c in &mut calls {
-        if let Ok(sel) = starknet::core::types::Felt::from_hex(&c.function_name) {
-            c.function_name = helpers::format_selector_name_or_hex(&sel, abi_reg);
-        }
-    }
-
-    // A single tx can call the same contract multiple times (multicall, nested
-    // calls). Dune returns one row per call, so merge them into one entry per
-    // tx with function names joined in Dune's trace order.
-    let calls = crate::data::types::deduplicate_contract_calls(calls);
+    // Resolve selectors, dedupe, and backfill real sender + fee + timestamp.
+    // Dune's `starknet.calls.caller_address` is the immediate caller (often a
+    // router like Ekubo), not the outer tx sender; `enrich_dune_calls` replaces
+    // it with `fetched_tx.sender()` and fills in fee/timestamp from the receipt.
+    let calls = enrich_dune_calls(address, dune_calls, abi_reg, ds, pf, action_tx).await;
 
     info!(
         addr = %format!("{:#x}", address),

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -1158,7 +1158,16 @@ pub(super) async fn fetch_and_send_address_info(
             let latest_block = ds_c.get_latest_block_number().await.unwrap_or(0);
 
             // --- Use cached search progress + nonce delta to narrow the window ---
-            let search_progress = ds_c.load_search_progress(&address);
+            // TASK C's scan uses the same `kind` as ensure_address_events_window
+            // (derived from is_contract below at line ~1200). Match the
+            // filter_kind here so the cursor lookup and update land on the
+            // same row.
+            let filter_kind = if is_contract {
+                crate::data::FilterKind::Unkeyed
+            } else {
+                crate::data::FilterKind::Keyed
+            };
+            let search_progress = ds_c.load_search_progress(&address, filter_kind);
 
             // If nonce hasn't changed and we've already searched up to near the tip,
             // skip the full search — only check the small delta.
@@ -1642,7 +1651,7 @@ pub(super) async fn fetch_and_send_address_info(
             // Save search progress only when events were found — otherwise the initial
             // window may have been too small and we need to retry with probe guidance.
             if any_events_found {
-                ds_c.save_search_progress(&address, from_block, latest_block);
+                ds_c.save_search_progress(&address, filter_kind, from_block, latest_block);
             }
 
             // RPC task complete

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -3,9 +3,11 @@
 
 use std::sync::Arc;
 
+use std::future::Future;
 use std::sync::LazyLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::{Semaphore, mpsc};
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 /// Caps concurrent RPC `get_transaction` / `get_receipt` calls fired from the
@@ -14,6 +16,24 @@ use tracing::{debug, info, warn};
 /// pf-query is unavailable (or didn't return the requested hash). User clicks
 /// bypass this semaphore entirely.
 static ENRICH_RPC_SEMAPHORE: LazyLock<Semaphore> = LazyLock::new(|| Semaphore::new(8));
+
+/// Spawn a detached sub-task that aborts when `cancel` fires. Used for every
+/// background task fanned out from `fetch_and_send_address_info` so that
+/// foreground navigation to a new address stops stale RPC/Dune/PF enrichment
+/// work piling up on shared clients.
+fn spawn_cancellable<F>(cancel: CancellationToken, fut: F) -> tokio::task::JoinHandle<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(async move {
+        tokio::select! {
+            _ = fut => {}
+            _ = cancel.cancelled() => {
+                debug!("Address sub-task cancelled on navigation");
+            }
+        }
+    })
+}
 
 use crate::app::actions::{Action, Source};
 use crate::data::DataSource;
@@ -565,11 +585,9 @@ pub(super) async fn build_contract_calls_from_hashes(
     // these multicalls by `address` — the Calls row's `function_name` column
     // mirrors what the block and tx detail views show for the same tx, i.e.
     // the entire top-level endpoint list (see `helpers::format_endpoint_names`).
-    // For contracts called only internally (e.g. Ekubo Core via an aggregator)
-    // this surfaces the aggregator's outer function name, which is consistent
-    // with the rest of the UI and avoids needing `starknet_traceTransaction`.
-    helpers::prewarm_abis([address], abi_reg).await;
-
+    // For contracts called only internally (e.g. via an aggregator) this
+    // surfaces the aggregator's outer function name, which is consistent with
+    // the rest of the UI and avoids needing `starknet_traceTransaction`.
     let mut calls_list = Vec::new();
     for chunk in hashes_with_blocks.chunks(20) {
         let futs: Vec<_> = chunk
@@ -587,9 +605,10 @@ pub(super) async fn build_contract_calls_from_hashes(
             .collect();
         let results = futures::future::join_all(futs).await;
 
-        // Prewarm the ABIs for the top-level call targets we're about to
-        // format, otherwise `format_endpoint_names` would hit a cold registry
-        // for the aggregator/router contracts and fall back to hex.
+        // Prewarm `{address} ∪ multicall targets` in one pass. `address`
+        // covers direct calls to the inspected contract; the multicall
+        // targets cover aggregator/router routes that would otherwise hit a
+        // cold registry in `format_endpoint_names` and fall back to hex.
         let prewarm_targets: std::collections::HashSet<_> = results
             .iter()
             .filter_map(|(_, _, tx_r, _)| tx_r.as_ref().ok())
@@ -598,6 +617,7 @@ pub(super) async fn build_contract_calls_from_hashes(
                 _ => Vec::new(),
             })
             .map(|c| c.contract_address)
+            .chain(std::iter::once(address))
             .collect();
         helpers::prewarm_abis(prewarm_targets, abi_reg).await;
 
@@ -618,6 +638,7 @@ pub(super) async fn build_contract_calls_from_hashes(
                     .unwrap_or("?")
                     .to_string();
                 let function_name = helpers::format_endpoint_names(&fetched_tx, abi_reg);
+                let (nonce, tip) = helpers::extract_nonce_tip(&fetched_tx);
                 calls_list.push(crate::data::types::ContractCallSummary {
                     tx_hash: hash,
                     sender: fetched_tx.sender(),
@@ -626,6 +647,8 @@ pub(super) async fn build_contract_calls_from_hashes(
                     timestamp: 0,
                     total_fee_fri: fee_fri,
                     status,
+                    nonce: Some(nonce),
+                    tip,
                 });
             }
         }
@@ -702,6 +725,8 @@ pub(super) async fn build_contract_calls_from_pf_rows(
             timestamp: row.block_timestamp,
             total_fee_fri: fee_fri,
             status: row.status.clone(),
+            nonce: row.nonce,
+            tip: row.tip,
         });
     }
 
@@ -720,6 +745,7 @@ pub(super) async fn fetch_and_send_address_info(
     pf: &Option<Arc<crate::data::pathfinder::PathfinderClient>>,
     voyager_c: &Option<Arc<voyager::VoyagerClient>>,
     tx: &mpsc::UnboundedSender<Action>,
+    cancel: &CancellationToken,
 ) {
     let start = std::time::Instant::now();
     debug!(address = %format!("{:#x}", address), "Fetching address info");
@@ -729,7 +755,7 @@ pub(super) async fn fetch_and_send_address_info(
     {
         let ds_bal = Arc::clone(ds);
         let tx_bal = tx.clone();
-        tokio::spawn(async move {
+        spawn_cancellable(cancel.clone(), async move {
             let balances = fetch_token_balances(address, &ds_bal).await;
             let _ = tx_bal.send(Action::AddressBalancesLoaded { address, balances });
         });
@@ -739,7 +765,7 @@ pub(super) async fn fetch_and_send_address_info(
     if let Some(vc) = voyager_c {
         let vc = Arc::clone(vc);
         let tx_v = tx.clone();
-        tokio::spawn(async move {
+        spawn_cancellable(cancel.clone(), async move {
             voyager::fetch_and_send_label(address, &vc, &tx_v).await;
         });
     }
@@ -778,7 +804,8 @@ pub(super) async fn fetch_and_send_address_info(
         let ds_c = Arc::clone(ds);
         let tx_c = tx.clone();
         let addr = address;
-        tokio::spawn(async move {
+        let cancel_c = cancel.clone();
+        spawn_cancellable(cancel.clone(), async move {
             match pf_c.get_class_history(addr).await {
                 Ok(entries) => {
                     // Use earliest entry (deployment block) to find the deploy tx
@@ -786,10 +813,15 @@ pub(super) async fn fetch_and_send_address_info(
                         let deploy_block = deploy_entry.block_number;
                         let tx_c2 = tx_c.clone();
                         let ds_c2 = Arc::clone(&ds_c);
-                        tokio::spawn(async move {
+                        spawn_cancellable(cancel_c.clone(), async move {
                             find_deploy_tx(addr, deploy_block, &ds_c2, &tx_c2).await;
                         });
                     }
+                    debug!(
+                        address = %format!("{:#x}", addr),
+                        entries = entries.len(),
+                        "PF class history fetched"
+                    );
                     let _ = tx_c.send(Action::ClassHistoryLoaded {
                         address: addr,
                         entries,
@@ -821,29 +853,48 @@ pub(super) async fn fetch_and_send_address_info(
         sources: sources.clone(),
     });
 
-    // Send partial info immediately (cached txs seed the UI)
-    // Decode cached events so the Events tab renders instantly on revisit,
-    // mirroring the cache-first behaviour already in place for Txs/Calls.
-    // Live fetches downstream will emit AddressEventsStreamed with newer
-    // events; decoded_events here is the starting set the reducer can merge on.
+    // Send partial info immediately (cached txs seed the UI).
+    //
+    // The per-event ABI decode used to run inline here, gating the
+    // `AddressInfoLoaded` send on hundreds of `get_abi_for_address` calls
+    // (each potentially an RPC round-trip + SQLite cache mutex hop). Under
+    // any cache contention that loop could stretch to tens of seconds,
+    // keeping the "Fetching address info…" spinner up even though the
+    // tx/call caches were already in memory. Decode now runs in a
+    // background task; the Events tab renders when `AddressEventsCacheLoaded`
+    // arrives.
     let cached_events = ds.load_address_events(&address);
-    let mut cached_decoded = Vec::with_capacity(cached_events.len());
-    for event in &cached_events {
-        let abi = abi_reg.get_abi_for_address(&event.from_address).await;
-        cached_decoded.push(decode_event(event, abi.as_deref()));
-    }
     let _ = tx.send(Action::AddressInfoLoaded {
         info: crate::data::types::SnAddressInfo {
             address,
             nonce,
             class_hash,
-            recent_events: cached_events,
+            recent_events: cached_events.clone(),
             token_balances: Vec::new(),
         },
-        decoded_events: cached_decoded,
+        decoded_events: Vec::new(),
         tx_summaries: ds.load_cached_address_txs(&address),
         contract_calls: ds.load_cached_address_calls(&address),
     });
+
+    // Kick off the decode pass in the background. Cancellable so navigation
+    // away from this address doesn't leave the decoder chewing on a stale
+    // class-hash / ABI-fetch queue.
+    if !cached_events.is_empty() {
+        let abi_reg_c = Arc::clone(abi_reg);
+        let tx_c = tx.clone();
+        spawn_cancellable(cancel.clone(), async move {
+            let mut decoded = Vec::with_capacity(cached_events.len());
+            for event in &cached_events {
+                let abi = abi_reg_c.get_abi_for_address(&event.from_address).await;
+                decoded.push(decode_event(event, abi.as_deref()));
+            }
+            let _ = tx_c.send(Action::AddressEventsCacheLoaded {
+                address,
+                decoded_events: decoded,
+            });
+        });
+    }
 
     // Seed the MetaTxs tab count from cache up-front, like `tx_summaries` /
     // `contract_calls` above. Previously the cache was only loaded when the
@@ -886,9 +937,8 @@ pub(super) async fn fetch_and_send_address_info(
         tokio::sync::watch::channel::<Option<dune::AddressActivityProbe>>(None);
     // Load cached range WITH event count for accurate density calculation
     let cached_range_with_count = ds.load_cached_activity_range_with_count(&address);
-    if cached_range.is_some() {
+    if let Some((min_b, max_b)) = cached_range {
         // Build probe from cache — no Dune query needed.
-        let (min_b, max_b) = cached_range.unwrap();
         let event_count = cached_range_with_count
             .map(|(_, _, c)| c)
             .filter(|&c| c > 1) // Ignore stale rows with placeholder count
@@ -898,13 +948,15 @@ pub(super) async fn fetch_and_send_address_info(
                 let span = max_b.saturating_sub(min_b).max(1);
                 (span / 100).max(100)
             });
-        let mut probe = dune::AddressActivityProbe::default();
-        probe.callee_min_block = min_b;
-        probe.callee_max_block = max_b;
         // Cached count is derived from Dune's events-from-address query, which
         // populates callee activity only. Sender tx totals come from the
         // on-chain nonce in the address info path; leave sender_* at 0.
-        probe.callee_call_count = event_count;
+        let probe = dune::AddressActivityProbe {
+            callee_min_block: min_b,
+            callee_max_block: max_b,
+            callee_call_count: event_count,
+            ..Default::default()
+        };
         // Publish to both the UI reducer (so the Calls tab can show its
         // `shown / known+` fragment on re-entry from cache) AND the watch
         // channel (for downstream task window sizing). Previously only the
@@ -928,7 +980,7 @@ pub(super) async fn fetch_and_send_address_info(
         let ds_probe = Arc::clone(ds);
         let tx_probe = tx.clone();
         let probe_watch_tx_c = probe_watch_tx.clone();
-        tokio::spawn(async move {
+        spawn_cancellable(cancel.clone(), async move {
             // Common post-success step: cache the discovered range, emit the
             // UI action, and publish on the watch channel so downstream tasks
             // can size their windows.
@@ -966,10 +1018,12 @@ pub(super) async fn fetch_and_send_address_info(
                         // `shown / cached_count+` during the delta probe than
                         // regress to a bare `Calls(N)` for the seconds it
                         // takes Dune to respond (or forever, if Dune fails).
-                        let mut stale_probe = dune::AddressActivityProbe::default();
-                        stale_probe.callee_min_block = cached_min;
-                        stale_probe.callee_max_block = cached_max;
-                        stale_probe.callee_call_count = cached_count;
+                        let stale_probe = dune::AddressActivityProbe {
+                            callee_min_block: cached_min,
+                            callee_max_block: cached_max,
+                            callee_call_count: cached_count,
+                            ..Default::default()
+                        };
                         let _ = tx_probe.send(Action::AddressProbeLoaded {
                             address,
                             probe: stale_probe.clone(),
@@ -990,12 +1044,13 @@ pub(super) async fn fetch_and_send_address_info(
                                 // expands, count sums. `save_activity_range_with_count`
                                 // also merges at the DB layer, but we need a
                                 // fully-populated probe to publish to the UI.
-                                let mut merged = dune::AddressActivityProbe::default();
-                                merged.callee_min_block = cached_min;
-                                merged.callee_max_block =
-                                    delta.callee_max_block.max(cached_max);
-                                merged.callee_call_count =
-                                    cached_count.saturating_add(delta.callee_call_count);
+                                let merged = dune::AddressActivityProbe {
+                                    callee_min_block: cached_min,
+                                    callee_max_block: delta.callee_max_block.max(cached_max),
+                                    callee_call_count: cached_count
+                                        .saturating_add(delta.callee_call_count),
+                                    ..Default::default()
+                                };
                                 publish(merged, "Dune probe (delta)");
                             }
                             Err(e) => {
@@ -1044,7 +1099,7 @@ pub(super) async fn fetch_and_send_address_info(
             let tx_a = tx.clone();
             let ds_a = Arc::clone(ds);
             let pf_ok = Arc::clone(&pf_succeeded);
-            tokio::spawn(async move {
+            spawn_cancellable(cancel.clone(), async move {
                 const PF_LIMIT: u32 = 200;
                 let _ = tx_a.send(Action::LoadingStatus("PF: fetching tx history...".into()));
                 match pf_c.get_sender_txs(address, PF_LIMIT).await {
@@ -1116,10 +1171,8 @@ pub(super) async fn fetch_and_send_address_info(
         let abi_b = Arc::clone(abi_reg);
         let dune_b = dune.as_ref().map(Arc::clone);
         let pf_b = pf.as_ref().map(Arc::clone);
-        tokio::spawn(async move {
-            let _ = tx_b.send(Action::LoadingStatus(
-                "Calls: fetching from Dune...".into(),
-            ));
+        spawn_cancellable(cancel.clone(), async move {
+            let _ = tx_b.send(Action::LoadingStatus("Calls: fetching from Dune...".into()));
             fetch_address_contract_calls(
                 address,
                 &ds_b,
@@ -1134,6 +1187,12 @@ pub(super) async fn fetch_and_send_address_info(
             // Stream completion marker so source tracking clears the loading
             // flag; tx_summaries is empty because Calls populate via
             // AddressInfoLoaded.contract_calls, not via AddressTxsStreamed.
+            debug!(
+                address = %format!("{:#x}", address),
+                source = ?Source::Dune,
+                tx_summaries = 0,
+                "AddressTxsStreamed dispatching complete marker"
+            );
             let _ = tx_b.send(Action::AddressTxsStreamed {
                 address,
                 source: Source::Dune,
@@ -1157,7 +1216,7 @@ pub(super) async fn fetch_and_send_address_info(
         const INITIAL_WINDOW: u64 = 5_000;
 
         // Account: windowed tx fetch
-        tokio::spawn(async move {
+        spawn_cancellable(cancel.clone(), async move {
             let _ = tx_b.send(Action::LoadingStatus(
                 "Dune: fetching recent account txs...".into(),
             ));
@@ -1306,7 +1365,7 @@ pub(super) async fn fetch_and_send_address_info(
         let pf_c = pf.as_ref().map(Arc::clone);
         let mut probe_rx_c = probe_watch_rx.clone();
 
-        tokio::spawn(async move {
+        spawn_cancellable(cancel.clone(), async move {
             let latest_block = ds_c.get_latest_block_number().await.unwrap_or(0);
 
             // --- Use cached search progress + nonce delta to narrow the window ---
@@ -1351,7 +1410,7 @@ pub(super) async fn fetch_and_send_address_info(
             let window_size = latest_block.saturating_sub(from_block);
             let _ = tx_c.send(Action::LoadingStatus(format!(
                 "RPC: scanning {}k blocks for events...",
-                (window_size + 999) / 1000
+                window_size.div_ceil(1000)
             )));
             // Phase 1 page limit is now managed inside the event_window helper
             // (`EVENT_PAGE_LIMIT` in event_window.rs). The old per-caller
@@ -1384,43 +1443,42 @@ pub(super) async fn fetch_and_send_address_info(
                 "Events scan".to_string(),
             );
             let ds_dyn: Arc<dyn crate::data::DataSource> = ds_c.clone();
-            let pf_page: Option<AddressActivityPage> = match crate::network::event_window::ensure_address_events_window(
-                address,
-                kind,
-                crate::network::event_window::EventWindowPolicy::TopDelta,
-                pf_c.as_ref(),
-                &ds_dyn,
-                latest_block,
-                0, // TopDelta doesn't scan old history; floor is unused.
-            )
-            .await
-            {
-                Ok(o) => {
-                    let _ = tx_c.send(Action::AddressEventWindowUpdated {
-                        address,
-                        min_searched: o.min_searched,
-                        max_searched: o.max_searched,
-                        deferred_gap: o.deferred_gap,
-                    });
-                    Some(o.page)
-                }
-                Err(e) => {
-                    warn!(
-                        error = %e,
-                        address = %format!("{:#x}", address),
-                        "event_window fetch failed in TASK C"
-                    );
-                    let _ = tx_c.send(Action::LoadingStatus(format!(
-                        "Event fetch failed: {}",
-                        e
-                    )));
-                    let _ = tx_c.send(Action::SourceUpdate {
-                        source: Source::Rpc,
-                        status: crate::app::state::SourceStatus::FetchError(e.to_string()),
-                    });
-                    None
-                }
-            };
+            let pf_page: Option<AddressActivityPage> =
+                match crate::network::event_window::ensure_address_events_window(
+                    address,
+                    kind,
+                    crate::network::event_window::EventWindowPolicy::TopDelta,
+                    pf_c.as_ref(),
+                    &ds_dyn,
+                    latest_block,
+                    0, // TopDelta doesn't scan old history; floor is unused.
+                )
+                .await
+                {
+                    Ok(o) => {
+                        let _ = tx_c.send(Action::AddressEventWindowUpdated {
+                            address,
+                            min_searched: o.min_searched,
+                            max_searched: o.max_searched,
+                            deferred_gap: o.deferred_gap,
+                        });
+                        Some(o.page)
+                    }
+                    Err(e) => {
+                        warn!(
+                            error = %e,
+                            address = %format!("{:#x}", address),
+                            "event_window fetch failed in TASK C"
+                        );
+                        let _ =
+                            tx_c.send(Action::LoadingStatus(format!("Event fetch failed: {}", e)));
+                        let _ = tx_c.send(Action::SourceUpdate {
+                            source: Source::Rpc,
+                            status: crate::app::state::SourceStatus::FetchError(e.to_string()),
+                        });
+                        None
+                    }
+                };
 
             let events = pf_page
                 .as_ref()
@@ -1812,6 +1870,12 @@ pub(super) async fn fetch_and_send_address_info(
             }
 
             // RPC task complete
+            debug!(
+                address = %format!("{:#x}", address),
+                source = ?Source::Rpc,
+                tx_summaries = 0,
+                "AddressTxsStreamed dispatching complete marker"
+            );
             let _ = tx_c.send(Action::AddressTxsStreamed {
                 address,
                 source: Source::Rpc,
@@ -2456,13 +2520,15 @@ pub(super) async fn fetch_more_address_txs(
     let cached = ds.load_cached_activity_range(&address);
     let window_size = if let Some((min_b, max_b)) = cached {
         // Build a lightweight probe to compute recommended_window
-        let mut p = dune::AddressActivityProbe::default();
-        p.sender_min_block = min_b;
-        p.sender_max_block = max_b;
-        p.callee_min_block = min_b;
-        p.callee_max_block = max_b;
-        p.sender_tx_count = 1;
-        p.callee_call_count = 1;
+        let p = dune::AddressActivityProbe {
+            sender_min_block: min_b,
+            sender_max_block: max_b,
+            callee_min_block: min_b,
+            callee_max_block: max_b,
+            sender_tx_count: 1,
+            callee_call_count: 1,
+            ..Default::default()
+        };
         p.recommended_window()
     } else {
         50_000u64
@@ -2796,6 +2862,9 @@ pub(super) async fn enrich_dune_calls(
             if let Some(call) = chunk.iter_mut().find(|c| c.tx_hash == hash) {
                 if let Ok(ref fetched_tx) = tx_result {
                     call.sender = fetched_tx.sender();
+                    let (nonce, tip) = helpers::extract_nonce_tip(fetched_tx);
+                    call.nonce = Some(nonce);
+                    call.tip = tip;
                 }
                 if let Ok(receipt) = rx_result {
                     call.total_fee_fri = felt_to_u128(&receipt.actual_fee);

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -29,6 +29,49 @@ use super::dune_source_update;
 use super::helpers;
 use super::voyager;
 
+/// RAII helper that registers an entry in the per-query status bar on
+/// construction and clears it on drop. Every early-return path in the
+/// fetcher it guards gets the clear for free, so we can't leave a stale
+/// label in the UI.
+struct QueryGuard {
+    tx: mpsc::UnboundedSender<Action>,
+    key: String,
+}
+
+impl QueryGuard {
+    fn new(tx: &mpsc::UnboundedSender<Action>, key: impl Into<String>, label: String) -> Self {
+        let key = key.into();
+        let _ = tx.send(Action::SetActiveQuery {
+            key: key.clone(),
+            label: Some(label),
+        });
+        Self {
+            tx: tx.clone(),
+            key,
+        }
+    }
+}
+
+impl Drop for QueryGuard {
+    fn drop(&mut self) {
+        let _ = self.tx.send(Action::SetActiveQuery {
+            key: std::mem::take(&mut self.key),
+            label: None,
+        });
+    }
+}
+
+/// Short prefix of a Felt address used as the stable part of an
+/// [`ActiveQueries`] key. Six hex chars is enough to tell two concurrent
+/// addresses apart without bloating the status bar.
+fn query_addr_prefix(address: &starknet::core::types::Felt) -> String {
+    let hex = format!("{:064x}", address);
+    hex.trim_start_matches('0')
+        .chars()
+        .take(6)
+        .collect::<String>()
+}
+
 /// UDC ContractDeployed event selector.
 const UDC_CONTRACT_DEPLOYED: &str =
     "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d";
@@ -2969,6 +3012,14 @@ pub(super) async fn fetch_address_meta_txs(
         EXTEND_DOWN_INITIAL_WINDOW, EventWindowPolicy, ensure_address_events_window,
     };
 
+    // Register the query in the status bar for the duration of this scan.
+    // Dropped automatically on every early-return path below.
+    let _guard = QueryGuard::new(
+        action_tx,
+        format!("meta:{}", query_addr_prefix(&address)),
+        "MetaTxs scan".to_string(),
+    );
+
     let send_empty = || {
         let _ = action_tx.send(Action::AddressMetaTxsLoaded {
             address,
@@ -3132,6 +3183,14 @@ pub(super) async fn fetch_address_contract_calls(
         );
         return;
     };
+
+    // Register the Calls fetch in the status bar for the duration of the
+    // Dune round-trip + enrichment. Dropped on every return path below.
+    let _guard = QueryGuard::new(
+        action_tx,
+        format!("calls:{}", query_addr_prefix(&address)),
+        "Calls fetch".to_string(),
+    );
 
     // TopDelta: if we've already cached rows for this address, only ask Dune
     // for blocks strictly newer than the highest block we've seen. Cold cache

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -2793,6 +2793,83 @@ pub(super) async fn find_deploy_tx(
     debug!(%addr, deploy_block, "Deploy tx not found in block (neither native nor UDC)");
 }
 
+/// Three tab-specific projections of an [`AddressActivityPage`] derived in
+/// a single classification pass.
+///
+/// Authority per projection:
+///
+/// - [`ClassifiedPage::txs`] — **authoritative.** All tx_rows where
+///   `sender == address`. Direct match, no decoding.
+/// - [`ClassifiedPage::meta_txs`] — **authoritative.** All tx_rows whose
+///   calldata contains an `execute_from_outside*` inner call with
+///   `intender == address`. Complete because `execute_from_outside` always
+///   emits `TRANSACTION_EXECUTED`, so pf-query's tx_rows covers every
+///   meta-tx within the scan range.
+/// - [`ClassifiedPage::calls`] — **supplementary only.** tx_rows whose
+///   multicall contains any inner call to `address`. Misses calls to
+///   contracts that don't emit events (pf-query indexes via events).
+///   Dune is the authoritative Calls source; these rows are valuable for
+///   showing something immediately while Dune loads, and for covering
+///   blocks past Dune's indexing lag.
+pub(super) struct ClassifiedPage {
+    pub txs: Vec<crate::data::types::AddressTxSummary>,
+    pub calls: Vec<crate::data::types::ContractCallSummary>,
+    pub meta_txs: Vec<crate::data::types::MetaTxIntenderSummary>,
+}
+
+/// Single-pass classifier over an [`AddressActivityPage`].
+///
+/// Composes the three existing per-tab helpers so every caller that wants
+/// the full fan-out (the shared window scan, WS event replay, etc.) goes
+/// through one entry point. Semantics match the per-helper versions
+/// exactly — migration target for tasks #3 (Calls merge) and #4 (WS
+/// routing) in the address-view revamp plan.
+pub(super) async fn classify_activity_page(
+    address: starknet::core::types::Felt,
+    page: &AddressActivityPage,
+    abi_reg: &Arc<AbiRegistry>,
+) -> ClassifiedPage {
+    use starknet::core::types::Felt;
+
+    // Prewarm the address's own ABI once. The individual helpers prewarm
+    // the same address too, so this is redundant with them but cheap and
+    // keeps the classifier's contract explicit ("ABIs are warm on entry").
+    helpers::prewarm_abis([address], abi_reg).await;
+
+    // Txs: rows the address authored itself. Filter to sender==address
+    // before batch-converting so prewarm targets inside the tx helper only
+    // see actually-relevant multicall destinations.
+    let sender_rows: Vec<_> = page
+        .tx_rows
+        .iter()
+        .filter(|r| {
+            Felt::from_hex(&r.sender)
+                .map(|s| s == address)
+                .unwrap_or(false)
+        })
+        .cloned()
+        .collect();
+    let txs = if sender_rows.is_empty() {
+        Vec::new()
+    } else {
+        build_tx_summaries_from_pf_rows(&sender_rows, abi_reg).await
+    };
+
+    // Calls: pf-query-supplementary rows (Dune authoritative). Reuses the
+    // existing builder verbatim — any row with an inner call to address.
+    let calls = build_contract_calls_from_pf_rows(address, &page.tx_rows, abi_reg).await;
+
+    // MetaTxs: full page-level derivation so the tx_index tie-breaker
+    // (built from event_index ordering) stays correct.
+    let meta_txs = derive_meta_txs_from_page(address, page, abi_reg).await;
+
+    ClassifiedPage {
+        txs,
+        calls,
+        meta_txs,
+    }
+}
+
 /// Classify every tx row in a shared activity page as a meta-tx where
 /// `address` is the intender, returning the recency-sorted summaries.
 ///
@@ -3577,6 +3654,79 @@ mod shared_pipeline_tests {
         assert_eq!(out[1].hash, Felt::from(2u64));
         assert_eq!(out[1].block_number, 101);
         assert_eq!(out[0].sender, Some(sender));
+    }
+
+    /// `classify_activity_page` fan-out for a direct sender-authored invoke:
+    /// sender == address and the multicall contains an inner call to address.
+    /// Expect Txs=1 (sender match) + Calls=1 (inner-call target match) +
+    /// MetaTxs=0 (no execute_from_outside shape, so not a meta-tx).
+    ///
+    /// Guards the unified classifier against regressing the per-tab fan-out
+    /// that the address-view revamp depends on.
+    #[tokio::test]
+    async fn classify_activity_page_fans_out_sender_and_call() {
+        let addr =
+            Felt::from_hex("0x3a496b92d292386ad70dab94ae181a06d289440e3b632a2435721b4280874c4")
+                .unwrap();
+        let tx_hash = Felt::from(0xABCDu64);
+
+        // Multicall with a single inner call targeting `addr`.
+        // Layout: [count=1, target=addr, selector=0x22, calldata_len=0].
+        let calldata = vec![Felt::from(1u64), addr, Felt::from(0x22u64), Felt::ZERO];
+        let page = AddressActivityPage {
+            events: vec![ev(tx_hash, 100, 0)],
+            tx_rows: vec![tx_row(tx_hash, addr, 100, 5, calldata)],
+            unique_hashes: vec![tx_hash],
+            tx_block_map: std::collections::HashMap::from([(tx_hash, 100u64)]),
+            next_token: None,
+        };
+        let abi = mk_abi_reg();
+
+        let classified = classify_activity_page(addr, &page, &abi).await;
+
+        assert_eq!(
+            classified.txs.len(),
+            1,
+            "sender == address ⇒ one tx summary"
+        );
+        assert_eq!(classified.txs[0].hash, tx_hash);
+        assert_eq!(classified.txs[0].sender, Some(addr));
+
+        assert_eq!(
+            classified.calls.len(),
+            1,
+            "inner call to address ⇒ one call summary"
+        );
+        assert_eq!(classified.calls[0].tx_hash, tx_hash);
+        assert_eq!(classified.calls[0].sender, addr);
+
+        assert!(
+            classified.meta_txs.is_empty(),
+            "no outside_execution shape ⇒ no meta-tx classification, got: {:?}",
+            classified.meta_txs
+        );
+    }
+
+    /// `classify_activity_page` on an empty page returns empty projections
+    /// in all three slots. Guards against the classifier ever accidentally
+    /// fabricating rows when there are none to classify.
+    #[tokio::test]
+    async fn classify_activity_page_empty_page_yields_empty_projections() {
+        let addr =
+            Felt::from_hex("0x3a496b92d292386ad70dab94ae181a06d289440e3b632a2435721b4280874c4")
+                .unwrap();
+        let page = AddressActivityPage {
+            events: vec![],
+            tx_rows: vec![],
+            unique_hashes: vec![],
+            tx_block_map: std::collections::HashMap::new(),
+            next_token: None,
+        };
+        let abi = mk_abi_reg();
+        let classified = classify_activity_page(addr, &page, &abi).await;
+        assert!(classified.txs.is_empty());
+        assert!(classified.calls.is_empty());
+        assert!(classified.meta_txs.is_empty());
     }
 }
 

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -1279,6 +1279,11 @@ pub(super) async fn fetch_and_send_address_info(
             // so TASK C's custom `from_block` (derived from nonce_delta /
             // search_progress above) is now only used for the fast-skip
             // short-circuit and the loading-status banner — not for the fetch.
+            let _events_guard = QueryGuard::new(
+                &tx_c,
+                format!("events:{}", query_addr_prefix(&address)),
+                "Events scan".to_string(),
+            );
             let ds_dyn: Arc<dyn crate::data::DataSource> = ds_c.clone();
             let pf_page: Option<AddressActivityPage> = match crate::network::event_window::ensure_address_events_window(
                 address,

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -3118,11 +3118,21 @@ pub(super) async fn fetch_address_meta_txs(
 
     let summaries = derive_meta_txs_from_page(address, &outcome.page, abi_reg).await;
 
+    // Plan §2: the meta-tx scan's tx_rows are also valuable Calls rows — every
+    // `execute_from_outside(intender=ADDR)` tx is an outer invoke whose
+    // multicall calls ADDR. Dune alone caps at 500 rows (collapses hard after
+    // tx_hash dedup for meta-tx-heavy accounts), so merging the shared page's
+    // call-shaped projection is what keeps the MetaTxs ⊆ Calls invariant
+    // visible on high-volume accounts.
+    let calls_from_page =
+        build_contract_calls_from_pf_rows(address, &outcome.page.tx_rows, abi_reg).await;
+
     info!(
         addr = %format!("{:#x}", address),
         events = outcome.page.events.len(),
         candidates = outcome.page.tx_rows.len(),
         meta_txs = summaries.len(),
+        supplementary_calls = calls_from_page.len(),
         min_searched = outcome.min_searched,
         max_searched = outcome.max_searched,
         floor = from_block,
@@ -3133,6 +3143,13 @@ pub(super) async fn fetch_address_meta_txs(
 
     if !summaries.is_empty() {
         ds.save_meta_txs(&address, &summaries);
+    }
+
+    if !calls_from_page.is_empty() {
+        let _ = action_tx.send(Action::AddressCallsMerged {
+            address,
+            calls: calls_from_page,
+        });
     }
 
     // Signal "has more older" via Some(min_searched). The UI doesn't interpret

--- a/src/network/dune.rs
+++ b/src/network/dune.rs
@@ -229,27 +229,47 @@ impl DuneClient {
     }
 
     /// Windowed variant of `query_contract_calls` — scoped to a block range for fast completion.
+    ///
+    /// `min_block_date` is an optional partition hint: `starknet.calls` is partitioned by
+    /// `block_date`, and without a date predicate Dune has to scan every partition to find
+    /// the requested `block_number` range, which times out as `QUERY_STATE_FAILED` on dense
+    /// contracts. Pass the `block_date` of `from_block` (minus a 1-day UTC buffer) whenever
+    /// the caller has a reasonable estimate — the SQL stays correct either way.
     pub async fn query_contract_calls_windowed(
         &self,
         contract: Felt,
         from_block: u64,
         to_block: u64,
         limit: u32,
+        min_block_date: Option<chrono::NaiveDate>,
     ) -> Result<Vec<ContractCallSummary>, String> {
         let contract_hex = format!("{:#066x}", contract);
+        let date_clause = min_block_date
+            .map(|d| format!("AND block_date >= date '{}' ", d.format("%Y-%m-%d")))
+            .unwrap_or_default();
+        // DuneSQL (Trino) uses bigint for block_number; any literal above i64::MAX
+        // (9_223_372_036_854_775_807) is rejected at parse time as "Invalid numeric
+        // literal" — so a caller passing u64::MAX as "no upper bound" would have
+        // the whole query fail. Emit an open-ended predicate in that case.
+        let range_clause = if to_block == u64::MAX {
+            format!("AND block_number >= {}", from_block)
+        } else {
+            format!("AND block_number BETWEEN {} AND {}", from_block, to_block)
+        };
         let sql = format!(
             "SELECT transaction_hash, caller_address, entry_point_selector, \
              block_number, block_time, revert_reason \
              FROM starknet.calls \
              WHERE contract_address = {} \
-             AND block_number BETWEEN {} AND {} \
+             {}\
+             {} \
              AND call_type = 'CALL' \
              ORDER BY block_number DESC \
              LIMIT {}",
-            contract_hex, from_block, to_block, limit
+            contract_hex, date_clause, range_clause, limit
         );
 
-        debug!(contract = %contract_hex, from_block, to_block, "Querying Dune for contract calls (windowed)");
+        debug!(contract = %contract_hex, from_block, to_block, ?min_block_date, "Querying Dune for contract calls (windowed)");
         let rows = self.execute_sql(&sql).await?;
         info!(
             rows = rows.len(),

--- a/src/network/dune.rs
+++ b/src/network/dune.rs
@@ -194,6 +194,8 @@ impl DuneClient {
                     timestamp: block_time,
                     total_fee_fri: 0, // Not in calls table
                     status,
+                    nonce: None, // Not in calls table — merged in from RPC/pf path
+                    tip: 0,
                 })
             })
             .collect())
@@ -313,6 +315,8 @@ impl DuneClient {
                     timestamp: block_time,
                     total_fee_fri: 0,
                     status,
+                    nonce: None,
+                    tip: 0,
                 })
             })
             .collect())

--- a/src/network/dune.rs
+++ b/src/network/dune.rs
@@ -373,6 +373,55 @@ impl DuneClient {
         Ok(probe)
     }
 
+    /// TopDelta variant of [`Self::probe_address_activity`].
+    ///
+    /// When a prior probe result is cached but stale, we only need to extend
+    /// its `max_block` + event count toward the chain tip — `min_block`
+    /// never regresses. This query scopes to `block_number > from_block`,
+    /// making the re-probe cheap regardless of chain age.
+    ///
+    /// Returns a partial probe: `callee_call_count` counts the delta events,
+    /// and `callee_max_block` is their upper bound. The caller is expected to
+    /// merge this into the cached row (cache.rs `save_activity_range_with_count`
+    /// handles the min-preserve / max-expand / count-max semantics).
+    pub async fn probe_address_activity_delta(
+        &self,
+        address: Felt,
+        from_block: u64,
+    ) -> Result<AddressActivityProbe, String> {
+        let addr_hex = format!("{:#066x}", address);
+        let sql = format!(
+            "SELECT COUNT(*) AS cnt, \
+               MIN(block_number) AS min_block, MAX(block_number) AS max_block \
+             FROM starknet.events \
+             WHERE from_address = {addr} \
+             AND block_number > {from}",
+            addr = addr_hex,
+            from = from_block,
+        );
+
+        debug!(address = %addr_hex, from_block, "Dune events probe (delta): extending activity range");
+        let rows = self.execute_sql(&sql).await?;
+
+        let mut probe = AddressActivityProbe::default();
+        if let Some(row) = rows.first() {
+            let cnt = row.get("cnt").and_then(|v| v.as_u64()).unwrap_or(0);
+            let min_b = row.get("min_block").and_then(|v| v.as_u64()).unwrap_or(0);
+            let max_b = row.get("max_block").and_then(|v| v.as_u64()).unwrap_or(0);
+            probe.callee_call_count = cnt;
+            probe.callee_min_block = min_b;
+            probe.callee_max_block = max_b;
+        }
+
+        info!(
+            event_count = probe.callee_call_count,
+            from_block,
+            max_block = probe.callee_max_block,
+            "Dune events probe (delta) complete"
+        );
+        Ok(probe)
+    }
+
     /// Query the declare transaction for a class hash (fallback when PF is unavailable).
     pub async fn query_declare_tx(
         &self,

--- a/src/network/event_window.rs
+++ b/src/network/event_window.rs
@@ -1,0 +1,342 @@
+//! Unified windowed event-fetch pipeline for an address.
+//!
+//! Backs the three "additive" address tabs (MetaTxs, Calls, Events) on a single
+//! source: pf-query events persisted to `address_events` with a per-address
+//! scanned-range cursor (`address_search_progress`). Each tab is a projection
+//! over the same cache; fetching once updates all three.
+//!
+//! # Policies
+//!
+//! - [`EventWindowPolicy::TopDelta`] — the default on tab entry. Fetches the
+//!   block range `(max_searched_block, latest_block]` so we only ever pay for
+//!   what's new since the last visit. On a cold cache, falls back to a bounded
+//!   first-paint window from the tip — we don't auto-walk to the deploy block.
+//! - [`EventWindowPolicy::ExtendDown`] / [`EventWindowPolicy::FillGap`] are
+//!   the scrolling primitives; wiring lands with the gap UI.
+//!
+//! # Invariants
+//!
+//! - Every returned event is also persisted (additively) to `address_events`.
+//! - `address_search_progress` is advanced only over ranges we actually scanned
+//!   contiguously; a deferred gap is reported to the caller instead of being
+//!   silently bridged.
+
+use std::sync::Arc;
+
+use starknet::core::types::Felt;
+use tracing::{debug, warn};
+
+use crate::data::DataSource;
+use crate::data::pathfinder::PathfinderClient;
+use crate::data::types::SnEvent;
+use crate::error::Result;
+use crate::network::address::{
+    AddressActivityPage, EventQueryKind, fetch_address_activity, fetch_events_routed,
+};
+
+/// Initial window size (events) when no prior scan exists. Matches the pre-
+/// existing Phase-1 scan limits used by `fetch_and_send_address_info`.
+pub const EVENT_FIRST_PAINT_TARGET: u32 = 200;
+
+/// If the delta between `max_searched_block` and `latest_block` exceeds this
+/// threshold, don't auto-fill the intervening range — record a deferred gap
+/// and scan only the tip. Prevents "address wasn't visited in a month" from
+/// triggering a multi-million-block walk on revisit.
+///
+/// ~100k blocks ≈ 3 days on Starknet mainnet at current block rate.
+pub const EVENT_LARGE_GAP_THRESHOLD_BLOCKS: u64 = 100_000;
+
+/// When the delta is larger than the threshold, this is the tip window we do
+/// fetch (blocks from `latest_block - TIP_ONLY_WINDOW_BLOCKS` to `latest_block`).
+pub const TIP_ONLY_WINDOW_BLOCKS: u64 = 5_000;
+
+/// How many events a single `TopDelta` fetch is allowed to pull.
+pub const EVENT_PAGE_LIMIT: u32 = 200;
+
+/// Fetch policy for [`ensure_address_events_window`].
+#[derive(Debug, Clone, Copy)]
+pub enum EventWindowPolicy {
+    /// Fetch events newer than our cursor. Default on tab entry.
+    ///
+    /// Semantics:
+    /// - Cold cache → fetch newest `EVENT_FIRST_PAINT_TARGET` events from tip.
+    /// - Warm cache, small delta → fetch `(max_searched, latest]`.
+    /// - Warm cache, large delta → fetch the last `TIP_ONLY_WINDOW_BLOCKS` and
+    ///   record a deferred gap; caller decides when/if to fill.
+    TopDelta,
+    /// Fetch events strictly older than the current `min_searched_block`.
+    /// Triggered when the user scrolls past the bottom of the cached window.
+    #[allow(dead_code)] // wired with the gap UI task
+    ExtendDown,
+    /// Fetch a specific block range — used to fill a previously deferred gap.
+    #[allow(dead_code)] // wired with the gap UI task
+    FillGap { from_block: u64, to_block: u64 },
+}
+
+/// Result of a single window fetch.
+#[derive(Debug, Clone)]
+pub(crate) struct EventWindowOutcome {
+    /// Full merged event list for the address, newest-first. Includes both
+    /// cached and freshly-fetched events.
+    pub merged: Vec<SnEvent>,
+    /// How many events the upstream returned for *this* call. Independent of
+    /// cache contents — a revisit with nothing new yields 0.
+    pub fetched: usize,
+    /// pf-query continuation token. `Some` ⇒ the current page wasn't exhausted
+    /// and calling again would return more within the same window.
+    pub next_token: Option<u64>,
+    /// Range `(lo, hi)` we *knowingly* skipped because the gap exceeded
+    /// `EVENT_LARGE_GAP_THRESHOLD_BLOCKS`. `None` ⇒ the scanned range is
+    /// contiguous. Meant to be surfaced as a gap marker in the UI.
+    pub deferred_gap: Option<(u64, u64)>,
+    /// New max scanned block after this call (reflects what we actually
+    /// scanned, not what we deferred).
+    pub max_searched: u64,
+    /// Lowest block we've ever scanned for this address. `0` means "we've
+    /// reached history" (or never scanned). Used as the "more older events
+    /// to fetch" signal — if `min_searched > 0`, an `ExtendDown` call can
+    /// pull more.
+    pub min_searched: u64,
+    /// The unfiltered pf-query page from the fetch, with `tx_rows` included.
+    /// Callers that need the raw events + per-tx metadata (e.g. MetaTxs
+    /// classification) can derive from this without re-querying.
+    pub page: crate::network::address::AddressActivityPage,
+}
+
+/// Advance the per-address event window according to `policy`, merging new
+/// events into the persistent cache and updating the scanned-range cursor.
+///
+/// pf-query is preferred — it returns tx_rows in bulk alongside events so
+/// downstream classifiers (meta-tx, calls) don't need a second round trip.
+/// When pf is unavailable we fall back to an RPC-only scan via
+/// [`fetch_events_routed`]; `page.tx_rows` will be empty in that case and
+/// callers that need rich tx data should re-fetch per-hash through the
+/// [`DataSource`] (see `build_contract_calls_from_hashes`).
+pub(crate) async fn ensure_address_events_window(
+    address: Felt,
+    kind: EventQueryKind,
+    policy: EventWindowPolicy,
+    pf: Option<&Arc<PathfinderClient>>,
+    ds: &Arc<dyn DataSource>,
+    latest_block: u64,
+) -> Result<EventWindowOutcome> {
+    // Current cursor (None ⇒ cold cache).
+    let progress = ds.load_search_progress(&address);
+
+    // Pick a fetch window.
+    let (from_block, deferred_gap) = match policy {
+        EventWindowPolicy::TopDelta => resolve_top_delta(progress, latest_block),
+        EventWindowPolicy::ExtendDown => {
+            // Scan below the cached floor. `fetch_address_activity` fetches
+            // newest-first, so "older" here means a lower from_block paired
+            // with to_block = current min - 1.
+            match progress {
+                Some((min, _)) if min > 0 => {
+                    let from = min.saturating_sub(TIP_ONLY_WINDOW_BLOCKS);
+                    (from, None)
+                }
+                Some(_) => {
+                    // Already at genesis — nothing older to fetch.
+                    let (min, max) = progress.unwrap_or((0, 0));
+                    return Ok(EventWindowOutcome {
+                        merged: ds.load_address_events(&address),
+                        fetched: 0,
+                        next_token: None,
+                        deferred_gap: None,
+                        max_searched: max,
+                        min_searched: min,
+                        page: empty_page(),
+                    });
+                }
+                None => {
+                    // Cold cache: no "down" to extend. Degrade to TopDelta.
+                    resolve_top_delta(progress, latest_block)
+                }
+            }
+        }
+        EventWindowPolicy::FillGap { from_block, .. } => (from_block, None),
+    };
+
+    let to_block = match policy {
+        EventWindowPolicy::FillGap { to_block, .. } => Some(to_block),
+        EventWindowPolicy::ExtendDown => progress.and_then(|(min, _)| min.checked_sub(1)),
+        EventWindowPolicy::TopDelta => None,
+    };
+
+    debug!(
+        address = %format!("{:#x}", address),
+        ?policy,
+        from_block,
+        ?to_block,
+        ?deferred_gap,
+        pf_available = pf.is_some(),
+        "event_window: fetching"
+    );
+
+    let page = match pf {
+        Some(pf_client) => {
+            fetch_address_activity(address, kind, from_block, None, EVENT_PAGE_LIMIT, pf_client)
+                .await
+                .inspect_err(|e| {
+                    warn!(
+                        address = %format!("{:#x}", address),
+                        error = %e,
+                        "event_window: fetch_address_activity failed"
+                    );
+                })?
+        }
+        None => {
+            // RPC fallback: just events, no bulk tx_rows. Callers that need
+            // tx data build it per-hash via the DataSource.
+            let events = fetch_events_routed(
+                kind,
+                None,
+                ds,
+                address,
+                Some(from_block),
+                to_block,
+                EVENT_PAGE_LIMIT as usize,
+            )
+            .await
+            .inspect_err(|e| {
+                warn!(
+                    address = %format!("{:#x}", address),
+                    error = %e,
+                    "event_window: RPC event scan failed"
+                );
+            })?;
+            page_from_events(events)
+        }
+    };
+
+    let fetched = page.events.len();
+    let merged = ds.merge_address_events(&address, &page.events);
+
+    // Update cursor. We only advance over ranges we *actually* scanned; if a
+    // gap was deferred, the old min/max remain and we merge in the tip range.
+    let scanned_min = match policy {
+        EventWindowPolicy::TopDelta => from_block,
+        EventWindowPolicy::ExtendDown => from_block,
+        EventWindowPolicy::FillGap { from_block, .. } => from_block,
+    };
+    let scanned_max = to_block.unwrap_or(latest_block);
+    if scanned_max >= scanned_min {
+        ds.save_search_progress(&address, scanned_min, scanned_max);
+    }
+
+    let (min_searched, max_searched) = ds
+        .load_search_progress(&address)
+        .unwrap_or((scanned_min, scanned_max));
+
+    Ok(EventWindowOutcome {
+        merged,
+        fetched,
+        next_token: page.next_token,
+        deferred_gap,
+        max_searched,
+        min_searched,
+        page,
+    })
+}
+
+/// Empty page for short-circuit paths (e.g. ExtendDown past genesis).
+fn empty_page() -> AddressActivityPage {
+    AddressActivityPage {
+        events: Vec::new(),
+        tx_rows: Vec::new(),
+        unique_hashes: Vec::new(),
+        tx_block_map: std::collections::HashMap::new(),
+        next_token: None,
+    }
+}
+
+/// Build an [`AddressActivityPage`] from a bare event list (RPC fallback).
+///
+/// `tx_rows` is empty because the RPC path doesn't bulk-fetch tx bodies;
+/// `unique_hashes` and `tx_block_map` are derived so downstream code that
+/// only needs (tx_hash, block) pairs works uniformly. The `next_token` is
+/// always `None` — the RPC path doesn't produce pf-style continuation
+/// tokens.
+fn page_from_events(events: Vec<SnEvent>) -> AddressActivityPage {
+    let mut unique_hashes: Vec<Felt> = Vec::with_capacity(events.len());
+    let mut seen: std::collections::HashSet<Felt> = std::collections::HashSet::new();
+    let mut tx_block_map: std::collections::HashMap<Felt, u64> = std::collections::HashMap::new();
+    for e in &events {
+        if e.transaction_hash != Felt::ZERO && seen.insert(e.transaction_hash) {
+            unique_hashes.push(e.transaction_hash);
+        }
+        tx_block_map
+            .entry(e.transaction_hash)
+            .or_insert(e.block_number);
+    }
+    AddressActivityPage {
+        events,
+        tx_rows: Vec::new(),
+        unique_hashes,
+        tx_block_map,
+        next_token: None,
+    }
+}
+
+/// Compute `(from_block, deferred_gap)` for a TopDelta fetch.
+///
+/// Split out so the branching logic is unit-testable without a pf client.
+fn resolve_top_delta(progress: Option<(u64, u64)>, latest_block: u64) -> (u64, Option<(u64, u64)>) {
+    let Some((_min, max_searched)) = progress else {
+        // Cold cache: fetch from a tip window only — don't walk history.
+        let from = latest_block.saturating_sub(TIP_ONLY_WINDOW_BLOCKS);
+        return (from, None);
+    };
+
+    if latest_block <= max_searched {
+        // Nothing new.
+        return (max_searched.saturating_add(1), None);
+    }
+
+    let delta = latest_block - max_searched;
+    if delta <= EVENT_LARGE_GAP_THRESHOLD_BLOCKS {
+        // Small enough — scan contiguously.
+        (max_searched.saturating_add(1), None)
+    } else {
+        // Stale cache: only scan the tip, record the gap.
+        let tip_start = latest_block.saturating_sub(TIP_ONLY_WINDOW_BLOCKS);
+        let gap = (max_searched.saturating_add(1), tip_start.saturating_sub(1));
+        (tip_start, Some(gap))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn top_delta_cold_cache_fetches_tip_only() {
+        let (from, gap) = resolve_top_delta(None, 9_000_000);
+        assert_eq!(from, 9_000_000 - TIP_ONLY_WINDOW_BLOCKS);
+        assert_eq!(gap, None);
+    }
+
+    #[test]
+    fn top_delta_small_gap_fetches_contiguous() {
+        // max_searched = 8_900_000, latest = 8_950_000 → delta 50k < threshold.
+        let (from, gap) = resolve_top_delta(Some((3_000_000, 8_900_000)), 8_950_000);
+        assert_eq!(from, 8_900_001);
+        assert_eq!(gap, None);
+    }
+
+    #[test]
+    fn top_delta_large_gap_defers_backfill() {
+        // max_searched = 5_000_000, latest = 9_000_000 → delta 4M >> threshold.
+        let (from, gap) = resolve_top_delta(Some((3_000_000, 5_000_000)), 9_000_000);
+        let tip_start = 9_000_000 - TIP_ONLY_WINDOW_BLOCKS;
+        assert_eq!(from, tip_start);
+        assert_eq!(gap, Some((5_000_001, tip_start - 1)));
+    }
+
+    #[test]
+    fn top_delta_no_new_blocks_is_noop() {
+        let (from, gap) = resolve_top_delta(Some((0, 9_000_000)), 9_000_000);
+        assert_eq!(from, 9_000_001); // effectively no-op when fed to pf
+        assert_eq!(gap, None);
+    }
+}

--- a/src/network/event_window.rs
+++ b/src/network/event_window.rs
@@ -53,6 +53,22 @@ pub const TIP_ONLY_WINDOW_BLOCKS: u64 = 5_000;
 /// How many events a single `TopDelta` fetch is allowed to pull.
 pub const EVENT_PAGE_LIMIT: u32 = 200;
 
+/// Initial `ExtendDown` window size (blocks). Small enough to return results
+/// quickly on dense addresses; grown adaptively when the backend returns
+/// empty pages (sparse addresses).
+pub const EXTEND_DOWN_INITIAL_WINDOW: u64 = 5_000;
+
+/// Minimum `ExtendDown` window size (blocks). We halve toward this floor
+/// when a scan hits the [`EVENT_PAGE_LIMIT`] cap (signal that the window
+/// was too big and events may have been truncated).
+pub const EXTEND_DOWN_MIN_WINDOW: u64 = 5_000;
+
+/// Maximum `ExtendDown` window size (blocks). We double toward this cap
+/// when a scan returns zero events on a sparse address. Kept well below
+/// what a keyed pf-query bloom scan can complete within the 30 s client
+/// deadline — start conservative, raise if measurements allow.
+pub const EXTEND_DOWN_MAX_WINDOW: u64 = 500_000;
+
 /// Fetch policy for [`ensure_address_events_window`].
 #[derive(Debug, Clone, Copy)]
 pub enum EventWindowPolicy {
@@ -65,9 +81,11 @@ pub enum EventWindowPolicy {
     ///   record a deferred gap; caller decides when/if to fill.
     TopDelta,
     /// Fetch events strictly older than the current `min_searched_block`.
-    /// Triggered when the user scrolls past the bottom of the cached window.
-    #[allow(dead_code)] // wired with the gap UI task
-    ExtendDown,
+    /// The `window_size` is the number of blocks below the cached floor to
+    /// scan in this call; the caller decides how to adapt it across
+    /// successive pages (e.g. doubling on empty hits up to
+    /// [`EXTEND_DOWN_MAX_WINDOW`]).
+    ExtendDown { window_size: u64 },
     /// Fetch a specific block range — used to fill a previously deferred gap.
     #[allow(dead_code)] // wired with the gap UI task
     FillGap { from_block: u64, to_block: u64 },
@@ -97,6 +115,15 @@ pub(crate) struct EventWindowOutcome {
     /// to fetch" signal — if `min_searched > 0`, an `ExtendDown` call can
     /// pull more.
     pub min_searched: u64,
+    /// Suggested window size (blocks) for the *next* `ExtendDown` call,
+    /// derived from this call's hit density:
+    /// - 0 events fetched → double (sparse address, amortize round-trips).
+    /// - `>= EVENT_PAGE_LIMIT` events → halve (dense address; we may have
+    ///   truncated at the page cap, narrow the next window).
+    /// - otherwise → keep the current size.
+    /// Clamped to `[EXTEND_DOWN_MIN_WINDOW, EXTEND_DOWN_MAX_WINDOW]`.
+    /// `None` for non-`ExtendDown` policies and short-circuit paths.
+    pub suggested_next_window: Option<u64>,
     /// The unfiltered pf-query page from the fetch, with `tx_rows` included.
     /// Callers that need the raw events + per-tx metadata (e.g. MetaTxs
     /// classification) can derive from this without re-querying.
@@ -119,6 +146,7 @@ pub(crate) async fn ensure_address_events_window(
     pf: Option<&Arc<PathfinderClient>>,
     ds: &Arc<dyn DataSource>,
     latest_block: u64,
+    floor_block: u64,
 ) -> Result<EventWindowOutcome> {
     // Current cursor (None ⇒ cold cache).
     let progress = ds.load_search_progress(&address);
@@ -126,17 +154,21 @@ pub(crate) async fn ensure_address_events_window(
     // Pick a fetch window.
     let (from_block, deferred_gap) = match policy {
         EventWindowPolicy::TopDelta => resolve_top_delta(progress, latest_block),
-        EventWindowPolicy::ExtendDown => {
+        EventWindowPolicy::ExtendDown { window_size } => {
             // Scan below the cached floor. `fetch_address_activity` fetches
             // newest-first, so "older" here means a lower from_block paired
             // with to_block = current min - 1.
             match progress {
-                Some((min, _)) if min > 0 => {
-                    let from = min.saturating_sub(TIP_ONLY_WINDOW_BLOCKS);
+                Some((min, _)) if min > floor_block => {
+                    // Clamp at floor so we never scan past e.g. the deploy
+                    // block. `to_block` below is still `min - 1`, so the
+                    // window we actually hit is `[from, min-1]` — no double
+                    // coverage of already-scanned range above `min`.
+                    let from = min.saturating_sub(window_size).max(floor_block);
                     (from, None)
                 }
                 Some(_) => {
-                    // Already at genesis — nothing older to fetch.
+                    // Already at floor (or below) — nothing older to fetch.
                     let (min, max) = progress.unwrap_or((0, 0));
                     return Ok(EventWindowOutcome {
                         merged: ds.load_address_events(&address),
@@ -145,6 +177,7 @@ pub(crate) async fn ensure_address_events_window(
                         deferred_gap: None,
                         max_searched: max,
                         min_searched: min,
+                        suggested_next_window: None,
                         page: empty_page(),
                     });
                 }
@@ -159,7 +192,7 @@ pub(crate) async fn ensure_address_events_window(
 
     let to_block = match policy {
         EventWindowPolicy::FillGap { to_block, .. } => Some(to_block),
-        EventWindowPolicy::ExtendDown => progress.and_then(|(min, _)| min.checked_sub(1)),
+        EventWindowPolicy::ExtendDown { .. } => progress.and_then(|(min, _)| min.checked_sub(1)),
         EventWindowPolicy::TopDelta => None,
     };
 
@@ -216,7 +249,7 @@ pub(crate) async fn ensure_address_events_window(
     // gap was deferred, the old min/max remain and we merge in the tip range.
     let scanned_min = match policy {
         EventWindowPolicy::TopDelta => from_block,
-        EventWindowPolicy::ExtendDown => from_block,
+        EventWindowPolicy::ExtendDown { .. } => from_block,
         EventWindowPolicy::FillGap { from_block, .. } => from_block,
     };
     let scanned_max = to_block.unwrap_or(latest_block);
@@ -228,6 +261,17 @@ pub(crate) async fn ensure_address_events_window(
         .load_search_progress(&address)
         .unwrap_or((scanned_min, scanned_max));
 
+    // Adapt the next ExtendDown window based on hit density. Empty window →
+    // widen (sparse address, minimise round-trips); full page (bloom cap
+    // hit) → narrow (dense address; we may have truncated events). Only
+    // meaningful for ExtendDown.
+    let suggested_next_window = match policy {
+        EventWindowPolicy::ExtendDown { window_size } => {
+            Some(suggest_next_window(window_size, fetched))
+        }
+        _ => None,
+    };
+
     Ok(EventWindowOutcome {
         merged,
         fetched,
@@ -235,8 +279,28 @@ pub(crate) async fn ensure_address_events_window(
         deferred_gap,
         max_searched,
         min_searched,
+        suggested_next_window,
         page,
     })
+}
+
+/// Density-aware window-size adaptation for `ExtendDown`.
+///
+/// - `fetched == 0` → double, up to [`EXTEND_DOWN_MAX_WINDOW`]. On a sparse
+///   address this amortises round-trips so we don't walk 6M blocks at 5K/step.
+/// - `fetched >= EVENT_PAGE_LIMIT` → halve, down to [`EXTEND_DOWN_MIN_WINDOW`].
+///   The bloom cap capped this page; a smaller next window is less likely to
+///   truncate.
+/// - otherwise → keep the current size.
+fn suggest_next_window(current: u64, fetched: usize) -> u64 {
+    let next = if fetched == 0 {
+        current.saturating_mul(2)
+    } else if fetched >= EVENT_PAGE_LIMIT as usize {
+        current / 2
+    } else {
+        current
+    };
+    next.clamp(EXTEND_DOWN_MIN_WINDOW, EXTEND_DOWN_MAX_WINDOW)
 }
 
 /// Empty page for short-circuit paths (e.g. ExtendDown past genesis).
@@ -338,5 +402,44 @@ mod tests {
         let (from, gap) = resolve_top_delta(Some((0, 9_000_000)), 9_000_000);
         assert_eq!(from, 9_000_001); // effectively no-op when fed to pf
         assert_eq!(gap, None);
+    }
+
+    #[test]
+    fn suggest_next_window_doubles_on_empty_page() {
+        assert_eq!(suggest_next_window(5_000, 0), 10_000);
+        assert_eq!(suggest_next_window(50_000, 0), 100_000);
+    }
+
+    #[test]
+    fn suggest_next_window_caps_at_max() {
+        assert_eq!(
+            suggest_next_window(EXTEND_DOWN_MAX_WINDOW, 0),
+            EXTEND_DOWN_MAX_WINDOW
+        );
+        assert_eq!(
+            suggest_next_window(EXTEND_DOWN_MAX_WINDOW / 2 + 1, 0),
+            EXTEND_DOWN_MAX_WINDOW
+        );
+    }
+
+    #[test]
+    fn suggest_next_window_halves_on_full_page() {
+        assert_eq!(
+            suggest_next_window(100_000, EVENT_PAGE_LIMIT as usize),
+            50_000
+        );
+    }
+
+    #[test]
+    fn suggest_next_window_floors_at_min() {
+        assert_eq!(
+            suggest_next_window(EXTEND_DOWN_MIN_WINDOW, EVENT_PAGE_LIMIT as usize),
+            EXTEND_DOWN_MIN_WINDOW
+        );
+    }
+
+    #[test]
+    fn suggest_next_window_keeps_on_partial_page() {
+        assert_eq!(suggest_next_window(20_000, 37), 20_000);
     }
 }

--- a/src/network/event_window.rs
+++ b/src/network/event_window.rs
@@ -26,13 +26,23 @@ use std::sync::Arc;
 use starknet::core::types::Felt;
 use tracing::{debug, warn};
 
-use crate::data::DataSource;
 use crate::data::pathfinder::PathfinderClient;
 use crate::data::types::SnEvent;
+use crate::data::{DataSource, FilterKind};
 use crate::error::Result;
 use crate::network::address::{
     AddressActivityPage, EventQueryKind, fetch_address_activity, fetch_events_routed,
 };
+
+/// Map an [`EventQueryKind`] to the scan-coverage kind recorded in
+/// `address_search_progress`. Accounts scan with a `TRANSACTION_EXECUTED`
+/// key filter (keyed), contracts scan without a key filter (unkeyed).
+fn filter_kind_for(kind: EventQueryKind) -> FilterKind {
+    match kind {
+        EventQueryKind::Account => FilterKind::Keyed,
+        EventQueryKind::Contract => FilterKind::Unkeyed,
+    }
+}
 
 /// Initial window size (events) when no prior scan exists. Matches the pre-
 /// existing Phase-1 scan limits used by `fetch_and_send_address_info`.
@@ -148,8 +158,10 @@ pub(crate) async fn ensure_address_events_window(
     latest_block: u64,
     floor_block: u64,
 ) -> Result<EventWindowOutcome> {
-    // Current cursor (None ⇒ cold cache).
-    let progress = ds.load_search_progress(&address);
+    // Current cursor (None ⇒ cold cache). Keyed/unkeyed coverage is tracked
+    // separately so a narrower keyed scan doesn't lie about broader coverage.
+    let filter_kind = filter_kind_for(kind);
+    let progress = ds.load_search_progress(&address, filter_kind);
 
     // Pick a fetch window.
     let (from_block, deferred_gap) = match policy {
@@ -254,11 +266,11 @@ pub(crate) async fn ensure_address_events_window(
     };
     let scanned_max = to_block.unwrap_or(latest_block);
     if scanned_max >= scanned_min {
-        ds.save_search_progress(&address, scanned_min, scanned_max);
+        ds.save_search_progress(&address, filter_kind, scanned_min, scanned_max);
     }
 
     let (min_searched, max_searched) = ds
-        .load_search_progress(&address)
+        .load_search_progress(&address, filter_kind)
         .unwrap_or((scanned_min, scanned_max));
 
     // Adapt the next ExtendDown window based on hit density. Empty window →

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -72,7 +72,9 @@ pub async fn run_network_task(
 
         // Spawn each request as a separate task for concurrency
         tokio::spawn(async move {
+            let cancel_inner = cancel.clone();
             let task = async move {
+                let cancel = cancel_inner;
                 match action {
                     Action::FetchRecentBlocks { count } => {
                         let start = std::time::Instant::now();
@@ -132,7 +134,7 @@ pub async fn run_network_task(
                     Action::FetchAddressInfo { address } => {
                         let _ = tx.send(Action::NavigateToAddress { address });
                         address::fetch_and_send_address_info(
-                            address, &ds, &abi_reg, &dune, &pf, &voyager, &tx,
+                            address, &ds, &abi_reg, &dune, &pf, &voyager, &tx, &cancel,
                         )
                         .await;
                     }
@@ -205,8 +207,10 @@ pub async fn run_network_task(
                         }
                     }
                     Action::ResolveSearch { query } => {
-                        search::resolve_search(query, &ds, &abi_reg, &dune, &pf, &voyager, &tx)
-                            .await;
+                        search::resolve_search(
+                            query, &ds, &abi_reg, &dune, &pf, &voyager, &tx, &cancel,
+                        )
+                        .await;
                     }
                     Action::EnrichAddressTxs { address, hashes } => {
                         address::enrich_address_txs(

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -283,6 +283,7 @@ pub async fn run_network_task(
                         address,
                         from_block,
                         continuation_token,
+                        window_size,
                         limit,
                     } => {
                         // On first page, emit cached rows immediately so the UI
@@ -302,6 +303,7 @@ pub async fn run_network_task(
                                 address,
                                 from_block,
                                 continuation_token,
+                                window_size,
                                 limit,
                                 &ds,
                                 pf,
@@ -316,6 +318,7 @@ pub async fn run_network_task(
                                 address,
                                 summaries: Vec::new(),
                                 next_token: None,
+                                next_window_size: None,
                             });
                         }
                     }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -357,6 +357,21 @@ pub async fn run_network_task(
                             }
                         }
                     }
+                    Action::DecodeAddressWsEvent { address, event } => {
+                        // Streaming path from WS: a raw event for the
+                        // currently-viewed `address` arrived. Resolve its
+                        // emitter ABI, decode, and forward so the Events tab
+                        // merges the decoded row in real time. ABI miss falls
+                        // back to an undecoded `DecodedEvent` (raw keys/data
+                        // preserved) — the user still sees live activity, it
+                        // just renders without names.
+                        let abi = abi_reg.get_abi_for_address(&event.from_address).await;
+                        let decoded = crate::decode::events::decode_event(&event, abi.as_deref());
+                        let _ = tx.send(Action::AddressEventStreamed {
+                            address,
+                            decoded_event: decoded,
+                        });
+                    }
                     Action::FetchClassInfo { class_hash } => {
                         class::fetch_class_info(class_hash, &ds, &abi_reg, &dune, &pf, &tx).await;
                     }
@@ -431,6 +446,7 @@ fn action_is_cancellable(action: &Action) -> bool {
             | Action::EnrichAddressCalls { .. }
             | Action::FetchAddressMetaTxs { .. }
             | Action::ClassifyPotentialMetaTx { .. }
+            | Action::DecodeAddressWsEvent { .. }
             | Action::FetchMoreAddressTxs { .. }
     )
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -13,6 +13,7 @@ mod address;
 mod block;
 mod class;
 pub mod dune;
+pub mod event_window;
 pub mod helpers;
 pub mod prices;
 mod search;

--- a/src/network/search.rs
+++ b/src/network/search.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 
 use crate::app::actions::Action;
 use crate::data::DataSource;
@@ -26,6 +27,7 @@ pub(super) async fn resolve_search(
     pf: &Option<Arc<crate::data::pathfinder::PathfinderClient>>,
     voyager: &Option<Arc<voyager::VoyagerClient>>,
     tx: &mpsc::UnboundedSender<Action>,
+    cancel: &CancellationToken,
 ) {
     // Try as block number first
     if let Ok(num) = query.parse::<u64>() {
@@ -45,7 +47,8 @@ pub(super) async fn resolve_search(
         if is_contract {
             // It's an address — go to address view
             let _ = tx.send(Action::NavigateToAddress { address: felt });
-            address::fetch_and_send_address_info(felt, ds, abi_reg, dune, pf, voyager, tx).await;
+            address::fetch_and_send_address_info(felt, ds, abi_reg, dune, pf, voyager, tx, cancel)
+                .await;
             return;
         }
 

--- a/src/network/transaction.rs
+++ b/src/network/transaction.rs
@@ -72,19 +72,13 @@ pub(super) async fn decode_and_send_transaction(
     resolve_call_abis(&mut decoded_calls, abi_reg).await;
     let outside_executions = detect_and_resolve_outside_executions(&decoded_calls, abi_reg).await;
 
-    // Only pay for the block fetch when the tx touches a tracked token —
-    // we'd just discard the timestamp otherwise.
-    let needs_timestamp = decoded_events
-        .iter()
-        .any(|e| crate::network::prices::is_tracked(&e.contract_address));
-    let block_timestamp = if needs_timestamp {
-        ds.get_block(receipt.block_number)
-            .await
-            .ok()
-            .map(|b| b.timestamp)
-    } else {
-        None
-    };
+    // Fetch block timestamp (used for age display and price lookups on tracked tokens).
+    // Block fetches are cached, so repeat calls for the same block are cheap.
+    let block_timestamp = ds
+        .get_block(receipt.block_number)
+        .await
+        .ok()
+        .map(|b| b.timestamp);
 
     let _ = action_tx.send(Action::TransactionLoaded {
         transaction,

--- a/src/network/ws.rs
+++ b/src/network/ws.rs
@@ -1104,10 +1104,7 @@ mod tests {
         }
 
         let ws_event = actions.iter().find_map(|a| match a {
-            Action::AddressWsEvent {
-                address: ca,
-                event,
-            } if *ca == address => Some(event),
+            Action::AddressWsEvent { address: ca, event } if *ca == address => Some(event),
             _ => None,
         });
         let ev = ws_event.expect("TRANSACTION_EXECUTED must emit AddressWsEvent");
@@ -1117,10 +1114,7 @@ mod tests {
             "first key must be TRANSACTION_EXECUTED selector so the reducer \
              dispatches ClassifyPotentialMetaTx"
         );
-        assert_eq!(
-            ev.transaction_hash,
-            Felt::from_hex_unchecked(tx_hash_hex)
-        );
+        assert_eq!(ev.transaction_hash, Felt::from_hex_unchecked(tx_hash_hex));
         assert_eq!(ev.block_number, 8914198);
     }
 
@@ -1165,10 +1159,7 @@ mod tests {
         }
 
         let ws_event = actions.iter().find_map(|a| match a {
-            Action::AddressWsEvent {
-                address: ca,
-                event,
-            } if *ca == address => Some(event),
+            Action::AddressWsEvent { address: ca, event } if *ca == address => Some(event),
             _ => None,
         });
         let ev = ws_event.expect("non-TRANSACTION_EXECUTED event must still emit AddressWsEvent");

--- a/src/network/ws.rs
+++ b/src/network/ws.rs
@@ -35,7 +35,7 @@ use tracing::{debug, error, info, warn};
 use crate::app::actions::{Action, Source};
 use crate::app::state::SourceStatus;
 use crate::data::DataSource;
-use crate::data::types::{AddressTxSummary, ContractCallSummary};
+use crate::data::types::{AddressTxSummary, SnEvent};
 use crate::utils::felt_to_u64;
 
 /// Maximum reconnect delay (capped exponential backoff).
@@ -530,7 +530,7 @@ async fn handle_message(
             handle_new_heads(&params.result, data_source, response_tx).await;
         }
         SubscriptionKind::Events { address } => {
-            handle_event(&params.result, address, response_tx);
+            handle_event(&params.result, address, data_source, response_tx);
         }
         SubscriptionKind::Transactions { address } => {
             handle_new_transaction(&params.result, address, response_tx);
@@ -574,7 +574,12 @@ async fn handle_new_heads(
     }
 }
 
-fn handle_event(result: &Value, address: Felt, response_tx: &mpsc::UnboundedSender<Action>) {
+fn handle_event(
+    result: &Value,
+    address: Felt,
+    data_source: &Arc<dyn DataSource>,
+    response_tx: &mpsc::UnboundedSender<Action>,
+) {
     let event: EmittedEventWithFinality = match serde_json::from_value(result.clone()) {
         Ok(e) => e,
         Err(e) => {
@@ -585,49 +590,46 @@ fn handle_event(result: &Value, address: Felt, response_tx: &mpsc::UnboundedSend
 
     let tx_hash = event.emitted_event.transaction_hash;
     let block_number = event.emitted_event.block_number.unwrap_or(0);
+    // event_index isn't carried in the subscription payload type; the WS
+    // notification includes it, but `EmittedEventWithFinality` doesn't expose
+    // it. Persisting it as 0 means the cache dedupe key degrades to
+    // (tx_hash, block) for WS-received events — fine in practice because the
+    // same (tx, block) never fires twice legitimately, and the reload path
+    // re-fetches the full event with its real index via pf-query.
+    let sn_event = SnEvent {
+        from_address: event.emitted_event.from_address,
+        keys: event.emitted_event.keys.clone(),
+        data: event.emitted_event.data.clone(),
+        transaction_hash: tx_hash,
+        block_number,
+        event_index: 0,
+    };
+
     debug!(
         address = %format!("{:#x}", address),
         tx = %format!("{:#x}", tx_hash),
         block = block_number,
-        "Received event via WS → Calls tab"
+        "Received event via WS → cache + single broadcast"
     );
 
-    // Events tell us the contract was invoked (called) — route to Calls tab.
-    // The tx sender and function name are not available from the event payload;
-    // they will be enriched later via the normal enrichment pipeline.
-    let call = ContractCallSummary {
-        tx_hash,
-        sender: Felt::ZERO, // Unknown from event alone; will be enriched
-        function_name: String::new(),
-        block_number,
-        timestamp: 0,
-        total_fee_fri: 0,
-        status: "OK".to_string(), // Events only fire for successful txs
-    };
+    // Route through the shared event cache so subsequent helper calls
+    // (`ensure_address_events_window`, tab loaders) see the new event
+    // without a round trip.
+    data_source.merge_address_events(&address, &[sn_event.clone()]);
 
-    let _ = response_tx.send(Action::AddressCallsStreamed {
+    // Single broadcast — the reducer fans out to Calls, MetaTxs classifier,
+    // and Events tab. Avoids multiple per-tab streaming actions diverging.
+    let _ = response_tx.send(Action::AddressWsEvent {
         address,
-        calls: vec![call],
+        event: sn_event,
     });
-
-    // If the viewed address is an Argent/Braavos account, every invoke —
-    // including execute_from_outside* — emits TRANSACTION_EXECUTED. Classify
-    // the tx to see whether it's a meta-tx with this address as the intender,
-    // and if so stream it into the MetaTxs tab. Cheap check up front: only
-    // dispatch when the first key matches the selector.
-    if event
-        .emitted_event
-        .keys
-        .first()
-        .map(|k| *k == tx_executed_selector())
-        .unwrap_or(false)
-    {
-        let _ = response_tx.send(Action::ClassifyPotentialMetaTx { address, tx_hash });
-    }
 }
 
 /// Cached `TRANSACTION_EXECUTED` selector as `Felt` (parsed once per process).
-fn tx_executed_selector() -> Felt {
+///
+/// pub(crate) so the `AddressWsEvent` reducer can compare the first key of a
+/// live event without re-parsing the hex string on every WS notification.
+pub(crate) fn tx_executed_selector() -> Felt {
     use std::sync::OnceLock;
     static SELECTOR: OnceLock<Felt> = OnceLock::new();
     *SELECTOR.get_or_init(|| {
@@ -817,7 +819,72 @@ fn block_from_raw(v: &Value) -> Option<crate::data::types::SnBlock> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use starknet::core::types::AddressFilter;
+    use crate::data::types::{SnBlock, SnReceipt, SnTransaction};
+    use async_trait::async_trait;
+    use starknet::core::types::{AddressFilter, ContractClass};
+
+    /// Minimal DataSource stub for `handle_event` tests. The handler only
+    /// calls `merge_address_events` (default trait impl returns the input
+    /// unchanged) — all other methods are unused here.
+    struct TestDataSource;
+
+    #[async_trait]
+    impl DataSource for TestDataSource {
+        async fn get_latest_block_number(&self) -> crate::error::Result<u64> {
+            unimplemented!()
+        }
+        async fn get_block(&self, _number: u64) -> crate::error::Result<SnBlock> {
+            unimplemented!()
+        }
+        async fn get_block_by_hash(&self, _hash: Felt) -> crate::error::Result<u64> {
+            unimplemented!()
+        }
+        async fn get_block_with_txs(
+            &self,
+            _number: u64,
+        ) -> crate::error::Result<(SnBlock, Vec<SnTransaction>)> {
+            unimplemented!()
+        }
+        async fn get_transaction(&self, _hash: Felt) -> crate::error::Result<SnTransaction> {
+            unimplemented!()
+        }
+        async fn get_receipt(&self, _hash: Felt) -> crate::error::Result<SnReceipt> {
+            unimplemented!()
+        }
+        async fn get_nonce(&self, _address: Felt) -> crate::error::Result<Felt> {
+            unimplemented!()
+        }
+        async fn get_class_hash(&self, _address: Felt) -> crate::error::Result<Felt> {
+            unimplemented!()
+        }
+        async fn get_class(&self, _class_hash: Felt) -> crate::error::Result<ContractClass> {
+            unimplemented!()
+        }
+        async fn get_recent_blocks(&self, _count: usize) -> crate::error::Result<Vec<SnBlock>> {
+            unimplemented!()
+        }
+        async fn get_events_for_address(
+            &self,
+            _address: Felt,
+            _from_block: Option<u64>,
+            _to_block: Option<u64>,
+            _limit: usize,
+        ) -> crate::error::Result<Vec<SnEvent>> {
+            unimplemented!()
+        }
+        async fn call_contract(
+            &self,
+            _contract_address: Felt,
+            _selector: Felt,
+            _calldata: Vec<Felt>,
+        ) -> crate::error::Result<Vec<Felt>> {
+            unimplemented!()
+        }
+    }
+
+    fn test_data_source() -> Arc<dyn DataSource> {
+        Arc::new(TestDataSource)
+    }
 
     #[test]
     fn build_subscribe_new_heads_msg() {
@@ -995,12 +1062,11 @@ mod tests {
 
     /// Bug-guard (address-view live updates): when a `TRANSACTION_EXECUTED`
     /// event arrives via WS for the viewed account, `handle_event` must
-    /// fan it out to **both** the Calls tab and the meta-tx classifier.
-    /// The latter is how execute_from_outside meta-txs populate the MetaTxs
-    /// tab in real time — if this emission goes missing, MetaTxs appears
-    /// stale even while Calls keeps ticking.
+    /// emit a single `AddressWsEvent` broadcast carrying the event. The
+    /// reducer fans this out to the Calls tab and the meta-tx classifier;
+    /// this test pins the emission at the handler boundary.
     #[test]
-    fn handle_event_tx_executed_fans_out_to_calls_and_classifier() {
+    fn handle_event_tx_executed_broadcasts_ws_event() {
         use crate::app::actions::Action;
         use tokio::sync::mpsc;
 
@@ -1029,44 +1095,40 @@ mod tests {
         let result: Value = serde_json::from_str(&event_json).unwrap();
 
         let (tx, mut rx) = mpsc::unbounded_channel();
-        super::handle_event(&result, address, &tx);
+        let ds = test_data_source();
+        super::handle_event(&result, address, &ds, &tx);
 
-        // Drain everything the handler produced.
         let mut actions: Vec<Action> = Vec::new();
         while let Ok(a) = rx.try_recv() {
             actions.push(a);
         }
 
-        let saw_calls = actions
-            .iter()
-            .any(|a| matches!(a, Action::AddressCallsStreamed { .. }));
-        let saw_classify = actions.iter().any(|a| {
-            matches!(
-                a,
-                Action::ClassifyPotentialMetaTx { address: ca, .. } if *ca == address
-            )
+        let ws_event = actions.iter().find_map(|a| match a {
+            Action::AddressWsEvent {
+                address: ca,
+                event,
+            } if *ca == address => Some(event),
+            _ => None,
         });
-
-        assert!(
-            saw_calls,
-            "TRANSACTION_EXECUTED must route to the Calls tab. Got: {:?}",
-            actions
+        let ev = ws_event.expect("TRANSACTION_EXECUTED must emit AddressWsEvent");
+        assert_eq!(
+            ev.keys.first().copied(),
+            Some(super::tx_executed_selector()),
+            "first key must be TRANSACTION_EXECUTED selector so the reducer \
+             dispatches ClassifyPotentialMetaTx"
         );
-        assert!(
-            saw_classify,
-            "TRANSACTION_EXECUTED for a viewed account must dispatch \
-             ClassifyPotentialMetaTx so execute_from_outside calls \
-             populate the MetaTxs tab live. Got: {:?}",
-            actions
+        assert_eq!(
+            ev.transaction_hash,
+            Felt::from_hex_unchecked(tx_hash_hex)
         );
+        assert_eq!(ev.block_number, 8914198);
     }
 
-    /// Bug-guard: a non-`TRANSACTION_EXECUTED` event (e.g. a plain contract
-    /// event like an ERC20 Transfer) must still route to Calls but must NOT
-    /// trigger meta-tx classification — `classify_meta_tx_candidate` would
-    /// always reject it, so the dispatch is wasted work.
+    /// Bug-guard: a non-`TRANSACTION_EXECUTED` event still emits the broadcast,
+    /// but its first key must not equal the TRANSACTION_EXECUTED selector —
+    /// the reducer uses that check to skip meta-tx classification.
     #[test]
-    fn handle_event_non_tx_executed_skips_classifier() {
+    fn handle_event_non_tx_executed_broadcasts_with_other_key() {
         use crate::app::actions::Action;
         use tokio::sync::mpsc;
 
@@ -1094,20 +1156,26 @@ mod tests {
         let result: Value = serde_json::from_str(&event_json).unwrap();
 
         let (tx, mut rx) = mpsc::unbounded_channel();
-        super::handle_event(&result, address, &tx);
+        let ds = test_data_source();
+        super::handle_event(&result, address, &ds, &tx);
 
         let mut actions: Vec<Action> = Vec::new();
         while let Ok(a) = rx.try_recv() {
             actions.push(a);
         }
 
-        let saw_classify = actions
-            .iter()
-            .any(|a| matches!(a, Action::ClassifyPotentialMetaTx { .. }));
-        assert!(
-            !saw_classify,
-            "Non-TRANSACTION_EXECUTED event must not trigger meta-tx classify. Got: {:?}",
-            actions
+        let ws_event = actions.iter().find_map(|a| match a {
+            Action::AddressWsEvent {
+                address: ca,
+                event,
+            } if *ca == address => Some(event),
+            _ => None,
+        });
+        let ev = ws_event.expect("non-TRANSACTION_EXECUTED event must still emit AddressWsEvent");
+        assert_ne!(
+            ev.keys.first().copied(),
+            Some(super::tx_executed_selector()),
+            "first key must NOT match TRANSACTION_EXECUTED selector"
         );
     }
 }

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -36,6 +36,16 @@ fn tx_count_fragment(app: &App) -> String {
 }
 
 /// Count fragment for the Calls tab.
+///
+/// Priority of forms:
+/// - `"N / total"` — when an authoritative probe (Dune or cached range) gave
+///   us a count and we haven't filled it yet.
+/// - `"N+"` — when we know older history exists below the scanned floor
+///   (`event_window.min_searched > 0`) but no authoritative total is
+///   available. This is the scroll-driven signal for addresses where the
+///   only source of counts is the local `address_events` cache.
+/// - `"N"` — the window has been scanned to the bottom, or no "+ more"
+///   signal is available yet.
 fn call_count_fragment(app: &App) -> String {
     let count = app.address.calls.items.len();
     let total = app
@@ -43,8 +53,14 @@ fn call_count_fragment(app: &App) -> String {
         .activity_probe
         .as_ref()
         .map(|p| p.callee_call_count);
-    match total {
-        Some(total) if (count as u64) < total => format!("{count} / {total}"),
+    let has_more = app
+        .address
+        .event_window
+        .as_ref()
+        .is_some_and(|w| w.min_searched > 0);
+    match (total, has_more) {
+        (Some(total), _) if (count as u64) < total => format!("{count} / {total}"),
+        (_, true) => format!("{count}+"),
         _ => count.to_string(),
     }
 }
@@ -736,8 +752,17 @@ fn draw_meta_txs_tab(f: &mut Frame, app: &mut App, area: Rect) {
     // `None` only occurs before dispatch, in which case callers short-circuit
     // above on empty items — render a bare label defensively.
     let count = meta_tx_count_fragment(app).unwrap_or_default();
+    // While an adaptive walk is in flight, surface how far back we've
+    // scanned — helpful signal for sparse addresses where the first few
+    // windows return nothing and the list appears to hang.
+    let scan_suffix = match app.address.event_window.as_ref() {
+        Some(hint) if hint.min_searched > 0 && app.address.fetching_meta_txs => {
+            format!(" scanned to block {}", hint.min_searched)
+        }
+        _ => String::new(),
+    };
     let title = if app.address.fetching_meta_txs {
-        format!(" MetaTxs ({count}) fetching...{gap_suffix} ")
+        format!(" MetaTxs ({count}) fetching...{scan_suffix}{gap_suffix} ")
     } else {
         format!(" MetaTxs ({count}){gap_suffix} ")
     };

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -15,6 +15,78 @@ use crate::ui::widgets::price;
 use crate::ui::widgets::{search_bar, status_bar};
 use crate::utils::{felt_to_u64, felt_to_u128};
 
+/// Count fragment for the Txs tab — just the parens content (`"3"`, `"3 / 27"`).
+///
+/// `tx_count_fragment` / `call_count_fragment` / `meta_tx_count_fragment` are
+/// the single source of truth for what goes inside the `(...)` on each tab,
+/// shared by the compact `draw_tabs` row at the top of the view and the
+/// per-tab body title. Previously each site recomputed the fragment
+/// independently; keeping them aligned by hand was fragile (the MetaTxs body
+/// title in particular used to lag the compact row's `"+"` indicator).
+fn tx_count_fragment(app: &App) -> String {
+    let count = app.address.txs.items.len();
+    // Authoritative total is the on-chain nonce: one invoke per sender nonce.
+    // Dune's event count over-counts on hybrid accounts (it counts emitted
+    // events, not sender txs) — not suitable here.
+    let total = app.address.info.as_ref().map(|i| felt_to_u64(&i.nonce));
+    match total {
+        Some(total) if (count as u64) < total => format!("{count} / {total}"),
+        _ => count.to_string(),
+    }
+}
+
+/// Count fragment for the Calls tab.
+fn call_count_fragment(app: &App) -> String {
+    let count = app.address.calls.items.len();
+    let total = app
+        .address
+        .activity_probe
+        .as_ref()
+        .map(|p| p.callee_call_count);
+    match total {
+        Some(total) if (count as u64) < total => format!("{count} / {total}"),
+        _ => count.to_string(),
+    }
+}
+
+/// Count fragment for the MetaTxs tab. Returns `None` when the tab hasn't
+/// been dispatched yet and has no rows — callers render an empty `" MetaTxs "`
+/// label in that case so users don't see a misleading `"(0)"` while the
+/// classifier is still spinning up.
+///
+/// `"N+"` signals "more results possible" while paging is in-flight or
+/// `meta_tx_has_more` is set; `"N"` alone means the classifier has exhausted
+/// the scanned window.
+fn meta_tx_count_fragment(app: &App) -> Option<String> {
+    let count = app.address.meta_txs.items.len();
+    if !app.address.meta_txs_dispatched && count == 0 {
+        return None;
+    }
+    if app.address.meta_tx_has_more || app.address.fetching_meta_txs {
+        Some(format!("{count}+"))
+    } else {
+        Some(count.to_string())
+    }
+}
+
+/// Title suffix describing any passive gap the event-window helper reported
+/// on its last fetch. Shared between the Calls and MetaTxs tabs (Events tab
+/// is intentionally excluded here — see task #13 for a follow-up review).
+/// Returns an empty string when no gap is known, so callers can always
+/// concatenate without a None-check.
+fn event_window_gap_suffix(app: &App) -> String {
+    let Some(hint) = app.address.event_window.as_ref() else {
+        return String::new();
+    };
+    match hint.deferred_gap {
+        Some((lo, hi)) => {
+            let span = hi.saturating_sub(lo).saturating_add(1);
+            format!(" — gap {lo}..{hi} ({span} blocks deferred) ")
+        }
+        None => String::new(),
+    }
+}
+
 pub fn draw(f: &mut Frame, app: &mut App) {
     let has_deploy = app.address.deployment.is_some();
     let has_deployer = app
@@ -225,9 +297,6 @@ fn draw_header(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_tabs(f: &mut Frame, app: &App, area: Rect) {
-    let tx_count = app.address.txs.items.len();
-    let meta_count = app.address.meta_txs.items.len();
-    let call_count = app.address.calls.items.len();
     let bal_count = app
         .address
         .info
@@ -235,44 +304,15 @@ fn draw_tabs(f: &mut Frame, app: &App, area: Rect) {
         .map(|i| i.token_balances.len())
         .unwrap_or(0);
     let ev_count = app.address.events.items.len();
-
     let class_count = app.address.class_history.len();
 
-    // Probe gives the authoritative total when it's landed. Surface it as
-    // "loaded / total" so the user sees "3 / 27" instead of just "3" and
-    // knows there's more behind pagination.
-    //
-    // For senders (Txs tab), the authoritative total is the on-chain nonce —
-    // Dune's event count counts emitted events, not sender txs, so it
-    // over-counts wildly on hybrid accounts. For callees (Calls tab), the
-    // probe's event-derived count is the right signal.
-    let probe = app.address.activity_probe.as_ref();
-    let tx_total = app.address.info.as_ref().map(|i| felt_to_u64(&i.nonce));
-    let call_total = probe.map(|p| p.callee_call_count);
-    let tx_label = match tx_total {
-        Some(total) if (tx_count as u64) < total => {
-            format!(" Txs ({tx_count} / {total}) ")
-        }
-        _ => format!(" Txs ({tx_count}) "),
-    };
-    let call_label = match call_total {
-        Some(total) if (call_count as u64) < total => {
-            format!(" Calls ({call_count} / {total}) ")
-        }
-        _ => format!(" Calls ({call_count}) "),
-    };
-
-    // MetaTxs: no upstream count exists (requires classification). Show a
-    // progress indicator instead:
-    //   - before dispatch: " MetaTxs " (body shows spinner)
-    //   - while paging:    " MetaTxs (N+) "  — "+" signals more possible
-    //   - exhausted:       " MetaTxs (N) "   — definitive count
-    let meta_label = if !app.address.meta_txs_dispatched && meta_count == 0 {
-        " MetaTxs ".to_string()
-    } else if app.address.meta_tx_has_more || app.address.fetching_meta_txs {
-        format!(" MetaTxs ({meta_count}+) ")
-    } else {
-        format!(" MetaTxs ({meta_count}) ")
+    let tx_label = format!(" Txs ({}) ", tx_count_fragment(app));
+    let call_label = format!(" Calls ({}) ", call_count_fragment(app));
+    // None ⇒ classifier hasn't been dispatched yet — render a bare label so
+    // users don't see a misleading "(0)" while the tab is still warming up.
+    let meta_label = match meta_tx_count_fragment(app) {
+        Some(frag) => format!(" MetaTxs ({frag}) "),
+        None => " MetaTxs ".to_string(),
     };
 
     let titles = vec![
@@ -433,18 +473,11 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
         Some(g) => format!(" — gap of {} txs (press r to retry) ", g.missing_count),
         None => String::new(),
     };
+    let count = tx_count_fragment(app);
     let title = if app.is_loading {
-        format!(
-            " Transactions ({}) fetching...{} ",
-            app.address.txs.items.len(),
-            gap_suffix
-        )
+        format!(" Transactions ({count}) fetching...{gap_suffix} ")
     } else {
-        format!(
-            " Transactions ({}){} ",
-            app.address.txs.items.len(),
-            gap_suffix
-        )
+        format!(" Transactions ({count}){gap_suffix} ")
     };
 
     let list = List::new(items)
@@ -563,10 +596,12 @@ fn draw_calls_tab(f: &mut Frame, app: &mut App, area: Rect) {
         })
         .collect();
 
+    let gap_suffix = event_window_gap_suffix(app);
+    let count = call_count_fragment(app);
     let title = if app.is_loading {
-        format!(" Calls ({}) fetching... ", app.address.calls.items.len())
+        format!(" Calls ({count}) fetching...{gap_suffix} ")
     } else {
-        format!(" Calls ({}) ", app.address.calls.items.len())
+        format!(" Calls ({count}){gap_suffix} ")
     };
 
     let list = List::new(items)
@@ -696,13 +731,15 @@ fn draw_meta_txs_tab(f: &mut Frame, app: &mut App, area: Rect) {
         })
         .collect();
 
+    let gap_suffix = event_window_gap_suffix(app);
+    // The body title shows the same count fragment as the compact tab row.
+    // `None` only occurs before dispatch, in which case callers short-circuit
+    // above on empty items — render a bare label defensively.
+    let count = meta_tx_count_fragment(app).unwrap_or_default();
     let title = if app.address.fetching_meta_txs {
-        format!(
-            " MetaTxs ({}) fetching... ",
-            app.address.meta_txs.items.len()
-        )
+        format!(" MetaTxs ({count}) fetching...{gap_suffix} ")
     } else {
-        format!(" MetaTxs ({}) ", app.address.meta_txs.items.len())
+        format!(" MetaTxs ({count}){gap_suffix} ")
     };
 
     let list = List::new(items)

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -605,10 +605,12 @@ fn draw_calls_tab(f: &mut Frame, app: &mut App, area: Rect) {
         ..area
     };
     let header = Paragraph::new(Line::from(vec![
-        Span::styled("    Sender              ", theme::SUGGESTION_STYLE),
+        Span::styled("    Sender                   ", theme::SUGGESTION_STYLE),
         Span::styled("Function             ", theme::SUGGESTION_STYLE),
         Span::styled("Hash          ", theme::SUGGESTION_STYLE),
+        Span::styled("Nonce     ", theme::SUGGESTION_STYLE),
         Span::styled("Fee(STRK)        ", theme::SUGGESTION_STYLE),
+        Span::styled("Tip              ", theme::SUGGESTION_STYLE),
         Span::styled("Block     ", theme::SUGGESTION_STYLE),
         Span::styled("St  ", theme::SUGGESTION_STYLE),
         Span::styled("Age  ", theme::SUGGESTION_STYLE),
@@ -639,8 +641,8 @@ fn draw_calls_tab(f: &mut Frame, app: &mut App, area: Rect) {
         .iter()
         .map(|call| {
             let sender_label = app.format_address(&call.sender);
-            let sender_display = if sender_label.chars().count() > 20 {
-                let truncated: String = sender_label.chars().take(19).collect();
+            let sender_display = if sender_label.chars().count() > 25 {
+                let truncated: String = sender_label.chars().take(24).collect();
                 format!("{truncated}…")
             } else {
                 sender_label
@@ -654,6 +656,15 @@ fn draw_calls_tab(f: &mut Frame, app: &mut App, area: Rect) {
             let fee_str = format_strk_u128(call.total_fee_fri)
                 .trim_end_matches(" STRK")
                 .to_string();
+            let nonce_str = match call.nonce {
+                Some(n) => n.to_string(),
+                None => "—".to_string(),
+            };
+            let tip_str = if call.tip > 0 {
+                format_fri(call.tip as u128)
+            } else {
+                "0".to_string()
+            };
             let status_style = match call.status.as_str() {
                 "OK" => theme::STATUS_OK,
                 "REV" => theme::STATUS_REVERTED,
@@ -661,13 +672,15 @@ fn draw_calls_tab(f: &mut Frame, app: &mut App, area: Rect) {
             };
 
             let line = Line::from(vec![
-                Span::styled(format!(" {:<20}", sender_display), theme::LABEL_STYLE),
+                Span::styled(format!(" {:<25} ", sender_display), theme::LABEL_STYLE),
                 Span::styled(format!("{:<21}", func), theme::LABEL_STYLE),
                 Span::styled(
                     format!("{:<14}", short_hash(&call.tx_hash)),
                     theme::TX_HASH_STYLE,
                 ),
+                Span::styled(format!("{:<10}", nonce_str), theme::NORMAL_STYLE),
                 Span::styled(format!("{:<17}", fee_str), theme::TX_FEE_STYLE),
+                Span::styled(format!("{:<17}", tip_str), theme::SUGGESTION_STYLE),
                 Span::styled(
                     format!("#{:<9}", call.block_number),
                     theme::BLOCK_NUMBER_STYLE,

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -88,27 +88,36 @@ fn call_count_fragment(app: &App) -> String {
     count_fragment(count, bound)
 }
 
-/// Count fragment for the MetaTxs tab. Returns `None` when the tab hasn't
-/// been dispatched yet and has no rows — callers render an empty `" MetaTxs "`
-/// label in that case so users don't see a misleading `"(0)"` while the
-/// classifier is still spinning up.
+/// Count fragment for the MetaTxs tab.
 ///
-/// While paging is in-flight (`meta_tx_has_more` or `fetching_meta_txs`),
-/// we emit [`CountBound::LowerBound`]. Once both flags drop we promote to
-/// [`CountBound::Exact`] at the current count — that matches the pre-revamp
-/// behavior. A tighter "exact when scan reached deploy_block" transition
-/// is a planned follow-up once filter_kind is tracked on the window hint.
-fn meta_tx_count_fragment(app: &App) -> Option<String> {
+/// Per the revamp spec we can only claim [`CountBound::Exact`] once the
+/// backwards scan has reached (or crossed) the deploy block — only then
+/// have we demonstrably seen every `execute_from_outside` targeting this
+/// address. Until that holds we stay [`CountBound::LowerBound`], even if
+/// `meta_tx_has_more` has flipped to false because the current fetch
+/// returned no new rows: a dry page doesn't imply history exhausted.
+///
+/// The function now always returns a fragment — callers render the label
+/// even on cold state so the tab doesn't silently hide behind a probe.
+/// "0+" on first paint is strictly more informative than no count at all.
+fn meta_tx_count_fragment(app: &App) -> String {
     let count = app.address.meta_txs.items.len() as u64;
-    if !app.address.meta_txs_dispatched && count == 0 {
-        return None;
-    }
-    let bound = if app.address.meta_tx_has_more || app.address.fetching_meta_txs {
-        CountBound::LowerBound { hint: None }
-    } else {
-        CountBound::Exact(count)
+    // Reached deploy-floor iff we know both values AND the scan has a
+    // non-zero min_searched <= deploy_block. `min_searched == 0` is the
+    // "never scanned" sentinel — never promote on that.
+    let reached_floor = match (
+        app.address.event_window.as_ref().map(|w| w.min_searched),
+        app.address.deployment.as_ref().map(|d| d.block_number),
+    ) {
+        (Some(m), Some(d)) if m > 0 => m <= d,
+        _ => false,
     };
-    Some(count_fragment(count, bound))
+    let bound = if reached_floor {
+        CountBound::Exact(count)
+    } else {
+        CountBound::LowerBound { hint: None }
+    };
+    count_fragment(count, bound)
 }
 
 /// Title suffix describing any passive gap the event-window helper reported
@@ -350,12 +359,9 @@ fn draw_tabs(f: &mut Frame, app: &App, area: Rect) {
 
     let tx_label = format!(" Txs ({}) ", tx_count_fragment(app));
     let call_label = format!(" Calls ({}) ", call_count_fragment(app));
-    // None ⇒ classifier hasn't been dispatched yet — render a bare label so
-    // users don't see a misleading "(0)" while the tab is still warming up.
-    let meta_label = match meta_tx_count_fragment(app) {
-        Some(frag) => format!(" MetaTxs ({frag}) "),
-        None => " MetaTxs ".to_string(),
-    };
+    // The fragment is always rendered — "0+" on cold state beats a bare
+    // label that hides the tab's existence while the classifier spins up.
+    let meta_label = format!(" MetaTxs ({}) ", meta_tx_count_fragment(app));
 
     let titles = vec![
         Span::raw(tx_label),
@@ -774,10 +780,8 @@ fn draw_meta_txs_tab(f: &mut Frame, app: &mut App, area: Rect) {
         .collect();
 
     let gap_suffix = event_window_gap_suffix(app);
-    // The body title shows the same count fragment as the compact tab row.
-    // `None` only occurs before dispatch, in which case callers short-circuit
-    // above on empty items — render a bare label defensively.
-    let count = meta_tx_count_fragment(app).unwrap_or_default();
+    // The body title shares the same fragment helper as the compact tab row.
+    let count = meta_tx_count_fragment(app);
     // While an adaptive walk is in flight, surface how far back we've
     // scanned — helpful signal for sparse addresses where the first few
     // windows return nothing and the list appears to hang.

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -22,10 +22,12 @@ use crate::utils::{felt_to_u64, felt_to_u128};
 /// - [`CountBound::Exact`] — the tab's total is known exactly (e.g. the
 ///   on-chain nonce for Txs, a Dune probe total for Calls). Renders as
 ///   `"N / total"` while we're filling, or bare `"N"` once `shown == total`.
-/// - [`CountBound::LowerBound`] — "at least N; more may exist". Renders as
-///   `"N+"`, or `"N / hint+"` if a non-authoritative hint suggests a rough
-///   upper bound. This is the default when no authoritative probe has
-///   completed — every tab starts here on first paint.
+/// - [`CountBound::LowerBound`] — "at least N; more may exist". Always
+///   renders with an explicit denominator — `"N / hint+"` if a hint is
+///   available and exceeds `shown`, otherwise `"N / N+"` because we
+///   know at least `shown` items exist. This is the default when no
+///   authoritative probe has completed — every tab starts here on
+///   first paint.
 ///
 /// Keeping this enum the single input to [`count_fragment`] prevents
 /// display divergence between tabs: no tab accidentally renders bare `"N"`
@@ -43,12 +45,20 @@ enum CountBound {
 /// title. Previously every site recomputed a fragment independently, and
 /// display nits (like the MetaTxs body title lagging the compact row's
 /// `"+"`) crept in.
+///
+/// Format rules:
+/// - `Exact(N)`, `shown == N` → `"N"` (full knowledge, no `+`)
+/// - `Exact(N)`, `shown < N` → `"shown / N"` (filling toward a known total)
+/// - `LowerBound` with hint `H > shown` → `"shown / H+"` (inexact hint)
+/// - `LowerBound` otherwise → `"shown / shown+"` (no better hint; we
+///   still always render a denominator so "0/0+" on a cold tab beats
+///   a lonely "0+")
 fn count_fragment(shown: u64, bound: CountBound) -> String {
     match bound {
         CountBound::Exact(total) if shown < total => format!("{shown} / {total}"),
         CountBound::Exact(_) => shown.to_string(),
         CountBound::LowerBound { hint: Some(h) } if h > shown => format!("{shown} / {h}+"),
-        CountBound::LowerBound { .. } => format!("{shown}+"),
+        CountBound::LowerBound { .. } => format!("{shown} / {shown}+"),
     }
 }
 
@@ -84,6 +94,32 @@ fn call_count_fragment(app: &App) -> String {
     let bound = match dune_total {
         Some(total) => CountBound::Exact(total),
         None => CountBound::LowerBound { hint: None },
+    };
+    count_fragment(count, bound)
+}
+
+/// Count fragment for the Events tab.
+///
+/// Events are all `from_address == ADDR` logs, sourced via the unkeyed
+/// event-window scan. Per the plan we can only claim [`CountBound::Exact`]
+/// when the backwards scan has reached deploy block; until then we stay
+/// [`CountBound::LowerBound`]. Shares the same `event_window.min_searched`
+/// signal as MetaTxs — technically imprecise because a keyed scan on a
+/// hybrid address could satisfy the floor check here even if the unkeyed
+/// scan hasn't, but that's the only signal the UI has today.
+fn events_count_fragment(app: &App) -> String {
+    let count = app.address.events.items.len() as u64;
+    let reached_floor = match (
+        app.address.event_window.as_ref().map(|w| w.min_searched),
+        app.address.deployment.as_ref().map(|d| d.block_number),
+    ) {
+        (Some(m), Some(d)) if m > 0 => m <= d,
+        _ => false,
+    };
+    let bound = if reached_floor {
+        CountBound::Exact(count)
+    } else {
+        CountBound::LowerBound { hint: None }
     };
     count_fragment(count, bound)
 }
@@ -354,7 +390,6 @@ fn draw_tabs(f: &mut Frame, app: &App, area: Rect) {
         .as_ref()
         .map(|i| i.token_balances.len())
         .unwrap_or(0);
-    let ev_count = app.address.events.items.len();
     let class_count = app.address.class_history.len();
 
     let tx_label = format!(" Txs ({}) ", tx_count_fragment(app));
@@ -368,7 +403,7 @@ fn draw_tabs(f: &mut Frame, app: &App, area: Rect) {
         Span::raw(meta_label),
         Span::raw(call_label),
         Span::raw(format!(" Balances ({bal_count}) ")),
-        Span::raw(format!(" Events ({ev_count}) ")),
+        Span::raw(format!(" Events ({}) ", events_count_fragment(app))),
         Span::raw(format!(" Class ({class_count}) ")),
     ];
     let selected = match app.address.tab {
@@ -924,10 +959,11 @@ fn draw_events_tab(f: &mut Frame, app: &mut App, area: Rect) {
         })
         .collect();
 
+    let count = events_count_fragment(app);
     let title = if app.is_loading {
-        format!(" Events ({}) fetching... ", app.address.events.items.len())
+        format!(" Events ({count}) fetching... ")
     } else {
-        format!(" Events ({}) ", app.address.events.items.len())
+        format!(" Events ({count}) ")
     };
 
     let list = List::new(items)
@@ -1066,10 +1102,23 @@ mod count_fragment_tests {
     }
 
     #[test]
-    fn lower_bound_without_hint_renders_plus_suffix() {
+    fn lower_bound_without_hint_renders_shown_over_shown_plus() {
+        // No hint ⇒ denominator defaults to `shown` itself. We know at
+        // least N items exist, so "N / N+" is both truthful and keeps
+        // the Shown/Known format across every tab state.
         assert_eq!(
             count_fragment(7, CountBound::LowerBound { hint: None }),
-            "7+"
+            "7 / 7+"
+        );
+    }
+
+    #[test]
+    fn lower_bound_zero_renders_zero_over_zero_plus() {
+        // The cold-state display the user wants on every tab — never a
+        // bare "0" or an empty label while probes are still warming up.
+        assert_eq!(
+            count_fragment(0, CountBound::LowerBound { hint: None }),
+            "0 / 0+"
         );
     }
 
@@ -1082,16 +1131,17 @@ mod count_fragment_tests {
     }
 
     #[test]
-    fn lower_bound_with_hint_at_or_below_shown_drops_to_bare_plus() {
-        // Hint is stale or conservative; at the very least `shown` exist.
-        // Don't lie about "7 / 3+" — just emit "7+".
+    fn lower_bound_with_hint_at_or_below_shown_falls_back_to_shown_denominator() {
+        // Hint is stale or conservative; we still want the Shown/Known
+        // format, so fall back to "shown / shown+" rather than a
+        // misleading "7 / 3+".
         assert_eq!(
             count_fragment(7, CountBound::LowerBound { hint: Some(3) }),
-            "7+"
+            "7 / 7+"
         );
         assert_eq!(
             count_fragment(7, CountBound::LowerBound { hint: Some(7) }),
-            "7+"
+            "7 / 7+"
         );
     }
 }

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -15,54 +15,77 @@ use crate::ui::widgets::price;
 use crate::ui::widgets::{search_bar, status_bar};
 use crate::utils::{felt_to_u64, felt_to_u128};
 
-/// Count fragment for the Txs tab — just the parens content (`"3"`, `"3 / 27"`).
+/// How confident are we in the tab's count?
 ///
-/// `tx_count_fragment` / `call_count_fragment` / `meta_tx_count_fragment` are
-/// the single source of truth for what goes inside the `(...)` on each tab,
-/// shared by the compact `draw_tabs` row at the top of the view and the
-/// per-tab body title. Previously each site recomputed the fragment
-/// independently; keeping them aligned by hand was fragile (the MetaTxs body
-/// title in particular used to lag the compact row's `"+"` indicator).
-fn tx_count_fragment(app: &App) -> String {
-    let count = app.address.txs.items.len();
-    // Authoritative total is the on-chain nonce: one invoke per sender nonce.
-    // Dune's event count over-counts on hybrid accounts (it counts emitted
-    // events, not sender txs) — not suitable here.
-    let total = app.address.info.as_ref().map(|i| felt_to_u64(&i.nonce));
-    match total {
-        Some(total) if (count as u64) < total => format!("{count} / {total}"),
-        _ => count.to_string(),
+/// The address-view revamp locks down two display states:
+///
+/// - [`CountBound::Exact`] — the tab's total is known exactly (e.g. the
+///   on-chain nonce for Txs, a Dune probe total for Calls). Renders as
+///   `"N / total"` while we're filling, or bare `"N"` once `shown == total`.
+/// - [`CountBound::LowerBound`] — "at least N; more may exist". Renders as
+///   `"N+"`, or `"N / hint+"` if a non-authoritative hint suggests a rough
+///   upper bound. This is the default when no authoritative probe has
+///   completed — every tab starts here on first paint.
+///
+/// Keeping this enum the single input to [`count_fragment`] prevents
+/// display divergence between tabs: no tab accidentally renders bare `"N"`
+/// when it only has a lower bound (the historical bug was Events/Calls
+/// hiding the `"+"` once a scan paused).
+enum CountBound {
+    Exact(u64),
+    LowerBound { hint: Option<u64> },
+}
+
+/// Render the parens content for a tab count given its [`CountBound`].
+///
+/// The single source of truth for what goes inside the `(...)` on each
+/// tab — shared by the compact `draw_tabs` row and each per-tab body
+/// title. Previously every site recomputed a fragment independently, and
+/// display nits (like the MetaTxs body title lagging the compact row's
+/// `"+"`) crept in.
+fn count_fragment(shown: u64, bound: CountBound) -> String {
+    match bound {
+        CountBound::Exact(total) if shown < total => format!("{shown} / {total}"),
+        CountBound::Exact(_) => shown.to_string(),
+        CountBound::LowerBound { hint: Some(h) } if h > shown => format!("{shown} / {h}+"),
+        CountBound::LowerBound { .. } => format!("{shown}+"),
     }
+}
+
+/// Count fragment for the Txs tab.
+///
+/// Authoritative total is the on-chain nonce (one invoke per sender nonce),
+/// so once nonce is known the bound is [`CountBound::Exact`]. Dune's event
+/// count over-counts on hybrid accounts (it counts emitted events, not
+/// sender txs) — not suitable here.
+fn tx_count_fragment(app: &App) -> String {
+    let count = app.address.txs.items.len() as u64;
+    let bound = match app.address.info.as_ref().map(|i| felt_to_u64(&i.nonce)) {
+        Some(nonce) => CountBound::Exact(nonce),
+        None => CountBound::LowerBound { hint: None },
+    };
+    count_fragment(count, bound)
 }
 
 /// Count fragment for the Calls tab.
 ///
-/// Priority of forms:
-/// - `"N / total"` — when an authoritative probe (Dune or cached range) gave
-///   us a count and we haven't filled it yet.
-/// - `"N+"` — when we know older history exists below the scanned floor
-///   (`event_window.min_searched > 0`) but no authoritative total is
-///   available. This is the scroll-driven signal for addresses where the
-///   only source of counts is the local `address_events` cache.
-/// - `"N"` — the window has been scanned to the bottom, or no "+ more"
-///   signal is available yet.
+/// Only the Dune probe total counts as "exact" here — pf-query-only
+/// backfill can't promise completeness (misses calls to contracts that
+/// don't emit events). Until Dune returns, we're in `LowerBound`. The
+/// `event_window.min_searched > 0` signal becomes the lower-bound hint's
+/// "+" indicator, not a claim of exactness.
 fn call_count_fragment(app: &App) -> String {
-    let count = app.address.calls.items.len();
-    let total = app
+    let count = app.address.calls.items.len() as u64;
+    let dune_total = app
         .address
         .activity_probe
         .as_ref()
         .map(|p| p.callee_call_count);
-    let has_more = app
-        .address
-        .event_window
-        .as_ref()
-        .is_some_and(|w| w.min_searched > 0);
-    match (total, has_more) {
-        (Some(total), _) if (count as u64) < total => format!("{count} / {total}"),
-        (_, true) => format!("{count}+"),
-        _ => count.to_string(),
-    }
+    let bound = match dune_total {
+        Some(total) => CountBound::Exact(total),
+        None => CountBound::LowerBound { hint: None },
+    };
+    count_fragment(count, bound)
 }
 
 /// Count fragment for the MetaTxs tab. Returns `None` when the tab hasn't
@@ -70,19 +93,22 @@ fn call_count_fragment(app: &App) -> String {
 /// label in that case so users don't see a misleading `"(0)"` while the
 /// classifier is still spinning up.
 ///
-/// `"N+"` signals "more results possible" while paging is in-flight or
-/// `meta_tx_has_more` is set; `"N"` alone means the classifier has exhausted
-/// the scanned window.
+/// While paging is in-flight (`meta_tx_has_more` or `fetching_meta_txs`),
+/// we emit [`CountBound::LowerBound`]. Once both flags drop we promote to
+/// [`CountBound::Exact`] at the current count — that matches the pre-revamp
+/// behavior. A tighter "exact when scan reached deploy_block" transition
+/// is a planned follow-up once filter_kind is tracked on the window hint.
 fn meta_tx_count_fragment(app: &App) -> Option<String> {
-    let count = app.address.meta_txs.items.len();
+    let count = app.address.meta_txs.items.len() as u64;
     if !app.address.meta_txs_dispatched && count == 0 {
         return None;
     }
-    if app.address.meta_tx_has_more || app.address.fetching_meta_txs {
-        Some(format!("{count}+"))
+    let bound = if app.address.meta_tx_has_more || app.address.fetching_meta_txs {
+        CountBound::LowerBound { hint: None }
     } else {
-        Some(count.to_string())
-    }
+        CountBound::Exact(count)
+    };
+    Some(count_fragment(count, bound))
 }
 
 /// Title suffix describing any passive gap the event-window helper reported
@@ -1008,4 +1034,60 @@ fn draw_class_history_tab(f: &mut Frame, app: &App, area: Rect) {
             .border_style(theme::BORDER_STYLE),
     );
     f.render_widget(list, list_area);
+}
+
+#[cfg(test)]
+mod count_fragment_tests {
+    //! The count-fragment helper is the single source of truth for what the
+    //! four address-view tabs render inside `(...)`. These tests pin its
+    //! five distinct display outputs so regressions show up here before
+    //! they surface on screen.
+    use super::{CountBound, count_fragment};
+
+    #[test]
+    fn exact_shown_less_than_total_renders_fraction() {
+        assert_eq!(count_fragment(7, CountBound::Exact(20)), "7 / 20");
+    }
+
+    #[test]
+    fn exact_shown_equal_total_renders_bare_count() {
+        assert_eq!(count_fragment(20, CountBound::Exact(20)), "20");
+    }
+
+    #[test]
+    fn exact_shown_greater_than_total_falls_back_to_bare_count() {
+        // Stale probe: Dune total lags an active stream. Never render a
+        // negative-looking "20 / 7" — fall back to the authoritative shown.
+        assert_eq!(count_fragment(20, CountBound::Exact(7)), "20");
+    }
+
+    #[test]
+    fn lower_bound_without_hint_renders_plus_suffix() {
+        assert_eq!(
+            count_fragment(7, CountBound::LowerBound { hint: None }),
+            "7+"
+        );
+    }
+
+    #[test]
+    fn lower_bound_with_hint_above_shown_renders_fraction_plus() {
+        assert_eq!(
+            count_fragment(7, CountBound::LowerBound { hint: Some(100) }),
+            "7 / 100+"
+        );
+    }
+
+    #[test]
+    fn lower_bound_with_hint_at_or_below_shown_drops_to_bare_plus() {
+        // Hint is stale or conservative; at the very least `shown` exist.
+        // Don't lie about "7 / 3+" — just emit "7+".
+        assert_eq!(
+            count_fragment(7, CountBound::LowerBound { hint: Some(3) }),
+            "7+"
+        );
+        assert_eq!(
+            count_fragment(7, CountBound::LowerBound { hint: Some(7) }),
+            "7+"
+        );
+    }
 }

--- a/src/ui/views/tx_detail.rs
+++ b/src/ui/views/tx_detail.rs
@@ -106,6 +106,24 @@ fn draw_scrollable_detail(
     } else {
         theme::BLOCK_NUMBER_STYLE
     };
+    // Block age (when the block timestamp has been fetched).
+    let age_suffix = app
+        .tx_detail
+        .block_timestamp
+        .map(|ts| {
+            let now = chrono::Utc::now().timestamp() as u64;
+            let diff = now.saturating_sub(ts);
+            if diff < 60 {
+                format!("  ({diff}s ago)")
+            } else if diff < 3600 {
+                format!("  ({}m ago)", diff / 60)
+            } else if diff < 86400 {
+                format!("  ({}h ago)", diff / 3600)
+            } else {
+                format!("  ({}d ago)", diff / 86400)
+            }
+        })
+        .unwrap_or_default();
     record(
         &TxNavItem::Block(blk_num),
         &lines,
@@ -119,6 +137,7 @@ fn draw_scrollable_detail(
         Span::styled(format!("  {}", block_hash_short), theme::BLOCK_HASH_STYLE),
         Span::styled(format!("  Idx: {}", tx.index()), theme::NORMAL_STYLE),
         Span::styled(format!("  {}", finality_str), theme::STATUS_OK),
+        Span::styled(age_suffix, theme::SUGGESTION_STYLE),
     ]));
 
     // Type
@@ -495,6 +514,11 @@ fn draw_scrollable_detail(
                 ),
                 theme::SUGGESTION_STYLE,
             ),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("   Tip:        ", theme::NORMAL_STYLE),
+            Span::raw(format_fri(tip as u128)),
+            Span::styled("  (Tip/gas)", theme::SUGGESTION_STYLE),
         ]));
 
         let res = &receipt.execution_resources;

--- a/src/ui/widgets/status_bar.rs
+++ b/src/ui/widgets/status_bar.rs
@@ -87,6 +87,20 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         spans.push(Span::styled(detail, theme::STATUS_LOADING));
     }
 
+    // Per-query registry: render up to 2 active query labels joined with
+    // " · " so parallel tab scans are both visible at once without
+    // overflowing the status bar.
+    if !app.active_queries.is_empty() {
+        let joined = app
+            .active_queries
+            .labels()
+            .take(2)
+            .collect::<Vec<_>>()
+            .join(" · ");
+        spans.push(Span::raw(" | "));
+        spans.push(Span::styled(joined, theme::STATUS_LOADING));
+    }
+
     let status =
         Paragraph::new(Line::from(spans)).style(Style::default().bg(ratatui::style::Color::Black));
     f.render_widget(status, area);

--- a/tests/dedup_test.rs
+++ b/tests/dedup_test.rs
@@ -11,6 +11,8 @@ fn make_call(tx_hash: u64, sender: u64, function_name: &str, block: u64) -> Cont
         timestamp: block * 10,
         total_fee_fri: 0,
         status: "OK".into(),
+        nonce: None,
+        tip: 0,
     }
 }
 


### PR DESCRIPTION
## Summary

This branch rebuilds the address view around a unified events stream so tab counts, tab contents, and streaming progress all come from one coherent model. 21 commits spanning from `dbe409a` forward.

### Major themes

- **Cache-first address open** — `AddressInfoLoaded` now dispatches immediately with empty `decoded_events`; the ABI decode pass runs in a background task and emits `AddressEventsCacheLoaded` when done. Previously the spinner blocked on a synchronous per-event `get_abi_for_address` loop that could stretch tens of seconds under cache-mutex contention.
- **Cancellation propagation** — sub-tasks fanned out from `fetch_and_send_address_info` now run through a `spawn_cancellable` helper. Navigating away from an address aborts stale RPC/Dune/PF work instead of letting it pile up on shared clients.
- **Merged call sources** — Dune, pf-query, and RPC rows now merge field-by-field in `deduplicate_contract_calls`, so a richer row from one source still contributes `function_name`/`fee`/`nonce` data to a hash-matched row from another.
- **Nonce + Tip columns** — `ContractCallSummary` gains `nonce: Option<u64>` and `tip: u64` (`#[serde(default)]` for back-compat). Populated on the RPC/pf-query path and rendered in the Calls tab.
- **TopDelta probes on warm cache** — address re-entry uses cached activity ranges to avoid re-probing history from scratch; a stale row still contributes a valid `min_block` floor.
- **Streaming status bar** — per-query status registry with `CountBound` helper keeps `Shown/Known+` tab counts consistent across cached and live sources.
- **Events tab revamp** — decoded events stream live via `AddressWsEvent`, MetaTxs get promoted into Calls on re-entry, and address_search_progress splits by `filter_kind` so keyed/unkeyed scans don't clobber each other's coverage.

### Commits (newest first)

- `e2aedf8` fmt-only cleanup
- `748507e` deferred cache decode, cancellation, nonce/tip (the commit from this session's uncommitted changes)
- `c7bb4c1` .. `dbe409a` — earlier work on this branch (20 commits)

## Test plan

- [ ] `cargo fmt && cargo clippy` clean
- [ ] `cargo build --release` clean
- [ ] `cargo test` (non-ignored suite) green
- [ ] Manually open a cold address in the TUI — spinner drops immediately, Events tab populates shortly after
- [ ] Navigate rapidly between addresses — no stale data leaks into the new view
- [ ] Re-open a cached address — tab counts render `Shown/Known+` without regressing to bare `Calls(N)`
- [ ] Calls tab shows Nonce + Tip columns populated for pf-query-sourced rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)