### PR TITLE
Resolve ABIs at the tx's block for tx detail decoding (#24)

### DIFF
--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -1102,6 +1102,16 @@ impl DataSource for CachingDataSource {
         Ok(class_hash)
     }
 
+    async fn get_class_hash_at(&self, address: Felt, block: u64) -> Result<Felt> {
+        // The (address, block) → class_hash mapping is immutable, but the
+        // class_history table already caches it at coarser granularity for
+        // the addresses tx decoding cares about. Pass through here; the
+        // helper that wraps this (`resolve_class_hash_at`) consults
+        // class_history first and only hits this fallback when the cached
+        // history is incomplete.
+        self.upstream.get_class_hash_at(address, block).await
+    }
+
     async fn get_class(&self, class_hash: Felt) -> Result<ContractClass> {
         // Classes are large — pass through to upstream.
         // Parsed ABIs are cached separately via the decode layer's class_cache.

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -57,6 +57,14 @@ pub trait DataSource: Send + Sync {
     async fn get_receipt(&self, hash: Felt) -> Result<SnReceipt>;
     async fn get_nonce(&self, address: Felt) -> Result<Felt>;
     async fn get_class_hash(&self, address: Felt) -> Result<Felt>;
+    /// Class hash that was active for `address` at `block`. Used by tx
+    /// decoding so old transactions render with the ABI that was deployed
+    /// when they ran, not the current one. Default implementation falls
+    /// back to `get_class_hash` (latest) — sources backed by RPC override
+    /// to use `BlockId::Number(block)`.
+    async fn get_class_hash_at(&self, address: Felt, _block: u64) -> Result<Felt> {
+        self.get_class_hash(address).await
+    }
     async fn get_class(&self, class_hash: Felt) -> Result<ContractClass>;
     async fn get_recent_blocks(&self, count: usize) -> Result<Vec<SnBlock>>;
     /// Fetch recent events emitted by or targeting an address.

--- a/src/data/rpc.rs
+++ b/src/data/rpc.rs
@@ -276,6 +276,13 @@ impl DataSource for RpcDataSource {
             .map_err(|e| SnbeatError::Provider(e.to_string()))
     }
 
+    async fn get_class_hash_at(&self, address: Felt, block: u64) -> Result<Felt> {
+        self.provider
+            .get_class_hash_at(BlockId::Number(block), address)
+            .await
+            .map_err(|e| SnbeatError::Provider(e.to_string()))
+    }
+
     async fn get_class(&self, class_hash: Felt) -> Result<ContractClass> {
         self.provider
             .get_class(BlockId::Tag(BlockTag::Latest), class_hash)

--- a/src/network/helpers.rs
+++ b/src/network/helpers.rs
@@ -102,13 +102,23 @@ pub async fn resolve_class_hash_at(
     // 1. cached class_history (desc-ordered).
     let mut history = ds.load_cached_class_history(&address);
 
-    // The cache is "complete" when the oldest entry's block <= our target —
-    // we can find the right class. If the target is older than anything we
-    // know about, refetch.
-    let cache_covers = history
+    // The cache "covers" the target block only if BOTH:
+    //   * the oldest cached entry is at/before `block` (cache reaches back
+    //     far enough to find the right class), AND
+    //   * pf-query has validated the cache forward through at least `block`
+    //     (no unobserved `replace_class` could sit between the newest cached
+    //     entry and `block`).
+    // Skipping the forward check would let a stale cache satisfy a newer
+    // target block and return the wrong class hash.
+    let reaches_back = history
         .last()
         .map(|e| e.block_number <= block)
         .unwrap_or(false);
+    let validated_through_target = ds
+        .load_class_history_max_block(&address)
+        .map(|max_block| max_block >= block)
+        .unwrap_or(false);
+    let cache_covers = reaches_back && validated_through_target;
     if !cache_covers && let Some(pf) = pf {
         match pf.get_class_history(address).await {
             Ok(entries) => {
@@ -167,9 +177,12 @@ pub async fn prewarm_abis_at(
     let addrs: Vec<Felt> = addresses.into_iter().collect();
 
     // Resolve all (address → class_hash @ block) in parallel.
-    let resolutions = futures::future::join_all(addrs.iter().copied().map(|a| async move {
-        (a, resolve_class_hash_at(a, block, ds, pf).await)
-    }))
+    let resolutions = futures::future::join_all(
+        addrs
+            .iter()
+            .copied()
+            .map(|a| async move { (a, resolve_class_hash_at(a, block, ds, pf).await) }),
+    )
     .await;
 
     let mut addr_to_class: HashMap<Felt, Felt> = HashMap::new();

--- a/src/network/helpers.rs
+++ b/src/network/helpers.rs
@@ -80,6 +80,120 @@ pub async fn prewarm_abis(addresses: impl IntoIterator<Item = Felt>, abi_reg: &A
     futures::future::join_all(futs).await;
 }
 
+/// Resolve the class hash that was active for `address` at `block`.
+///
+/// Tries in order:
+/// 1. Cached class_history (populated by address-view visits or earlier
+///    tx-decode calls). Pick the latest entry with `block_number <= block`.
+/// 2. pf-query `/class-history/{address}`, then save full history to cache.
+/// 3. RPC `starknet_getClassHashAt(BlockId::Number(block), address)`.
+///    Result is intentionally NOT written into class_history — that table
+///    is a list of class-hash *changes*, and a single point lookup would
+///    falsely indicate "this is the only class this address ever had".
+///
+/// Returns `None` if all three fail; callers should fall back to the
+/// latest-ABI path.
+pub async fn resolve_class_hash_at(
+    address: Felt,
+    block: u64,
+    ds: &Arc<dyn DataSource>,
+    pf: Option<&Arc<PathfinderClient>>,
+) -> Option<Felt> {
+    // 1. cached class_history (desc-ordered).
+    let mut history = ds.load_cached_class_history(&address);
+
+    // The cache is "complete" when the oldest entry's block <= our target —
+    // we can find the right class. If the target is older than anything we
+    // know about, refetch.
+    let cache_covers = history
+        .last()
+        .map(|e| e.block_number <= block)
+        .unwrap_or(false);
+    if !cache_covers && let Some(pf) = pf {
+        match pf.get_class_history(address).await {
+            Ok(entries) => {
+                if !entries.is_empty() {
+                    let latest = ds.get_latest_block_number().await.unwrap_or(0);
+                    ds.save_class_history(&address, &entries);
+                    if latest > 0 {
+                        ds.save_class_history_max_block(&address, latest);
+                    }
+                    history = entries;
+                }
+            }
+            Err(e) => {
+                debug!(address = %format!("{:#x}", address), error = %e, "pf-query class-history fetch failed");
+            }
+        }
+    }
+
+    // 2. scan desc-ordered history for first entry with block_number <= target
+    for entry in &history {
+        if entry.block_number <= block {
+            if let Ok(felt) = Felt::from_hex(&entry.class_hash) {
+                return Some(felt);
+            }
+            warn!(class_hash = %entry.class_hash, "Bad class_hash hex in class_history");
+            break;
+        }
+    }
+
+    // 3. RPC fallback (don't cache — see doc comment).
+    match ds.get_class_hash_at(address, block).await {
+        Ok(ch) => Some(ch),
+        Err(e) => {
+            debug!(address = %format!("{:#x}", address), block, error = %e, "RPC get_class_hash_at failed");
+            None
+        }
+    }
+}
+
+/// Pre-warm ABIs for every address used in a tx, resolving each one's
+/// class hash *as of `block`* (not latest). Returns the address → class_hash
+/// map so callers can decode events / calls against the correct ABI by
+/// passing the resolved class to `AbiRegistry::get_abi_for_class` (which
+/// will be a cache hit after this prewarm).
+///
+/// Addresses that fail to resolve are simply omitted from the returned
+/// map; callers should fall back to `AbiRegistry::get_abi_for_address`
+/// (latest) for those.
+pub async fn prewarm_abis_at(
+    addresses: impl IntoIterator<Item = Felt>,
+    block: u64,
+    ds: &Arc<dyn DataSource>,
+    pf: Option<&Arc<PathfinderClient>>,
+    abi_reg: &AbiRegistry,
+) -> HashMap<Felt, Felt> {
+    let addrs: Vec<Felt> = addresses.into_iter().collect();
+
+    // Resolve all (address → class_hash @ block) in parallel.
+    let resolutions = futures::future::join_all(addrs.iter().copied().map(|a| async move {
+        (a, resolve_class_hash_at(a, block, ds, pf).await)
+    }))
+    .await;
+
+    let mut addr_to_class: HashMap<Felt, Felt> = HashMap::new();
+    let mut unique_classes: HashSet<Felt> = HashSet::new();
+    for (addr, class_opt) in resolutions {
+        if let Some(ch) = class_opt {
+            addr_to_class.insert(addr, ch);
+            unique_classes.insert(ch);
+        }
+    }
+
+    // Prewarm ABIs for each unique class_hash in parallel.
+    let class_futs: Vec<_> = unique_classes
+        .iter()
+        .copied()
+        .map(|ch| async move {
+            let _ = abi_reg.get_abi_for_class(&ch).await;
+        })
+        .collect();
+    futures::future::join_all(class_futs).await;
+
+    addr_to_class
+}
+
 /// Extract execution status string from a receipt.
 pub fn receipt_status(receipt: Option<&SnReceipt>) -> String {
     receipt

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -130,7 +130,14 @@ pub async fn run_network_task(
                             .await;
                     }
                     Action::FetchTransaction { hash } => {
-                        transaction::fetch_and_send_transaction(hash, &ds, &abi_reg, &tx).await;
+                        transaction::fetch_and_send_transaction(
+                            hash,
+                            &ds,
+                            pf.as_ref(),
+                            &abi_reg,
+                            &tx,
+                        )
+                        .await;
                     }
                     Action::FetchAddressInfo { address } => {
                         let _ = tx.send(Action::NavigateToAddress { address });
@@ -184,7 +191,12 @@ pub async fn run_network_task(
                                         match ds.get_receipt(*hash).await {
                                             Ok(receipt) => {
                                                 transaction::decode_and_send_transaction(
-                                                    fetched_tx, receipt, &ds, &abi_reg, &tx,
+                                                    fetched_tx,
+                                                    receipt,
+                                                    &ds,
+                                                    pf.as_ref(),
+                                                    &abi_reg,
+                                                    &tx,
                                                 )
                                                 .await;
                                             }

--- a/src/network/search.rs
+++ b/src/network/search.rs
@@ -63,6 +63,7 @@ pub(super) async fn resolve_search(
                             transaction,
                             receipt,
                             ds,
+                            pf.as_ref(),
                             abi_reg,
                             tx,
                         )

--- a/src/network/transaction.rs
+++ b/src/network/transaction.rs
@@ -1,14 +1,18 @@
 //! Transaction-related network functions: fetching, decoding, and resolving call ABIs.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
+use starknet::core::types::Felt;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info};
 
 use crate::app::actions::Action;
 use crate::data::DataSource;
+use crate::data::pathfinder::PathfinderClient;
 use crate::data::types::SnTransaction;
 use crate::decode::AbiRegistry;
+use crate::decode::abi::ParsedAbi;
 use crate::decode::events::decode_event;
 use crate::decode::functions::parse_multicall;
 use crate::decode::outside_execution::{
@@ -16,17 +20,47 @@ use crate::decode::outside_execution::{
     looks_like_outside_execution, parse_forwarder_call, parse_outside_execution,
 };
 
+/// Resolve the ABI for `addr` as of `block`. Prefers the prewarmed
+/// `addr_to_class` map; on miss, falls back to a synchronous resolve via
+/// `class_history` (cached or fetched). If that also fails, falls through
+/// to the latest-ABI path (same behaviour as pre-issue-#24 code) so any
+/// degradation is graceful.
+async fn abi_at_block(
+    addr: &Felt,
+    block: u64,
+    addr_to_class: &HashMap<Felt, Felt>,
+    ds: &Arc<dyn DataSource>,
+    pf: Option<&Arc<PathfinderClient>>,
+    abi_reg: &AbiRegistry,
+) -> Option<Arc<ParsedAbi>> {
+    if let Some(class_hash) = addr_to_class.get(addr) {
+        return abi_reg.get_abi_for_class(class_hash).await;
+    }
+    if block > 0
+        && let Some(class_hash) = super::helpers::resolve_class_hash_at(*addr, block, ds, pf).await
+    {
+        return abi_reg.get_abi_for_class(&class_hash).await;
+    }
+    abi_reg.get_abi_for_address(addr).await
+}
+
 /// Resolve selector names, function definitions, and contract ABIs for a list of calls.
 /// Shared by all code paths that produce a `TransactionLoaded` action.
 pub(super) async fn resolve_call_abis(
     calls: &mut [crate::decode::functions::RawCall],
+    block: u64,
+    addr_to_class: &HashMap<Felt, Felt>,
+    ds: &Arc<dyn DataSource>,
+    pf: Option<&Arc<PathfinderClient>>,
     abi_reg: &Arc<AbiRegistry>,
 ) {
     for call in calls.iter_mut() {
         if let Some(name) = abi_reg.get_selector_name(&call.selector) {
             call.function_name = Some(name);
         }
-        if let Some(abi) = abi_reg.get_abi_for_address(&call.contract_address).await {
+        if let Some(abi) =
+            abi_at_block(&call.contract_address, block, addr_to_class, ds, pf, abi_reg).await
+        {
             if let Some(func) = abi.get_function(&call.selector) {
                 if call.function_name.is_none() {
                     call.function_name = Some(func.name.clone());
@@ -43,18 +77,23 @@ pub(super) async fn decode_and_send_transaction(
     transaction: SnTransaction,
     receipt: crate::data::types::SnReceipt,
     ds: &Arc<dyn DataSource>,
+    pf: Option<&Arc<PathfinderClient>>,
     abi_reg: &Arc<AbiRegistry>,
     action_tx: &mpsc::UnboundedSender<Action>,
 ) {
+    let block = receipt.block_number;
+
     // Parse multicall up front so we can prewarm the ABI cache for every
     // unique address referenced by this tx (event sources + call targets)
-    // in a single parallel round-trip. Every subsequent per-event /
-    // per-call `get_abi_for_address` call then hits warm cache.
+    // in a single parallel round-trip — resolving each address's class
+    // hash *as of `block`* so post-upgrade contracts decode pre-upgrade
+    // events correctly (issue #24). Subsequent per-event / per-call ABI
+    // lookups consult the resolved (address → class_hash) map first.
     let mut decoded_calls = match &transaction {
         SnTransaction::Invoke(invoke) => parse_multicall(&invoke.calldata),
         _ => Vec::new(),
     };
-    let mut prewarm_targets: std::collections::HashSet<starknet::core::types::Felt> =
+    let mut prewarm_targets: std::collections::HashSet<Felt> =
         std::collections::HashSet::with_capacity(receipt.events.len() + decoded_calls.len());
     for event in &receipt.events {
         prewarm_targets.insert(event.from_address);
@@ -62,23 +101,27 @@ pub(super) async fn decode_and_send_transaction(
     for call in &decoded_calls {
         prewarm_targets.insert(call.contract_address);
     }
-    super::helpers::prewarm_abis(prewarm_targets, abi_reg).await;
+    let addr_to_class = if block > 0 {
+        super::helpers::prewarm_abis_at(prewarm_targets, block, ds, pf, abi_reg).await
+    } else {
+        // Pending tx (no block yet). Use latest-ABI prewarm.
+        super::helpers::prewarm_abis(prewarm_targets, abi_reg).await;
+        HashMap::new()
+    };
 
     let mut decoded_events = Vec::with_capacity(receipt.events.len());
     for event in &receipt.events {
-        let abi = abi_reg.get_abi_for_address(&event.from_address).await;
+        let abi = abi_at_block(&event.from_address, block, &addr_to_class, ds, pf, abi_reg).await;
         decoded_events.push(decode_event(event, abi.as_deref()));
     }
-    resolve_call_abis(&mut decoded_calls, abi_reg).await;
-    let outside_executions = detect_and_resolve_outside_executions(&decoded_calls, abi_reg).await;
+    resolve_call_abis(&mut decoded_calls, block, &addr_to_class, ds, pf, abi_reg).await;
+    let outside_executions =
+        detect_and_resolve_outside_executions(&decoded_calls, block, &addr_to_class, ds, pf, abi_reg)
+            .await;
 
     // Fetch block timestamp (used for age display and price lookups on tracked tokens).
     // Block fetches are cached, so repeat calls for the same block are cheap.
-    let block_timestamp = ds
-        .get_block(receipt.block_number)
-        .await
-        .ok()
-        .map(|b| b.timestamp);
+    let block_timestamp = ds.get_block(block).await.ok().map(|b| b.timestamp);
 
     let _ = action_tx.send(Action::TransactionLoaded {
         transaction,
@@ -98,6 +141,10 @@ pub(super) async fn decode_and_send_transaction(
 /// 3. By known forwarder address (AVNU paymaster wraps outside execution in execute/execute_sponsored)
 async fn detect_and_resolve_outside_executions(
     calls: &[crate::decode::functions::RawCall],
+    block: u64,
+    addr_to_class: &HashMap<Felt, Felt>,
+    ds: &Arc<dyn DataSource>,
+    pf: Option<&Arc<PathfinderClient>>,
     abi_reg: &Arc<AbiRegistry>,
 ) -> Vec<(usize, OutsideExecutionInfo)> {
     let mut results = Vec::new();
@@ -120,7 +167,7 @@ async fn detect_and_resolve_outside_executions(
         }
 
         if let Some(mut oe) = oe {
-            resolve_call_abis(&mut oe.inner_calls, abi_reg).await;
+            resolve_call_abis(&mut oe.inner_calls, block, addr_to_class, ds, pf, abi_reg).await;
             results.push((i, oe));
         }
     }
@@ -132,6 +179,7 @@ async fn detect_and_resolve_outside_executions(
 pub(super) async fn fetch_and_send_transaction(
     hash: starknet::core::types::Felt,
     ds: &Arc<dyn DataSource>,
+    pf: Option<&Arc<PathfinderClient>>,
     abi_reg: &Arc<AbiRegistry>,
     tx: &mpsc::UnboundedSender<Action>,
 ) {
@@ -145,7 +193,7 @@ pub(super) async fn fetch_and_send_transaction(
     match (tx_result, receipt_result) {
         (Ok(transaction), Ok(receipt)) => {
             info!(tx_hash = %hash_short, elapsed_ms = start.elapsed().as_millis(), "Transaction fetched, decoding");
-            decode_and_send_transaction(transaction, receipt, ds, abi_reg, tx).await;
+            decode_and_send_transaction(transaction, receipt, ds, pf, abi_reg, tx).await;
         }
         (Err(e), _) | (_, Err(e)) => {
             error!(tx_hash = %hash_short, elapsed_ms = start.elapsed().as_millis(), error = %e, "Failed to fetch transaction");

--- a/src/network/transaction.rs
+++ b/src/network/transaction.rs
@@ -58,8 +58,15 @@ pub(super) async fn resolve_call_abis(
         if let Some(name) = abi_reg.get_selector_name(&call.selector) {
             call.function_name = Some(name);
         }
-        if let Some(abi) =
-            abi_at_block(&call.contract_address, block, addr_to_class, ds, pf, abi_reg).await
+        if let Some(abi) = abi_at_block(
+            &call.contract_address,
+            block,
+            addr_to_class,
+            ds,
+            pf,
+            abi_reg,
+        )
+        .await
         {
             if let Some(func) = abi.get_function(&call.selector) {
                 if call.function_name.is_none() {
@@ -115,9 +122,15 @@ pub(super) async fn decode_and_send_transaction(
         decoded_events.push(decode_event(event, abi.as_deref()));
     }
     resolve_call_abis(&mut decoded_calls, block, &addr_to_class, ds, pf, abi_reg).await;
-    let outside_executions =
-        detect_and_resolve_outside_executions(&decoded_calls, block, &addr_to_class, ds, pf, abi_reg)
-            .await;
+    let outside_executions = detect_and_resolve_outside_executions(
+        &decoded_calls,
+        block,
+        &addr_to_class,
+        ds,
+        pf,
+        abi_reg,
+    )
+    .await;
 
     // Fetch block timestamp (used for age display and price lookups on tracked tokens).
     // Block fetches are cached, so repeat calls for the same block are cheap.

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -433,7 +433,7 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
         Span::styled("   Nonce     ", theme::SUGGESTION_STYLE),
         Span::styled("Type            ", theme::SUGGESTION_STYLE),
         Span::styled("Hash          ", theme::SUGGESTION_STYLE),
-        Span::styled("Endpoint             ", theme::SUGGESTION_STYLE),
+        Span::styled("Endpoint(s)                    ", theme::SUGGESTION_STYLE),
         Span::styled("Fee(STRK)        ", theme::SUGGESTION_STYLE),
         Span::styled("Tip              ", theme::SUGGESTION_STYLE),
         Span::styled("Block     ", theme::SUGGESTION_STYLE),
@@ -483,8 +483,8 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
                 "0".to_string()
             };
             let age = format_age(tx.timestamp);
-            let endpoint = if tx.endpoint_names.chars().count() > 20 {
-                let truncated: String = tx.endpoint_names.chars().take(19).collect();
+            let endpoint = if tx.endpoint_names.chars().count() > 30 {
+                let truncated: String = tx.endpoint_names.chars().take(29).collect();
                 format!("{truncated}…")
             } else {
                 tx.endpoint_names.clone()
@@ -511,7 +511,7 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
                     format!("{:<14}", short_hash(&tx.hash)),
                     theme::TX_HASH_STYLE,
                 ),
-                Span::styled(format!("{:<21}", endpoint), theme::LABEL_STYLE),
+                Span::styled(format!("{:<31}", endpoint), theme::LABEL_STYLE),
                 Span::styled(format!("{:<17}", fee_str), theme::TX_FEE_STYLE),
                 Span::styled(format!("{:<17}", tip_str), theme::SUGGESTION_STYLE),
                 Span::styled(
@@ -606,7 +606,7 @@ fn draw_calls_tab(f: &mut Frame, app: &mut App, area: Rect) {
     };
     let header = Paragraph::new(Line::from(vec![
         Span::styled("    Sender                   ", theme::SUGGESTION_STYLE),
-        Span::styled("Function             ", theme::SUGGESTION_STYLE),
+        Span::styled("Endpoint(s)                    ", theme::SUGGESTION_STYLE),
         Span::styled("Hash          ", theme::SUGGESTION_STYLE),
         Span::styled("Nonce     ", theme::SUGGESTION_STYLE),
         Span::styled("Fee(STRK)        ", theme::SUGGESTION_STYLE),
@@ -647,8 +647,8 @@ fn draw_calls_tab(f: &mut Frame, app: &mut App, area: Rect) {
             } else {
                 sender_label
             };
-            let func = if call.function_name.chars().count() > 20 {
-                let truncated: String = call.function_name.chars().take(19).collect();
+            let func = if call.function_name.chars().count() > 30 {
+                let truncated: String = call.function_name.chars().take(29).collect();
                 format!("{truncated}…")
             } else {
                 call.function_name.clone()
@@ -673,7 +673,7 @@ fn draw_calls_tab(f: &mut Frame, app: &mut App, area: Rect) {
 
             let line = Line::from(vec![
                 Span::styled(format!(" {:<25} ", sender_display), theme::LABEL_STYLE),
-                Span::styled(format!("{:<21}", func), theme::LABEL_STYLE),
+                Span::styled(format!("{:<31}", func), theme::LABEL_STYLE),
                 Span::styled(
                     format!("{:<14}", short_hash(&call.tx_hash)),
                     theme::TX_HASH_STYLE,
@@ -728,7 +728,7 @@ fn draw_meta_txs_tab(f: &mut Frame, app: &mut App, area: Rect) {
         Span::styled("Paymaster            ", theme::SUGGESTION_STYLE),
         Span::styled("Ver   ", theme::SUGGESTION_STYLE),
         Span::styled("Protocol(s)          ", theme::SUGGESTION_STYLE),
-        Span::styled("Endpoint(s)              ", theme::SUGGESTION_STYLE),
+        Span::styled("Endpoint(s)                        ", theme::SUGGESTION_STYLE),
         Span::styled("Fee(STRK)      ", theme::SUGGESTION_STYLE),
         Span::styled("St  ", theme::SUGGESTION_STYLE),
     ]));
@@ -792,8 +792,8 @@ fn draw_meta_txs_tab(f: &mut Frame, app: &mut App, area: Rect) {
                 protocol
             };
 
-            let endpoint = if m.inner_endpoints.chars().count() > 24 {
-                let truncated: String = m.inner_endpoints.chars().take(23).collect();
+            let endpoint = if m.inner_endpoints.chars().count() > 34 {
+                let truncated: String = m.inner_endpoints.chars().take(33).collect();
                 format!("{truncated}…")
             } else {
                 m.inner_endpoints.clone()
@@ -819,7 +819,7 @@ fn draw_meta_txs_tab(f: &mut Frame, app: &mut App, area: Rect) {
                 Span::styled(format!("{:<21}", paymaster_display), theme::LABEL_STYLE),
                 Span::styled(format!("{:<6}", m.version), theme::SUGGESTION_STYLE),
                 Span::styled(format!("{:<21}", protocol_display), theme::LABEL_STYLE),
-                Span::styled(format!("{:<25}", endpoint), theme::LABEL_STYLE),
+                Span::styled(format!("{:<35}", endpoint), theme::LABEL_STYLE),
                 Span::styled(format!("{:<15}", fee_str), theme::TX_FEE_STYLE),
                 Span::styled(format!("{:<4}", &m.status), status_style),
             ]);

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -728,7 +728,10 @@ fn draw_meta_txs_tab(f: &mut Frame, app: &mut App, area: Rect) {
         Span::styled("Paymaster            ", theme::SUGGESTION_STYLE),
         Span::styled("Ver   ", theme::SUGGESTION_STYLE),
         Span::styled("Protocol(s)          ", theme::SUGGESTION_STYLE),
-        Span::styled("Endpoint(s)                        ", theme::SUGGESTION_STYLE),
+        Span::styled(
+            "Endpoint(s)                        ",
+            theme::SUGGESTION_STYLE,
+        ),
         Span::styled("Fee(STRK)      ", theme::SUGGESTION_STYLE),
         Span::styled("St  ", theme::SUGGESTION_STYLE),
     ]));

--- a/src/ui/views/block_detail.rs
+++ b/src/ui/views/block_detail.rs
@@ -119,7 +119,10 @@ fn draw_tx_list(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
         Span::styled("Hash          ", theme::SUGGESTION_STYLE),
         Span::styled("Sender               ", theme::SUGGESTION_STYLE),
         Span::styled("Intender             ", theme::SUGGESTION_STYLE),
-        Span::styled("Endpoint(s)                            ", theme::SUGGESTION_STYLE),
+        Span::styled(
+            "Endpoint(s)                            ",
+            theme::SUGGESTION_STYLE,
+        ),
         Span::styled("Nonce      ", theme::SUGGESTION_STYLE),
         Span::styled("Fee(STRK)        ", theme::SUGGESTION_STYLE),
         Span::styled("Tip             ", theme::SUGGESTION_STYLE),

--- a/src/ui/views/block_detail.rs
+++ b/src/ui/views/block_detail.rs
@@ -119,7 +119,7 @@ fn draw_tx_list(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
         Span::styled("Hash          ", theme::SUGGESTION_STYLE),
         Span::styled("Sender               ", theme::SUGGESTION_STYLE),
         Span::styled("Intender             ", theme::SUGGESTION_STYLE),
-        Span::styled("Endpoint                     ", theme::SUGGESTION_STYLE),
+        Span::styled("Endpoint(s)                            ", theme::SUGGESTION_STYLE),
         Span::styled("Nonce      ", theme::SUGGESTION_STYLE),
         Span::styled("Fee(STRK)        ", theme::SUGGESTION_STYLE),
         Span::styled("Tip             ", theme::SUGGESTION_STYLE),
@@ -196,8 +196,8 @@ fn draw_tx_list(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
                 .get(i)
                 .and_then(|n| n.as_deref())
                 .unwrap_or("");
-            let endpoint_display = if endpoint.chars().count() > 28 {
-                let truncated: String = endpoint.chars().take(27).collect();
+            let endpoint_display = if endpoint.chars().count() > 38 {
+                let truncated: String = endpoint.chars().take(37).collect();
                 format!("{truncated}…")
             } else {
                 endpoint.to_string()
@@ -302,7 +302,7 @@ fn draw_tx_list(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
                 ),
                 Span::styled(format!("{:<21}", sender_display), sender_style),
                 Span::styled(format!("{:<21}", intender_display), intender_style),
-                Span::styled(format!("{:<28} ", endpoint_display), theme::LABEL_STYLE),
+                Span::styled(format!("{:<38} ", endpoint_display), theme::LABEL_STYLE),
                 Span::styled(format!("{:<11}", nonce_str), theme::NORMAL_STYLE),
                 Span::styled(format!("{:<17}", fee_str), theme::TX_FEE_STYLE),
                 Span::styled(format!("{:<16}", tip_str), theme::TX_FEE_STYLE),


### PR DESCRIPTION
## Summary
- Tx detail decoding was always using the latest ABI per contract, so old transactions rendered incorrectly when the contract had been upgraded since (e.g. STRK Transfer event keys/data layout changed in v0.14.2). Closes #24.
- Resolve each address's class hash *as of the tx's block* using the existing pf-query `class_history` cache; on miss, refetch from pf-query and persist; if pf is unavailable, fall back to RPC `starknet_getClassHashAt`. The on-disk `parsed_abis` cache is already keyed by `class_hash`, so no schema change is needed.
- Block list, address view, and pending-tx paths continue to use the latest ABI (cheap, fine for those surfaces). Per-class ABI fetches are reused via `AbiRegistry::get_abi_for_class`, and the prewarm step does the resolves in parallel before the sequential decode loop.

## Test plan
- [x] `cargo build --release`
- [x] `cargo clippy --release --all-targets`
- [x] `cargo test --release`
- [x] Verified against live RPC + pf-query: STRK class history at the tx's block resolves to the pre-upgrade class (matches `starknet_getClassHashAt` for that block), so the resolution logic picks the right ABI.
- [ ] Open the reproducer tx referenced in #24 in the TUI and confirm the STRK Transfer event renders with the correct fields. Repeat with pf-query stopped to exercise the RPC fallback.
- [ ] Open a recent (post-upgrade) STRK transfer to confirm the latest path still decodes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)