### PR TITLE
Scope cold-cache calls Dune query, surface UDC v2 deploys

### DIFF
--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -825,8 +825,25 @@ pub(super) async fn fetch_and_send_address_info(
             // immediately on hit, so no network work runs here.
             find_deploy_tx(address, cached_deploy_block, &ds_c, &tx_c).await;
         });
+    } else if let Some(earliest) = cached_class_history.last() {
+        // No deploy_info cached, but class history is — meaning a previous
+        // flow (tx-detail decode, class info view) warmed class history but
+        // never triggered the deploy-tx scan. Kick it off here using the
+        // earliest cached entry as the deploy block. Without this, the pf
+        // re-fetch branch below only fires the lookup when the cache is
+        // *stale*, so a fresh-but-deploy-info-less cache would never show
+        // the deployment tx.
+        let deploy_block = earliest.block_number;
+        let ds_c = Arc::clone(ds);
+        let tx_c = tx.clone();
+        spawn_cancellable(cancel.clone(), async move {
+            find_deploy_tx(address, deploy_block, &ds_c, &tx_c).await;
+        });
     }
     let had_cached_deploy = cached_deploy.is_some();
+    // Whether the cached fast-path above already kicked off a find_deploy_tx
+    // run. Used to suppress a duplicate launch from the pf re-fetch branch.
+    let kicked_deploy_lookup = had_cached_deploy || !cached_class_history.is_empty();
 
     // Decide whether the cached class-history is still authoritative. If the
     // live class_hash matches the latest cached entry, no replace_class can
@@ -868,9 +885,12 @@ pub(super) async fn fetch_and_send_address_info(
                         ds_c.save_class_history(&addr, &entries);
                         ds_c.save_class_history_max_block(&addr, latest_block);
                         // Skip the deploy-tx lookup if the cached fast-path
-                        // already emitted the deploy summary above. Avoids a
-                        // duplicate AddressTxsStreamed for the same hash.
-                        if !had_cached_deploy && let Some(deploy_entry) = entries.last() {
+                        // (or the cached-class-history fallback) already
+                        // kicked one off. find_deploy_tx itself is cache-first,
+                        // but launching it twice causes duplicate
+                        // AddressTxsStreamed emits when both runs miss cache
+                        // and race the same block scan.
+                        if !kicked_deploy_lookup && let Some(deploy_entry) = entries.last() {
                             let deploy_block = deploy_entry.block_number;
                             let tx_c2 = tx_c.clone();
                             let ds_c2 = Arc::clone(&ds_c);
@@ -1231,6 +1251,7 @@ pub(super) async fn fetch_and_send_address_info(
         let abi_b = Arc::clone(abi_reg);
         let dune_b = dune.as_ref().map(Arc::clone);
         let pf_b = pf.as_ref().map(Arc::clone);
+        let voyager_b = voyager_c.as_ref().map(Arc::clone);
         spawn_cancellable(cancel.clone(), async move {
             let _ = tx_b.send(Action::LoadingStatus("Calls: fetching from Dune...".into()));
             fetch_address_contract_calls(
@@ -1238,6 +1259,7 @@ pub(super) async fn fetch_and_send_address_info(
                 &ds_b,
                 dune_b.as_ref(),
                 pf_b.as_ref(),
+                voyager_b.as_ref(),
                 &abi_b,
                 &tx_b,
                 nonce,
@@ -3418,6 +3440,7 @@ pub(super) async fn fetch_address_contract_calls(
     ds: &Arc<dyn crate::data::DataSource>,
     dune: Option<&Arc<dune::DuneClient>>,
     pf: Option<&Arc<crate::data::pathfinder::PathfinderClient>>,
+    voyager_c: Option<&Arc<voyager::VoyagerClient>>,
     abi_reg: &Arc<AbiRegistry>,
     action_tx: &mpsc::UnboundedSender<Action>,
     nonce: starknet::core::types::Felt,
@@ -3475,9 +3498,105 @@ pub(super) async fn fetch_address_contract_calls(
                 .await
         }
         None => {
-            dune_client
-                .query_contract_calls(address, CONTRACT_CALL_LIMIT)
-                .await
+            // Cold cache: scope the query to the contract's deploy block (and
+            // its date) so Dune doesn't scan every partition since 2024-01-01.
+            // For a contract deployed yesterday this turns a 2-minute query
+            // into a ~5-second one.
+            //
+            // Wait for the deploy block before dispatching Dune. Sources, in
+            // order:
+            //   1. cached deploy_info / class_history (instant)
+            //   2. pf class-history (~500ms, when pf is wired up)
+            //   3. Voyager label (~600ms, works without pf)
+            //
+            // The block timestamp comes from `ds.get_block`, which serves
+            // from cache or falls back to RPC — so this whole path works
+            // with just RPC + Voyager when pf is unavailable.
+            //
+            // `min_block_date` is a partition hint; without it the windowed
+            // query is no better than the unwindowed one (see comment on
+            // `query_contract_calls_windowed`). If we can't resolve either a
+            // floor block or a date, fall back to the unwindowed path.
+            let mut deploy_floor = ds
+                .load_cached_deploy_info(&address)
+                .map(|(_, block, _)| block)
+                .or_else(|| {
+                    ds.load_cached_class_history(&address)
+                        .iter()
+                        .map(|e| e.block_number)
+                        .min()
+                });
+
+            if deploy_floor.is_none()
+                && let Some(pf_client) = pf
+            {
+                match pf_client.get_class_history(address).await {
+                    Ok(entries) => {
+                        if !entries.is_empty() {
+                            ds.save_class_history(&address, &entries);
+                        }
+                        deploy_floor = entries.iter().map(|e| e.block_number).min();
+                    }
+                    Err(e) => {
+                        debug!(
+                            addr = %format!("{:#x}", address),
+                            error = %e,
+                            "Calls: pf class-history fetch failed; trying Voyager"
+                        );
+                    }
+                }
+            }
+
+            if deploy_floor.is_none()
+                && let Some(vc) = voyager_c
+            {
+                match vc.get_label(address).await {
+                    Ok(label) => {
+                        deploy_floor = label.deploy_block;
+                    }
+                    Err(e) => {
+                        debug!(
+                            addr = %format!("{:#x}", address),
+                            error = %e,
+                            "Calls: Voyager label fetch failed"
+                        );
+                    }
+                }
+            }
+
+            let hinted = if let Some(from_block) = deploy_floor {
+                let ts = ds.get_block(from_block).await.ok().map(|b| b.timestamp);
+                ts.and_then(|t| chrono::DateTime::from_timestamp(t as i64, 0))
+                    .map(|dt| dt.date_naive() - chrono::Duration::days(1))
+                    .map(|min_date| (from_block, min_date))
+            } else {
+                None
+            };
+
+            match hinted {
+                Some((from_block, min_date)) => {
+                    debug!(
+                        addr = %format!("{:#x}", address),
+                        from_block,
+                        ?min_date,
+                        "Calls: cold-cache windowed Dune query (deploy-scoped)"
+                    );
+                    dune_client
+                        .query_contract_calls_windowed(
+                            address,
+                            from_block,
+                            u64::MAX,
+                            CONTRACT_CALL_LIMIT,
+                            Some(min_date),
+                        )
+                        .await
+                }
+                None => {
+                    dune_client
+                        .query_contract_calls(address, CONTRACT_CALL_LIMIT)
+                        .await
+                }
+            }
         }
     };
 

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -3422,6 +3422,74 @@ pub(super) async fn fetch_address_meta_txs(
     });
 }
 
+/// Which Dune query variant the calls fetch should issue.
+///
+/// Pulled out as a pure decision so the choice can be unit-tested without
+/// mocking Dune/PF/Voyager — see `pick_calls_dune_query`.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum CallsDuneQuery {
+    /// We have cached calls. Pull only blocks newer than the highest cached
+    /// row; reuse the cached row's date as a partition hint.
+    TopDelta {
+        from_block: u64,
+        min_date: Option<chrono::NaiveDate>,
+    },
+    /// Cold cache, but we resolved the deploy block AND its timestamp.
+    /// Scope the windowed query to `[deploy_block, ∞)` with the deploy
+    /// date (minus a 1-day cushion) as the partition hint.
+    DeployScoped {
+        from_block: u64,
+        min_date: chrono::NaiveDate,
+    },
+    /// Cold cache and either no deploy floor or no timestamp for it.
+    /// Falls back to the legacy unwindowed `block_date >= '2024-01-01'`
+    /// query — slow on dense contracts but always correct.
+    Unwindowed,
+}
+
+/// Choose the Dune query variant for the contract-calls fetch.
+///
+/// The two inputs that drive the choice:
+///   * `newest_cached_pair` — `Some((block_number, timestamp))` if we have
+///     prior cached calls. `timestamp == 0` means "block known but date
+///     unknown" — we drop the partition hint in that case.
+///   * `deploy_floor` + `deploy_floor_ts` — both `Some` to qualify for
+///     `DeployScoped`. Either being `None` collapses to `Unwindowed`.
+///
+/// `min_date` for the windowed variants is `block_date - 1 day` to guard
+/// against the pinning row sitting right before a UTC day boundary.
+pub(super) fn pick_calls_dune_query(
+    newest_cached_pair: Option<(u64, u64)>,
+    deploy_floor: Option<u64>,
+    deploy_floor_ts: Option<u64>,
+) -> CallsDuneQuery {
+    if let Some((block, ts)) = newest_cached_pair {
+        let min_date = (ts > 0)
+            .then(|| chrono::DateTime::from_timestamp(ts as i64, 0))
+            .flatten()
+            .map(|dt| dt.date_naive() - chrono::Duration::days(1));
+        return CallsDuneQuery::TopDelta {
+            from_block: block + 1,
+            min_date,
+        };
+    }
+
+    match (deploy_floor, deploy_floor_ts) {
+        (Some(from_block), Some(ts)) if ts > 0 => {
+            match chrono::DateTime::from_timestamp(ts as i64, 0)
+                .map(|dt| dt.date_naive() - chrono::Duration::days(1))
+            {
+                Some(min_date) => CallsDuneQuery::DeployScoped {
+                    from_block,
+                    min_date,
+                },
+                None => CallsDuneQuery::Unwindowed,
+            }
+        }
+        _ => CallsDuneQuery::Unwindowed,
+    }
+}
+
 /// Fetch calls-to-contract for `address` via Dune and emit the resulting
 /// [`ContractCallSummary`](crate::data::types::ContractCallSummary) rows as
 /// `AddressInfoLoaded { contract_calls, .. }`.
@@ -3476,127 +3544,118 @@ pub(super) async fn fetch_address_contract_calls(
     // dense contracts. A 1-day UTC cushion guards against the cached row
     // sitting right before a day boundary.
     let cached_calls = ds.load_cached_address_calls(&address);
-    let newest_cached = cached_calls
+    let newest_cached_pair = cached_calls
         .iter()
         .filter(|c| c.block_number > 0)
-        .max_by_key(|c| c.block_number);
+        .max_by_key(|c| c.block_number)
+        .map(|c| (c.block_number, c.timestamp));
 
-    let dune_calls_result = match newest_cached {
-        Some(c) => {
-            let min_date = (c.timestamp > 0)
-                .then(|| chrono::DateTime::from_timestamp(c.timestamp as i64, 0))
-                .flatten()
-                .map(|dt| dt.date_naive() - chrono::Duration::days(1));
+    // Cold-cache path: resolve a deploy-block floor before deciding the Dune
+    // query variant. Sources, in order: cached deploy_info → cached
+    // class_history → pf class-history (~500ms) → Voyager label (~600ms).
+    // Either pf or voyager unblocks the deploy-scoped query; the cold path
+    // works against RPC + Voyager alone when pf isn't wired up.
+    let mut deploy_floor: Option<u64> = None;
+    if newest_cached_pair.is_none() {
+        deploy_floor = ds
+            .load_cached_deploy_info(&address)
+            .map(|(_, block, _)| block)
+            .or_else(|| {
+                ds.load_cached_class_history(&address)
+                    .iter()
+                    .map(|e| e.block_number)
+                    .min()
+            });
+
+        if deploy_floor.is_none()
+            && let Some(pf_client) = pf
+        {
+            match pf_client.get_class_history(address).await {
+                Ok(entries) => {
+                    if !entries.is_empty() {
+                        ds.save_class_history(&address, &entries);
+                    }
+                    deploy_floor = entries.iter().map(|e| e.block_number).min();
+                }
+                Err(e) => {
+                    debug!(
+                        addr = %format!("{:#x}", address),
+                        error = %e,
+                        "Calls: pf class-history fetch failed; trying Voyager"
+                    );
+                }
+            }
+        }
+
+        if deploy_floor.is_none()
+            && let Some(vc) = voyager_c
+        {
+            match vc.get_label(address).await {
+                Ok(label) => deploy_floor = label.deploy_block,
+                Err(e) => {
+                    debug!(
+                        addr = %format!("{:#x}", address),
+                        error = %e,
+                        "Calls: Voyager label fetch failed"
+                    );
+                }
+            }
+        }
+    }
+
+    // Block timestamp for the deploy floor. `ds.get_block` serves from cache
+    // or falls back to RPC, so this works without pf.
+    let deploy_floor_ts = match deploy_floor {
+        Some(b) => ds.get_block(b).await.ok().map(|blk| blk.timestamp),
+        None => None,
+    };
+
+    let plan = pick_calls_dune_query(newest_cached_pair, deploy_floor, deploy_floor_ts);
+    if let CallsDuneQuery::DeployScoped {
+        from_block,
+        min_date,
+    } = &plan
+    {
+        debug!(
+            addr = %format!("{:#x}", address),
+            from_block,
+            ?min_date,
+            "Calls: cold-cache windowed Dune query (deploy-scoped)"
+        );
+    }
+    let dune_calls_result = match plan {
+        CallsDuneQuery::TopDelta {
+            from_block,
+            min_date,
+        } => {
             dune_client
                 .query_contract_calls_windowed(
                     address,
-                    c.block_number + 1,
+                    from_block,
                     u64::MAX,
                     CONTRACT_CALL_LIMIT,
                     min_date,
                 )
                 .await
         }
-        None => {
-            // Cold cache: scope the query to the contract's deploy block (and
-            // its date) so Dune doesn't scan every partition since 2024-01-01.
-            // For a contract deployed yesterday this turns a 2-minute query
-            // into a ~5-second one.
-            //
-            // Wait for the deploy block before dispatching Dune. Sources, in
-            // order:
-            //   1. cached deploy_info / class_history (instant)
-            //   2. pf class-history (~500ms, when pf is wired up)
-            //   3. Voyager label (~600ms, works without pf)
-            //
-            // The block timestamp comes from `ds.get_block`, which serves
-            // from cache or falls back to RPC — so this whole path works
-            // with just RPC + Voyager when pf is unavailable.
-            //
-            // `min_block_date` is a partition hint; without it the windowed
-            // query is no better than the unwindowed one (see comment on
-            // `query_contract_calls_windowed`). If we can't resolve either a
-            // floor block or a date, fall back to the unwindowed path.
-            let mut deploy_floor = ds
-                .load_cached_deploy_info(&address)
-                .map(|(_, block, _)| block)
-                .or_else(|| {
-                    ds.load_cached_class_history(&address)
-                        .iter()
-                        .map(|e| e.block_number)
-                        .min()
-                });
-
-            if deploy_floor.is_none()
-                && let Some(pf_client) = pf
-            {
-                match pf_client.get_class_history(address).await {
-                    Ok(entries) => {
-                        if !entries.is_empty() {
-                            ds.save_class_history(&address, &entries);
-                        }
-                        deploy_floor = entries.iter().map(|e| e.block_number).min();
-                    }
-                    Err(e) => {
-                        debug!(
-                            addr = %format!("{:#x}", address),
-                            error = %e,
-                            "Calls: pf class-history fetch failed; trying Voyager"
-                        );
-                    }
-                }
-            }
-
-            if deploy_floor.is_none()
-                && let Some(vc) = voyager_c
-            {
-                match vc.get_label(address).await {
-                    Ok(label) => {
-                        deploy_floor = label.deploy_block;
-                    }
-                    Err(e) => {
-                        debug!(
-                            addr = %format!("{:#x}", address),
-                            error = %e,
-                            "Calls: Voyager label fetch failed"
-                        );
-                    }
-                }
-            }
-
-            let hinted = if let Some(from_block) = deploy_floor {
-                let ts = ds.get_block(from_block).await.ok().map(|b| b.timestamp);
-                ts.and_then(|t| chrono::DateTime::from_timestamp(t as i64, 0))
-                    .map(|dt| dt.date_naive() - chrono::Duration::days(1))
-                    .map(|min_date| (from_block, min_date))
-            } else {
-                None
-            };
-
-            match hinted {
-                Some((from_block, min_date)) => {
-                    debug!(
-                        addr = %format!("{:#x}", address),
-                        from_block,
-                        ?min_date,
-                        "Calls: cold-cache windowed Dune query (deploy-scoped)"
-                    );
-                    dune_client
-                        .query_contract_calls_windowed(
-                            address,
-                            from_block,
-                            u64::MAX,
-                            CONTRACT_CALL_LIMIT,
-                            Some(min_date),
-                        )
-                        .await
-                }
-                None => {
-                    dune_client
-                        .query_contract_calls(address, CONTRACT_CALL_LIMIT)
-                        .await
-                }
-            }
+        CallsDuneQuery::DeployScoped {
+            from_block,
+            min_date,
+        } => {
+            dune_client
+                .query_contract_calls_windowed(
+                    address,
+                    from_block,
+                    u64::MAX,
+                    CONTRACT_CALL_LIMIT,
+                    Some(min_date),
+                )
+                .await
+        }
+        CallsDuneQuery::Unwindowed => {
+            dune_client
+                .query_contract_calls(address, CONTRACT_CALL_LIMIT)
+                .await
         }
     };
 
@@ -4415,6 +4474,96 @@ mod tests {
                 );
             }
         }
+    }
+
+    // === pick_calls_dune_query unit tests ===
+    //
+    // The cold-cache calls path resolves a deploy floor through up to four
+    // sources (deploy_info → class_history → pf → Voyager) before deciding
+    // which Dune query variant to issue. Regressions back to the legacy
+    // unwindowed `block_date >= '2024-01-01'` query are silent (just slow,
+    // not wrong), so we test the decision exhaustively.
+
+    /// 2025-04-21 00:00:00 UTC — a representative deploy timestamp used
+    /// across these tests.
+    const DEPLOY_TS: u64 = 1_745_193_600;
+    /// 2025-04-21 minus the 1-day cushion `pick_calls_dune_query` applies.
+    fn deploy_min_date() -> chrono::NaiveDate {
+        chrono::NaiveDate::from_ymd_opt(2025, 4, 20).unwrap()
+    }
+
+    #[test]
+    fn warm_cache_uses_top_delta_with_date_hint() {
+        let plan = pick_calls_dune_query(Some((9_148_000, DEPLOY_TS)), None, None);
+        assert_eq!(
+            plan,
+            CallsDuneQuery::TopDelta {
+                from_block: 9_148_001,
+                min_date: Some(deploy_min_date()),
+            }
+        );
+    }
+
+    #[test]
+    fn warm_cache_with_zero_timestamp_drops_date_hint() {
+        // A cached row with `timestamp == 0` (e.g. enrichment never landed)
+        // must not produce `min_date = 1969-12-31`.
+        let plan = pick_calls_dune_query(Some((9_148_000, 0)), Some(9_013_975), Some(DEPLOY_TS));
+        assert_eq!(
+            plan,
+            CallsDuneQuery::TopDelta {
+                from_block: 9_148_001,
+                min_date: None,
+            }
+        );
+    }
+
+    #[test]
+    fn warm_cache_ignores_deploy_floor() {
+        // TopDelta wins over DeployScoped: if we already have cached rows
+        // there's no need to scan all the way back to deploy.
+        let plan = pick_calls_dune_query(
+            Some((9_148_000, DEPLOY_TS)),
+            Some(9_013_975),
+            Some(DEPLOY_TS),
+        );
+        match plan {
+            CallsDuneQuery::TopDelta { from_block, .. } => assert_eq!(from_block, 9_148_001),
+            other => panic!("expected TopDelta, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cold_cache_with_deploy_info_uses_deploy_scoped() {
+        let plan = pick_calls_dune_query(None, Some(9_013_975), Some(DEPLOY_TS));
+        assert_eq!(
+            plan,
+            CallsDuneQuery::DeployScoped {
+                from_block: 9_013_975,
+                min_date: deploy_min_date(),
+            }
+        );
+    }
+
+    #[test]
+    fn cold_cache_without_deploy_floor_falls_back_to_unwindowed() {
+        let plan = pick_calls_dune_query(None, None, None);
+        assert_eq!(plan, CallsDuneQuery::Unwindowed);
+    }
+
+    #[test]
+    fn cold_cache_with_floor_but_no_timestamp_falls_back() {
+        // Voyager gave us deploy_block but ds.get_block failed (or returned
+        // a sentinel `0` timestamp). Without a real date we can't prune
+        // partitions, so the windowed query is no better than unwindowed —
+        // emit the unwindowed query, which is what the comment on
+        // `query_contract_calls_windowed` says is required to avoid
+        // QUERY_STATE_FAILED on dense contracts.
+        let plan = pick_calls_dune_query(None, Some(9_013_975), None);
+        assert_eq!(plan, CallsDuneQuery::Unwindowed);
+
+        let plan_zero_ts = pick_calls_dune_query(None, Some(9_013_975), Some(0));
+        assert_eq!(plan_zero_ts, CallsDuneQuery::Unwindowed);
     }
 
     /// Smoke test that `batch_call_contracts` matches individual `call_contract`

--- a/src/network/voyager.rs
+++ b/src/network/voyager.rs
@@ -1,13 +1,13 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::path::Path;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use rusqlite::{Connection, params};
 use serde::Deserialize;
 use starknet::core::types::Felt;
-use tokio::sync::Semaphore;
+use tokio::sync::{Mutex as AsyncMutex, Semaphore};
 use tracing::{debug, info, warn};
 
 use crate::data::types::VoyagerLabelInfo;
@@ -36,10 +36,12 @@ pub struct VoyagerClient {
     /// Caps simultaneous outbound HTTP calls. Acquired only after a cache miss
     /// and after dedup, so cache-only paths stay free.
     sem: Semaphore,
-    /// Addresses currently being fetched. A second concurrent caller for the
-    /// same address returns an empty label immediately; the next render after
-    /// the in-flight call lands will hit the cache.
-    in_flight: Mutex<HashSet<Felt>>,
+    /// Per-address mutex for deduplicating concurrent fetches. The first
+    /// caller to acquire the inner async lock performs the fetch; concurrent
+    /// callers wait for it and then read from cache. Lets a downstream caller
+    /// (e.g. the cold-cache contract-calls path) get the real result instead
+    /// of an empty placeholder when another task is already mid-flight.
+    in_flight: Mutex<HashMap<Felt, Arc<AsyncMutex<()>>>>,
     /// Unix-secs gate. While `now < backoff_until`, outbound calls are skipped.
     /// Tripped on any non-cacheable Voyager error (429/5xx, transport error).
     backoff_until: AtomicU64,
@@ -105,29 +107,33 @@ fn empty_label() -> VoyagerLabelInfo {
     }
 }
 
-/// RAII guard for an in-flight address slot. Removes the entry on drop so a
-/// failure path can't wedge an address as "permanently in flight".
-struct InFlightGuard<'a> {
-    set: &'a Mutex<HashSet<Felt>>,
+/// Acquire (or create) the per-address async lock used to serialise
+/// concurrent fetches. The returned `Arc` is held until the caller drops it,
+/// keeping the entry alive for the duration of the fetch.
+fn acquire_addr_lock(
+    map: &Mutex<HashMap<Felt, Arc<AsyncMutex<()>>>>,
     addr: Felt,
+) -> Option<Arc<AsyncMutex<()>>> {
+    let mut g = map.lock().ok()?;
+    Some(
+        g.entry(addr)
+            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .clone(),
+    )
 }
 
-impl<'a> InFlightGuard<'a> {
-    fn try_acquire(set: &'a Mutex<HashSet<Felt>>, addr: Felt) -> Option<Self> {
-        let mut g = set.lock().ok()?;
-        if g.insert(addr) {
-            Some(InFlightGuard { set, addr })
-        } else {
-            None
-        }
-    }
-}
-
-impl Drop for InFlightGuard<'_> {
-    fn drop(&mut self) {
-        if let Ok(mut g) = self.set.lock() {
-            g.remove(&self.addr);
-        }
+/// Drop the per-address slot from the map *only* if we're the last holder.
+/// `addr_lock` is the local clone the caller is about to drop, so a strong
+/// count of 2 means "the map and us" — safe to remove.
+fn release_addr_lock(
+    map: &Mutex<HashMap<Felt, Arc<AsyncMutex<()>>>>,
+    addr: Felt,
+    addr_lock: &Arc<AsyncMutex<()>>,
+) {
+    if let Ok(mut g) = map.lock()
+        && Arc::strong_count(addr_lock) <= 2
+    {
+        g.remove(&addr);
     }
 }
 
@@ -157,7 +163,7 @@ impl VoyagerClient {
             api_key,
             db: Mutex::new(db),
             sem: Semaphore::new(MAX_CONCURRENT_FETCHES),
-            in_flight: Mutex::new(HashSet::new()),
+            in_flight: Mutex::new(HashMap::new()),
             backoff_until: AtomicU64::new(0),
         })
     }
@@ -169,7 +175,12 @@ impl VoyagerClient {
     ///   1. Error backoff: if Voyager recently errored, return an empty label
     ///      without firing a request.
     ///   2. In-flight dedup: if another task is already fetching this address,
-    ///      return an empty label and let the in-flight call populate the cache.
+    ///      wait for it to finish and read the result from cache. Avoids
+    ///      duplicate API calls while still letting concurrent callers see
+    ///      the real label (the previous behaviour returned empty here, which
+    ///      forced downstream callers — e.g. the cold-cache contract-calls
+    ///      path that needs `deploy_block` to scope a Dune query — to fall
+    ///      back to a much more expensive query).
     ///   3. Concurrency cap: only `MAX_CONCURRENT_FETCHES` requests run at once.
     ///
     /// "Empty label" means `VoyagerLabelInfo` with all `None` fields; callers
@@ -188,20 +199,33 @@ impl VoyagerClient {
             return Ok(empty_label());
         }
 
-        // Reserve the in-flight slot. If another task is already fetching this
-        // address, bail — we don't want N tasks racing to fetch the same key.
-        let _guard = match InFlightGuard::try_acquire(&self.in_flight, address) {
-            Some(g) => g,
-            None => {
-                debug!(address = %addr_hex, "Voyager fetch already in flight, skipping");
-                return Ok(empty_label());
-            }
+        // Acquire the per-address lock. If another task holds it, we wait
+        // here until they release — at which point either the cache is
+        // populated (cache check below short-circuits) or their fetch failed
+        // and we'll try ourselves.
+        let Some(addr_lock) = acquire_addr_lock(&self.in_flight, address) else {
+            return Ok(empty_label());
         };
+        let _held = addr_lock.lock().await;
+
+        // Re-check cache: a previous holder of the lock may have just written.
+        if let Some(cached) = self.get_cached(&addr_hex) {
+            debug!(address = %addr_hex, "Voyager label cache hit after dedup wait");
+            release_addr_lock(&self.in_flight, address, &addr_lock);
+            return Ok(cached);
+        }
+        // Re-check backoff too: a prior in-flight caller may have errored
+        // and tripped it while we were waiting. Avoids piling onto a
+        // failing endpoint.
+        if self.in_backoff() {
+            release_addr_lock(&self.in_flight, address, &addr_lock);
+            return Ok(empty_label());
+        }
 
         // `acquire` only fails if the semaphore is closed, which we never do.
         let _permit = self.sem.acquire().await.map_err(|e| e.to_string())?;
 
-        match self.fetch_from_api(&addr_hex).await {
+        let result = match self.fetch_from_api(&addr_hex).await {
             Ok(label) => {
                 self.store_cached(&addr_hex, &label);
                 Ok(label)
@@ -210,7 +234,9 @@ impl VoyagerClient {
                 self.trip_backoff();
                 Err(e)
             }
-        }
+        };
+        release_addr_lock(&self.in_flight, address, &addr_lock);
+        result
     }
 
     fn in_backoff(&self) -> bool {
@@ -628,33 +654,54 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn in_flight_guard_dedups_concurrent_callers() {
+    async fn in_flight_dedup_waits_and_reads_cache() {
         let (client, _f) = tmp_client();
+        let client = std::sync::Arc::new(client);
         let address =
             Felt::from_hex("0x0000000000000000000000000000000000000000000000000000000000000bbb")
                 .unwrap();
-        // Manually claim the in-flight slot to simulate an ongoing fetch by another task.
-        let _held = InFlightGuard::try_acquire(&client.in_flight, address)
-            .expect("first acquire must succeed");
+        let addr_hex = format!("{:#066x}", address);
 
-        // A second concurrent caller must NOT hit the network — short-circuit to empty.
-        // (No cache entry, no backoff: the only way `get_label` can return Ok here is
-        // via the in-flight short-circuit.)
-        let label = client.get_label(address).await.expect("must not error");
-        assert!(label.name.is_none(), "in-flight dedup must yield empty");
+        // Take the per-address lock to simulate an in-flight fetch by another
+        // task. While we hold it, populate the cache as that fetch would.
+        let addr_lock =
+            acquire_addr_lock(&client.in_flight, address).expect("acquire_addr_lock must succeed");
+        let held = addr_lock.lock().await;
+
+        let label = VoyagerLabelInfo {
+            name: Some("InFlightWriter".to_string()),
+            class_alias: None,
+            deploy_block: Some(42),
+        };
+        client.store_cached(&addr_hex, &label);
+
+        // A second caller racing with the in-flight fetch should block until
+        // we release, then read the freshly cached entry instead of bailing
+        // to empty.
+        let client_c = std::sync::Arc::clone(&client);
+        let waiter = tokio::spawn(async move { client_c.get_label(address).await });
+
+        // Give the waiter a chance to enter the lock acquisition.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        drop(held);
+
+        let result = waiter.await.expect("task must not panic").expect("ok");
+        assert_eq!(result.name.as_deref(), Some("InFlightWriter"));
+        assert_eq!(result.deploy_block, Some(42));
     }
 
-    #[test]
-    fn in_flight_guard_releases_on_drop() {
-        let set: Mutex<HashSet<Felt>> = Mutex::new(HashSet::new());
+    #[tokio::test]
+    async fn addr_lock_entry_cleaned_up_after_release() {
+        let map: Mutex<HashMap<Felt, Arc<AsyncMutex<()>>>> = Mutex::new(HashMap::new());
         let addr = Felt::from_hex("0x1").unwrap();
         {
-            let _g = InFlightGuard::try_acquire(&set, addr).unwrap();
-            assert_eq!(set.lock().unwrap().len(), 1);
+            let lock = acquire_addr_lock(&map, addr).unwrap();
+            assert_eq!(map.lock().unwrap().len(), 1);
+            release_addr_lock(&map, addr, &lock);
         }
         assert!(
-            set.lock().unwrap().is_empty(),
-            "guard must remove its entry on drop"
+            map.lock().unwrap().is_empty(),
+            "release must remove the entry when no other holder remains"
         );
     }
 }

--- a/src/registry/known_addresses.rs
+++ b/src/registry/known_addresses.rs
@@ -112,6 +112,7 @@ const BUNDLED_KNOWN_ADDRESSES: &str = r#"
 # Infrastructure
 "0x01176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8" = { name = "Starknet Sequencer", type = "Sequencer", verified = true, source = "bundled" }
 "0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf" = { name = "UDC", type = "Infrastructure", verified = true, source = "bundled" }
+"0x02ceed65a4bd731034c01113685c831b01c15d7d432f71afb1cf1634b53a2125" = { name = "UDC v2", type = "Infrastructure", verified = true, source = "bundled" }
 "0x0243eed6e2b2b02a24e249f2b39ef9e5bc8bc32b252174d1c0961a458640ed8a" = { name = "Pragma Oracle", type = "Oracle", verified = true, source = "bundled" }
 
 # Known exchanges/wallets


### PR DESCRIPTION
## Summary

Three fixes uncovered while opening a contract that had been deployed the day before — the call list took ~2 minutes to populate and the deployment tx never showed up.

- **Cold-cache Dune query is deploy-scoped.** First-time visits used `block_date >= '2024-01-01'` so Dune scanned 16 months of `starknet.calls` partitions even for a yesterday-old contract. We now resolve a deploy block via cache → pf class-history → Voyager and pull the timestamp through `ds.get_block` (cache → RPC), then pass `min_block_date = deploy_date - 1 day` to the windowed query. Verified against Dune: identical rows at ~18× lower compute cost (3.285 → 0.182 credits).
- **`find_deploy_tx` runs even when `class_history` was warmed by another flow.** Previously it only fired from the pf re-fetch branch, so an address whose class history had been pre-cached by a tx-detail decode (or class-info view) never got a deploy-tx scan unless `deploy_info` was also cached. Triggers the lookup whenever cached class history is non-empty but deploy info is missing; uses a `kicked_deploy_lookup` flag to suppress the duplicate launch from the pf branch.
- **UDC v2 (`0x02ceed65...`) is now a known address.** The `ContractDeployed` selector is unchanged from v1, and our scanners already match by event key (not `from_address`), so v2 deployments flow through the same path with a proper label.

## Test plan

- [x] `cargo fmt`, `cargo clippy --release --all-targets` clean
- [x] `cargo test --release --lib` (160 passed)
- [x] Verified the new Dune SQL produces identical rows to the old query at ~18× lower cost on the contract that triggered the report
- [ ] TUI walkthrough: open a previously-unseen recently deployed contract and confirm the deploy tx appears and the calls list populates in seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)