### PR TITLE
Use Pathfinder for paginated tx fetches and nonce gap fills

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,6 +1989,7 @@ dependencies = [
  "serde",
  "serde_json",
  "siphasher",
+ "tempfile",
  "tokio",
  "tower-http",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ APP_PATHFINDER_SERVICE_URL=http://192.168.1.10:8234
 | `GET /class-declaration/{class_hash}`  | Returns declaration info for a class hash               |
 | `GET /tx-by-hash/{hash}`               | Looks up a transaction by hash                          |
 | `GET /block-txs/{block_number}`        | Returns decoded transactions in a block                 |
-| `GET /sender-txs/{address}`            | Returns transactions sent by an address                 |
+| `GET /sender-txs/{address}`            | Returns transactions sent by an address. Supports `?limit=N&before_block=B&from_block=F` for pagination. |
 | `GET /contract-events/{address}`       | Returns events emitted by a contract                    |
 
 ---

--- a/crates/pf-query/Cargo.toml
+++ b/crates/pf-query/Cargo.toml
@@ -23,3 +23,6 @@ primitive-types = { version = "0.12.1", features = ["serde"] }
 siphasher = "1.0"
 tower-http = { version = "0.6", features = ["trace"] }
 rayon = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/pf-query/src/main.rs
+++ b/crates/pf-query/src/main.rs
@@ -225,6 +225,12 @@ struct NonceHistoryParams {
 #[derive(Deserialize)]
 struct SenderTxParams {
     limit: Option<u32>,
+    /// Exclusive upper bound on block_number. Lets the client paginate
+    /// older-than-X without re-fetching the most recent N every time.
+    before_block: Option<u64>,
+    /// Inclusive lower bound on block_number. Together with `before_block`
+    /// supports range scans (e.g. nonce-gap fills).
+    from_block: Option<u64>,
 }
 
 #[derive(Deserialize)]
@@ -749,6 +755,8 @@ async fn handler_sender_txs(
     State(state): State<AppState>,
 ) -> ApiResult<Vec<SenderTxEntry>> {
     let limit = params.limit.unwrap_or(500).min(2000);
+    let before_block = params.before_block.unwrap_or(u64::MAX);
+    let from_block = params.from_block.unwrap_or(0);
     let addr_bytes = parse_address(&address)
         .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid address: {e}")))?;
     let db_path = Arc::clone(&state.db_path);
@@ -759,7 +767,9 @@ async fn handler_sender_txs(
     let results = tokio::task::spawn_blocking(move || {
         let conn = open_db(&db_path).map_err(db_err)?;
 
-        // Step 1: Get block numbers from nonce_updates + timestamps
+        // Step 1: Get block numbers from nonce_updates + timestamps.
+        // before_block / from_block default to (u64::MAX, 0) so the bounds
+        // are no-ops when the client doesn't paginate.
         let mut stmt = conn
             .prepare(
                 "SELECT nu.block_number, nu.nonce, bh.timestamp \
@@ -767,14 +777,17 @@ async fn handler_sender_txs(
                  JOIN contract_addresses ca ON nu.contract_address_id = ca.id \
                  JOIN block_headers bh ON nu.block_number = bh.number \
                  WHERE ca.contract_address = ?1 \
-                 ORDER BY nu.block_number DESC LIMIT ?2",
+                 AND nu.block_number < ?2 \
+                 AND nu.block_number >= ?3 \
+                 ORDER BY nu.block_number DESC LIMIT ?4",
             )
             .map_err(db_err)?;
 
         let nonce_entries: Vec<(u64, u64, u64)> = stmt
-            .query_map(rusqlite::params![addr_bytes.as_slice(), limit], |row| {
-                Ok((row.get(0)?, decode_nonce(row, 1)?, row.get(2)?))
-            })
+            .query_map(
+                rusqlite::params![addr_bytes.as_slice(), before_block, from_block, limit],
+                |row| Ok((row.get(0)?, decode_nonce(row, 1)?, row.get(2)?)),
+            )
             .map_err(db_err)?
             .collect::<Result<Vec<_>, _>>()
             .map_err(db_err)?;

--- a/crates/pf-query/src/main.rs
+++ b/crates/pf-query/src/main.rs
@@ -755,8 +755,15 @@ async fn handler_sender_txs(
     State(state): State<AppState>,
 ) -> ApiResult<Vec<SenderTxEntry>> {
     let limit = params.limit.unwrap_or(500).min(2000);
-    let before_block = params.before_block.unwrap_or(u64::MAX);
-    let from_block = params.from_block.unwrap_or(0);
+    // SQLite INTEGER is i64. rusqlite refuses to bind u64 values above
+    // `i64::MAX`, so cap the unbounded sentinel at i64::MAX — far above any
+    // realistic block number. `from_block` defaults to 0 so the lower bound
+    // is a no-op when the client doesn't paginate.
+    let before_block = params
+        .before_block
+        .unwrap_or(i64::MAX as u64)
+        .min(i64::MAX as u64) as i64;
+    let from_block = params.from_block.unwrap_or(0).min(i64::MAX as u64) as i64;
     let addr_bytes = parse_address(&address)
         .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid address: {e}")))?;
     let db_path = Arc::clone(&state.db_path);

--- a/crates/pf-query/src/main.rs
+++ b/crates/pf-query/src/main.rs
@@ -1652,4 +1652,165 @@ mod tests {
         let filter = vec![vec![felt(0xAA)], vec![]];
         assert!(event_keys_match(&keys, &filter));
     }
+
+    // ----- handler smoke tests -----------------------------------------------
+    //
+    // These exercise the bind/prepare path of each route handler against a
+    // freshly-created in-memory schema. They don't try to validate result
+    // shape on real data — they catch the class of bug where a refactor
+    // (cursor params, type changes, schema drift) breaks the SQL prepare or
+    // bind step. The original motivation: a `u64::MAX` sentinel that hit
+    // rusqlite's `ToSql for u64` overflow check and returned 500 on every
+    // call. An empty-DB smoke test would have caught it because the bind
+    // happens before any rows are fetched.
+
+    use axum::extract::{Path as AxumPath, Query as AxumQuery, State as AxumState};
+
+    /// Build a tempfile-backed SQLite DB with the minimal pf-query schema and
+    /// one fixture block_header so handlers requiring `MAX(block_number)` or
+    /// `latest_block` don't fail before bind. Returns a guard that holds the
+    /// tempdir alive plus an AppState pointing at the file.
+    ///
+    /// Schema is inlined (rather than parsed from a real Pathfinder DB) so the
+    /// test stays hermetic — we verify the exact column names + types each
+    /// handler binds against.
+    fn setup_test_db() -> (tempfile::TempDir, AppState) {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let db_path = dir.path().join("test.db");
+        let conn = rusqlite::Connection::open(&db_path).expect("open rw");
+        conn.execute_batch(
+            "
+            CREATE TABLE block_headers (
+                number INTEGER PRIMARY KEY,
+                timestamp INTEGER NOT NULL
+            );
+            CREATE TABLE contract_addresses (
+                id INTEGER PRIMARY KEY,
+                contract_address BLOB NOT NULL UNIQUE
+            );
+            CREATE TABLE nonce_updates (
+                block_number INTEGER NOT NULL,
+                contract_address_id INTEGER NOT NULL,
+                nonce BLOB NOT NULL
+            );
+            CREATE TABLE contract_updates (
+                block_number INTEGER NOT NULL,
+                contract_address BLOB NOT NULL,
+                class_hash BLOB NOT NULL
+            );
+            CREATE TABLE class_definitions (
+                hash BLOB PRIMARY KEY,
+                block_number INTEGER NOT NULL
+            );
+            CREATE TABLE transactions (
+                block_number INTEGER PRIMARY KEY,
+                transactions BLOB NOT NULL,
+                events BLOB
+            );
+            CREATE TABLE transaction_hashes (
+                hash BLOB PRIMARY KEY,
+                block_number INTEGER NOT NULL,
+                idx INTEGER NOT NULL
+            );
+            CREATE TABLE event_filters (
+                from_block INTEGER NOT NULL,
+                to_block INTEGER NOT NULL,
+                bitmap BLOB NOT NULL
+            );
+            INSERT INTO block_headers(number, timestamp) VALUES (1, 1000);
+            ",
+        )
+        .expect("init schema");
+        drop(conn);
+
+        let state = AppState {
+            db_path: Arc::new(db_path.to_string_lossy().into_owned()),
+        };
+        (dir, state)
+    }
+
+    const TEST_ADDR: &str = "0x6acfcef048dcaac4a11fab313507d53145ed2a468f2a6188527918f1b12d935";
+
+    /// /sender-txs with no cursor params — the case that broke when
+    /// `before_block` was `u64::MAX` and rusqlite refused to bind it.
+    #[tokio::test]
+    async fn handler_sender_txs_default_bounds_smoke() {
+        let (_dir, state) = setup_test_db();
+        let result = handler_sender_txs(
+            AxumPath(TEST_ADDR.to_string()),
+            AxumQuery(SenderTxParams {
+                limit: None,
+                before_block: None,
+                from_block: None,
+            }),
+            AxumState(state),
+        )
+        .await;
+        let json = result.expect("handler returned error");
+        assert!(json.0.is_empty(), "empty DB should yield no rows");
+    }
+
+    /// /sender-txs with both cursor params set — exercises the new bind
+    /// shape end-to-end.
+    #[tokio::test]
+    async fn handler_sender_txs_with_cursor_smoke() {
+        let (_dir, state) = setup_test_db();
+        let result = handler_sender_txs(
+            AxumPath(TEST_ADDR.to_string()),
+            AxumQuery(SenderTxParams {
+                limit: Some(50),
+                before_block: Some(100_000),
+                from_block: Some(50_000),
+            }),
+            AxumState(state),
+        )
+        .await;
+        let json = result.expect("handler returned error");
+        assert!(json.0.is_empty());
+    }
+
+    #[tokio::test]
+    async fn handler_class_history_smoke() {
+        let (_dir, state) = setup_test_db();
+        let result =
+            handler_class_history(AxumPath(TEST_ADDR.to_string()), AxumState(state)).await;
+        let json = result.expect("handler returned error");
+        assert!(json.0.is_empty());
+    }
+
+    #[tokio::test]
+    async fn handler_contract_events_smoke() {
+        let (_dir, state) = setup_test_db();
+        let result = handler_contract_events(
+            AxumPath(TEST_ADDR.to_string()),
+            AxumQuery(ContractEventsParams {
+                from_block: None,
+                to_block: None,
+                keys: None,
+                limit: None,
+                continuation_token: None,
+            }),
+            AxumState(state),
+        )
+        .await;
+        let json = result.expect("handler returned error");
+        assert!(json.0.events.is_empty());
+        assert!(json.0.continuation_token.is_none());
+    }
+
+    /// /txs-by-hash with a hash that doesn't exist in the empty DB. Exercises
+    /// the per-hash lookup loop and the early-return-on-empty-locations path.
+    #[tokio::test]
+    async fn handler_txs_by_hash_smoke() {
+        let (_dir, state) = setup_test_db();
+        let result = handler_txs_by_hash(
+            AxumState(state),
+            axum::Json(TxsByHashRequest {
+                hashes: vec!["0xdeadbeef".to_string()],
+            }),
+        )
+        .await;
+        let json = result.expect("handler returned error");
+        assert!(json.0.is_empty());
+    }
 }

--- a/crates/pf-query/src/main.rs
+++ b/crates/pf-query/src/main.rs
@@ -1772,8 +1772,7 @@ mod tests {
     #[tokio::test]
     async fn handler_class_history_smoke() {
         let (_dir, state) = setup_test_db();
-        let result =
-            handler_class_history(AxumPath(TEST_ADDR.to_string()), AxumState(state)).await;
+        let result = handler_class_history(AxumPath(TEST_ADDR.to_string()), AxumState(state)).await;
         let json = result.expect("handler returned error");
         assert!(json.0.is_empty());
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -387,14 +387,20 @@ impl App {
     }
 
     /// Scroll the active address list by a delta and trigger viewport
-    /// enrichment for any rows newly exposed.
+    /// enrichment for any rows newly exposed. Also re-arms older-tx
+    /// pagination, so Ctrl+D landing near the tail behaves like `j`/`G`
+    /// did when the same row gets selected via single-step or jump-to-end.
     pub fn address_list_scroll_by(&mut self, delta: i64) {
         match self.address.tab {
             AddressTab::Transactions => {
                 self.address.txs.scroll_by(delta);
+                self.maybe_fetch_more_address_txs();
                 self.maybe_enrich_visible_address_txs();
             }
-            AddressTab::Calls => self.address.calls.scroll_by(delta),
+            AddressTab::Calls => {
+                self.address.calls.scroll_by(delta);
+                self.maybe_fetch_more_address_txs();
+            }
             AddressTab::MetaTxs => {
                 self.address.meta_txs.scroll_by(delta);
                 self.maybe_fetch_more_meta_txs();

--- a/src/data/pathfinder.rs
+++ b/src/data/pathfinder.rs
@@ -230,13 +230,26 @@ impl PathfinderClient {
 
     /// Fetch full decoded transaction history for an account.
     /// Combines nonce_updates + block blob decoding server-side.
+    ///
+    /// `before_block` (exclusive) and `from_block` (inclusive) bound the
+    /// scan; pass `None` for either side to leave it unbounded. Pagination
+    /// callers use `before_block = oldest_known_block` to walk backward;
+    /// gap-fill callers set both bounds.
     pub async fn get_sender_txs(
         &self,
         address: Felt,
         limit: u32,
+        before_block: Option<u64>,
+        from_block: Option<u64>,
     ) -> anyhow::Result<Vec<SenderTxEntry>> {
         let addr_hex = format!("{:#x}", address);
-        let url = format!("{}/sender-txs/{}?limit={}", self.base_url, addr_hex, limit);
+        let mut url = format!("{}/sender-txs/{}?limit={}", self.base_url, addr_hex, limit);
+        if let Some(b) = before_block {
+            url.push_str(&format!("&before_block={b}"));
+        }
+        if let Some(f) = from_block {
+            url.push_str(&format!("&from_block={f}"));
+        }
         debug!(url = %url, "Fetching sender txs from pf-query");
         let entries = self
             .client

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -2404,7 +2404,8 @@ async fn fill_small_nonce_gaps_phase(
                     .collect();
                 info!(
                     found = new.len(),
-                    "Sanity gap-fill: PF returned {} new txs", new.len()
+                    "Sanity gap-fill: PF returned {} new txs",
+                    new.len()
                 );
                 return new;
             }

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -2984,7 +2984,14 @@ pub(super) async fn fetch_more_address_txs(
         .min()
         .unwrap_or(from_block);
 
-    let at_deploy_floor = deploy_block.is_some_and(|db| from_block <= db);
+    // We've truly exhausted the deploy-block floor only when the *oldest
+    // returned tx* is at or below the deploy block. The previous shortcut
+    // — `from_block <= deploy_block ⇒ at_deploy_floor` — was wrong: PF can
+    // return `limit` rows entirely within [from_block, before_block) without
+    // walking the bottom of that range. Declaring has_more=false there
+    // stranded the user mid-history (regression seen on a 1500-nonce account
+    // where pagination stopped at nonce 503 with deploy at the floor).
+    let at_deploy_floor = deploy_block.is_some_and(|db| oldest_block <= db);
     let has_more = from_block > 0
         && !at_deploy_floor
         && (summaries.len() >= 50

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -2155,6 +2155,7 @@ pub(super) async fn run_endpoint_enrichment(
         &known_txs,
         ds,
         dune,
+        pf,
         abi_reg,
         action_tx,
     )
@@ -2221,12 +2222,12 @@ pub(super) async fn run_nonce_gap_fill(
         gap.missing_count
     )));
 
-    let found = fill_specific_large_gap(address, &known_txs, &gap, dune, action_tx).await;
+    let found = fill_specific_large_gap(address, &known_txs, &gap, dune, pf, action_tx).await;
 
     if !found.is_empty() {
         info!(
             found = found.len(),
-            "Gap fill: Dune returned {} new txs, enriching endpoints",
+            "Gap fill: backend returned {} new txs, enriching endpoints",
             found.len()
         );
         let _ = action_tx.send(Action::AddressTxsEnriched {
@@ -2234,8 +2235,9 @@ pub(super) async fn run_nonce_gap_fill(
             updates: found.clone(),
         });
 
-        // Enrich endpoints for the newly discovered txs (they usually arrive from
-        // Dune without endpoint names decoded).
+        // Enrich endpoints for the newly discovered txs (Dune txs arrive
+        // without endpoints; PF txs already carry hash/fee/status but still
+        // need ABI-driven endpoint name resolution).
         let mut combined = known_txs;
         for t in &found {
             if !combined.iter().any(|k| k.hash == t.hash) {
@@ -2244,7 +2246,7 @@ pub(super) async fn run_nonce_gap_fill(
         }
         enrich_all_empty_endpoints(address, &combined, ds, pf.as_ref(), abi_reg, action_tx).await;
     } else {
-        info!("Gap fill: no txs returned from Dune for this range");
+        info!("Gap fill: no txs returned for this range");
         let _ = action_tx.send(Action::LoadingStatus(String::new()));
     }
 
@@ -2266,6 +2268,7 @@ async fn fill_small_nonce_gaps_phase(
     known_txs: &[crate::data::types::AddressTxSummary],
     ds: &Arc<dyn DataSource>,
     _dune: &Option<Arc<dune::DuneClient>>,
+    pf: &Option<Arc<crate::data::pathfinder::PathfinderClient>>,
     abi_reg: &Arc<AbiRegistry>,
     action_tx: &mpsc::UnboundedSender<Action>,
 ) -> Vec<crate::data::types::AddressTxSummary> {
@@ -2362,68 +2365,161 @@ async fn fill_small_nonce_gaps_phase(
 
     let mut found_txs = Vec::new();
 
-    // Small gaps only: RPC block scan. Large gaps are left for on-demand fill.
-    if !small_gaps.is_empty() {
-        let mut blocks_to_scan: std::collections::BTreeSet<u64> = std::collections::BTreeSet::new();
-        for (_, from, to) in &small_gaps {
-            for b in *from..=*to {
-                blocks_to_scan.insert(b);
+    if small_gaps.is_empty() {
+        return found_txs;
+    }
+
+    // Pathfinder primary path: a single ranged `/sender-txs` call covers the
+    // bounding window across all small gaps. nonce_updates is indexed by
+    // address, so the range size is irrelevant — only the matching tx count
+    // (capped at our limit). This collapses the previous N-block RPC fan-out
+    // into one round-trip.
+    let bounding_from = small_gaps.iter().map(|(_, f, _)| *f).min().unwrap_or(0);
+    let bounding_to = small_gaps.iter().map(|(_, _, t)| *t).max().unwrap_or(0);
+    if let Some(pf_c) = pf.as_ref()
+        && bounding_to >= bounding_from
+    {
+        info!(
+            small = small_count,
+            from = bounding_from,
+            to = bounding_to,
+            "Sanity gap-fill: querying PF for blocks {}..{}",
+            bounding_from,
+            bounding_to
+        );
+        match pf_c
+            .get_sender_txs(
+                address,
+                1000,
+                Some(bounding_to.saturating_add(1)),
+                Some(bounding_from),
+            )
+            .await
+        {
+            Ok(entries) => {
+                let summaries = pf_txs_to_summaries(entries);
+                let new: Vec<_> = summaries
+                    .into_iter()
+                    .filter(|t| !known_txs.iter().any(|k| k.hash == t.hash))
+                    .collect();
+                info!(
+                    found = new.len(),
+                    "Sanity gap-fill: PF returned {} new txs", new.len()
+                );
+                return new;
+            }
+            Err(e) => {
+                warn!(error = %e, "Sanity gap-fill: PF query failed, falling back to RPC scan");
+                // Fall through to RPC.
             }
         }
-        // Cap RPC block scan to 200 blocks
-        if blocks_to_scan.len() <= 200 {
-            let blocks_vec: Vec<u64> = blocks_to_scan.into_iter().collect();
-            info!(
-                blocks = blocks_vec.len(),
-                "Sanity gap-fill: scanning {} blocks via RPC for small gaps",
-                blocks_vec.len()
-            );
-            let rpc_found =
-                fetch_txs_from_blocks(address, &blocks_vec, known_txs, ds, abi_reg, action_tx)
-                    .await;
-            info!(
-                found = rpc_found.len(),
-                "Sanity gap-fill: RPC scan found {} txs",
-                rpc_found.len()
-            );
-            found_txs.extend(rpc_found);
-        } else {
-            info!(
-                blocks = blocks_to_scan.len(),
-                "Sanity gap-fill: too many small-gap blocks ({}), skipping RPC scan",
-                blocks_to_scan.len()
-            );
+    }
+
+    // RPC fallback: union the gap windows into a flat block list and scan.
+    let mut blocks_to_scan: std::collections::BTreeSet<u64> = std::collections::BTreeSet::new();
+    for (_, from, to) in &small_gaps {
+        for b in *from..=*to {
+            blocks_to_scan.insert(b);
         }
+    }
+    // Cap RPC block scan to 200 blocks
+    if blocks_to_scan.len() <= 200 {
+        let blocks_vec: Vec<u64> = blocks_to_scan.into_iter().collect();
+        info!(
+            blocks = blocks_vec.len(),
+            "Sanity gap-fill: scanning {} blocks via RPC for small gaps",
+            blocks_vec.len()
+        );
+        let rpc_found =
+            fetch_txs_from_blocks(address, &blocks_vec, known_txs, ds, abi_reg, action_tx).await;
+        info!(
+            found = rpc_found.len(),
+            "Sanity gap-fill: RPC scan found {} txs",
+            rpc_found.len()
+        );
+        found_txs.extend(rpc_found);
+    } else {
+        info!(
+            blocks = blocks_to_scan.len(),
+            "Sanity gap-fill: too many small-gap blocks ({}), skipping RPC scan",
+            blocks_to_scan.len()
+        );
     }
 
     found_txs
 }
 
-/// On-demand Dune query for a single large nonce gap (issue #10).
+/// On-demand range query for a single large nonce gap (issue #10).
 ///
-/// Caller supplies the known lo/hi block bounds of the gap; we query Dune's
-/// windowed account-tx endpoint for that range, deduplicate against known
-/// hashes, and return the new entries.
+/// Prefers Pathfinder's `/sender-txs` (sub-second on indexed nonce_updates)
+/// when available; falls back to Dune's windowed account-tx query when PF
+/// isn't configured. Returns only entries the caller doesn't already know.
 async fn fill_specific_large_gap(
     address: starknet::core::types::Felt,
     known_txs: &[crate::data::types::AddressTxSummary],
     gap: &crate::app::views::address_info::UnfilledGap,
     dune: &Option<Arc<dune::DuneClient>>,
+    pf: &Option<Arc<crate::data::pathfinder::PathfinderClient>>,
     action_tx: &mpsc::UnboundedSender<Action>,
 ) -> Vec<crate::data::types::AddressTxSummary> {
+    let from = gap.lo_block;
+    let to = gap.hi_block;
+    let known_hashes: std::collections::HashSet<_> = known_txs.iter().map(|t| t.hash).collect();
+
+    // Pathfinder primary. `before_block` is exclusive in the pf-query API,
+    // so pass `to + 1` to keep the gap's upper bound inclusive — matching
+    // the Dune BETWEEN semantics this used to use.
+    if let Some(pf_c) = pf.as_ref() {
+        info!(
+            from,
+            to,
+            span = to.saturating_sub(from),
+            "Gap fill: querying Pathfinder for blocks {}..{}",
+            from,
+            to
+        );
+        match pf_c
+            .get_sender_txs(address, 1000, Some(to.saturating_add(1)), Some(from))
+            .await
+        {
+            Ok(entries) => {
+                let summaries = pf_txs_to_summaries(entries);
+                let total_returned = summaries.len();
+                let new: Vec<_> = summaries
+                    .into_iter()
+                    .filter(|t| !known_hashes.contains(&t.hash))
+                    .collect();
+                info!(
+                    returned = total_returned,
+                    new = new.len(),
+                    from,
+                    to,
+                    "Gap fill: PF returned {} txs, {} new for blocks {}..{}",
+                    total_returned,
+                    new.len(),
+                    from,
+                    to
+                );
+                return new;
+            }
+            Err(e) => {
+                warn!(error = %e, from, to, "Gap fill: PF query failed, falling back to Dune");
+                // Fall through to Dune.
+            }
+        }
+    }
+
     let Some(dune_c) = dune.as_ref() else {
         warn!(
-            "Gap fill: Dune client unavailable, cannot fill gap {}..{}",
+            "Gap fill: neither Pathfinder nor Dune available, cannot fill gap {}..{}",
             gap.lo_block, gap.hi_block
         );
         let _ = action_tx.send(Action::LoadingStatus(
-            "Gap fill unavailable (Dune not configured)".to_string(),
+            "Gap fill unavailable (no backend configured)".to_string(),
         ));
         return Vec::new();
     };
 
-    let from = gap.lo_block;
-    let to = gap.hi_block;
     info!(
         from,
         to,
@@ -2432,8 +2528,6 @@ async fn fill_specific_large_gap(
         from,
         to
     );
-
-    let known_hashes: std::collections::HashSet<_> = known_txs.iter().map(|t| t.hash).collect();
 
     match dune_c
         .query_account_txs_windowed(address, from, to, 1000)

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -1183,7 +1183,7 @@ pub(super) async fn fetch_and_send_address_info(
         spawn_cancellable(cancel.clone(), async move {
             const PF_LIMIT: u32 = 200;
             let _ = tx_a.send(Action::LoadingStatus("PF: fetching tx history...".into()));
-            match pf_c.get_sender_txs(address, PF_LIMIT).await {
+            match pf_c.get_sender_txs(address, PF_LIMIT, None, None).await {
                 Ok(pf_txs) => {
                     let _ = tx_a.send(Action::SourceUpdate {
                         source: Source::Pathfinder,
@@ -2702,6 +2702,34 @@ pub(super) async fn fetch_more_address_txs(
         .unwrap_or_default()
     };
 
+    // Pathfinder's /sender-txs handles the account pagination case in ~100ms
+    // (same fast path the initial fetch uses). When PF is wired up we skip
+    // Dune for accounts entirely; the windowed Dune query is the slow leg
+    // (sometimes 80+s) and PF is strictly better for sender txs.
+    //
+    // Dune is still the only source for contract-side pagination (calls TO
+    // the address), and the fallback for accounts when PF is unavailable.
+    let pf_pagination = pf.as_ref().map(Arc::clone);
+    let pf_fut = async move {
+        if is_contract {
+            return Vec::new();
+        }
+        let Some(pf_client) = pf_pagination else {
+            return Vec::new();
+        };
+        match pf_client
+            .get_sender_txs(address, 200, Some(before_block), Some(from_block))
+            .await
+        {
+            Ok(entries) => pf_txs_to_summaries(entries),
+            Err(e) => {
+                warn!(error = %e, "PF pagination sender-txs failed");
+                Vec::new()
+            }
+        }
+    };
+
+    let pf_active = !is_contract && pf.is_some();
     let dune_c = dune.as_ref().map(Arc::clone);
     let dune_fut = async move {
         let Some(dune_client) = dune_c else {
@@ -2723,6 +2751,9 @@ pub(super) async fn fetch_more_address_txs(
                     (Vec::new(), Vec::new())
                 }
             }
+        } else if pf_active {
+            // PF covers accounts; skip the slow windowed Dune sender-txs query.
+            (Vec::new(), Vec::new())
         } else {
             match dune_client
                 .query_account_txs_windowed(address, from_block, dune_to, 100)
@@ -2737,7 +2768,7 @@ pub(super) async fn fetch_more_address_txs(
         }
     };
 
-    let (events, (dune_txs, dune_calls)) = tokio::join!(rpc_fut, dune_fut);
+    let (events, (dune_txs, dune_calls), pf_txs) = tokio::join!(rpc_fut, dune_fut, pf_fut);
 
     // Build tx summaries from RPC events
     let mut seen = std::collections::HashSet::new();
@@ -2805,6 +2836,17 @@ pub(super) async fn fetch_more_address_txs(
             }
         }
         helpers::backfill_timestamps(&mut summaries, ds, pf.as_ref()).await;
+    }
+
+    // Merge PF account txs into summaries (dedup by hash). PF wins over Dune
+    // when both are present — same precedence the initial fetch uses.
+    if !pf_txs.is_empty() {
+        let existing: std::collections::HashSet<_> = summaries.iter().map(|s| s.hash).collect();
+        for ptx in pf_txs {
+            if !existing.contains(&ptx.hash) {
+                summaries.push(ptx);
+            }
+        }
     }
 
     // Merge Dune account txs into summaries (dedup by hash)

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -2797,46 +2797,30 @@ pub(super) async fn fetch_more_address_txs(
         .unwrap_or_default()
     };
 
-    // Pathfinder's /sender-txs handles the account pagination case in ~100ms
-    // (same fast path the initial fetch uses). When PF is wired up we skip
-    // Dune for accounts entirely; the windowed Dune query is the slow leg
-    // (sometimes 80+s) and PF is strictly better for sender txs.
+    // Pick the right tx source for this address kind, falling back as
+    // needed:
     //
-    // Dune is still the only source for contract-side pagination (calls TO
-    // the address), and the fallback for accounts when PF is unavailable.
-    let pf_pagination = pf.as_ref().map(Arc::clone);
-    let pf_fut = async move {
-        if is_contract {
-            return Vec::new();
-        }
-        let Some(pf_client) = pf_pagination else {
-            return Vec::new();
-        };
-        match pf_client
-            .get_sender_txs(address, 200, Some(before_block), Some(from_block))
-            .await
-        {
-            Ok(entries) => pf_txs_to_summaries(entries),
-            Err(e) => {
-                warn!(error = %e, "PF pagination sender-txs failed");
-                Vec::new()
-            }
-        }
-    };
-
-    let pf_active = !is_contract && pf.is_some();
-    let dune_c = dune.as_ref().map(Arc::clone);
-    let dune_fut = async move {
-        let Some(dune_client) = dune_c else {
-            return (Vec::new(), Vec::new());
-        };
+    //  * Contracts: Dune `query_contract_calls_windowed` is the only source
+    //    for "calls TO this contract" — pf-query has no equivalent.
+    //  * Accounts: Pathfinder `/sender-txs` is the fast happy path
+    //    (~100ms vs Dune windowed at 5–80s). On PF error we fall through to
+    //    Dune sequentially so a transient pf-query outage doesn't leave the
+    //    user with empty pagination — the slow Dune query is still
+    //    preferable to no data.
+    let pf_source = pf.as_ref().map(Arc::clone);
+    let dune_source = dune.as_ref().map(Arc::clone);
+    let txs_source_fut = async move {
         let dune_to = before_block.saturating_sub(1);
+
         if is_contract {
+            let Some(dune_client) = dune_source else {
+                return (Vec::new(), Vec::new());
+            };
             // Pagination walks backward from `before_block`; we don't keep a
-            // reliable timestamp for arbitrary historical windows, so skip the
-            // `block_date` hint here. The narrower LIMIT (100) and user-capped
-            // `window_size` keep Dune's scan bounded in practice.
-            match dune_client
+            // reliable timestamp for arbitrary historical windows, so skip
+            // the `block_date` hint here. The narrower LIMIT (100) and
+            // user-capped `window_size` keep Dune's scan bounded in practice.
+            return match dune_client
                 .query_contract_calls_windowed(address, from_block, dune_to, 100, None)
                 .await
             {
@@ -2845,25 +2829,39 @@ pub(super) async fn fetch_more_address_txs(
                     warn!(error = %e, "Dune pagination contract calls failed");
                     (Vec::new(), Vec::new())
                 }
-            }
-        } else if pf_active {
-            // PF covers accounts; skip the slow windowed Dune sender-txs query.
-            (Vec::new(), Vec::new())
-        } else {
-            match dune_client
-                .query_account_txs_windowed(address, from_block, dune_to, 100)
+            };
+        }
+
+        // Account branch.
+        if let Some(pf_client) = pf_source {
+            match pf_client
+                .get_sender_txs(address, 200, Some(before_block), Some(from_block))
                 .await
             {
-                Ok(txs) => (txs, Vec::new()),
+                Ok(entries) => return (pf_txs_to_summaries(entries), Vec::new()),
                 Err(e) => {
-                    warn!(error = %e, "Dune pagination account txs failed");
-                    (Vec::new(), Vec::new())
+                    warn!(error = %e, "PF pagination sender-txs failed; falling back to Dune");
+                    // Fall through to Dune below.
                 }
+            }
+        }
+
+        let Some(dune_client) = dune_source else {
+            return (Vec::new(), Vec::new());
+        };
+        match dune_client
+            .query_account_txs_windowed(address, from_block, dune_to, 100)
+            .await
+        {
+            Ok(txs) => (txs, Vec::new()),
+            Err(e) => {
+                warn!(error = %e, "Dune pagination account txs failed");
+                (Vec::new(), Vec::new())
             }
         }
     };
 
-    let (events, (dune_txs, dune_calls), pf_txs) = tokio::join!(rpc_fut, dune_fut, pf_fut);
+    let (events, (account_txs, dune_calls)) = tokio::join!(rpc_fut, txs_source_fut);
 
     // Build tx summaries from RPC events
     let mut seen = std::collections::HashSet::new();
@@ -2933,23 +2931,14 @@ pub(super) async fn fetch_more_address_txs(
         helpers::backfill_timestamps(&mut summaries, ds, pf.as_ref()).await;
     }
 
-    // Merge PF account txs into summaries (dedup by hash). PF wins over Dune
-    // when both are present — same precedence the initial fetch uses.
-    if !pf_txs.is_empty() {
+    // Merge account txs (whichever source `txs_source_fut` picked) into
+    // summaries (dedup by hash). For accounts the source is PF when it
+    // succeeded, otherwise the Dune fallback; for contracts it's empty.
+    if !account_txs.is_empty() {
         let existing: std::collections::HashSet<_> = summaries.iter().map(|s| s.hash).collect();
-        for ptx in pf_txs {
-            if !existing.contains(&ptx.hash) {
-                summaries.push(ptx);
-            }
-        }
-    }
-
-    // Merge Dune account txs into summaries (dedup by hash)
-    if !dune_txs.is_empty() {
-        let existing: std::collections::HashSet<_> = summaries.iter().map(|s| s.hash).collect();
-        for dtx in dune_txs {
-            if !existing.contains(&dtx.hash) {
-                summaries.push(dtx);
+        for atx in account_txs {
+            if !existing.contains(&atx.hash) {
+                summaries.push(atx);
             }
         }
     }

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -70,8 +70,32 @@ fn count_fragment(shown: u64, bound: CountBound) -> String {
 /// sender txs) — not suitable here.
 fn tx_count_fragment(app: &App) -> String {
     let count = app.address.txs.items.len() as u64;
+    // The on-chain `nonce` is the *next* nonce to use. For a self-deployed
+    // account (DEPLOY_ACCOUNT), the deploy itself consumed nonce 0 and is
+    // pulled out of `txs.items` by `filter_deployment_txs`, so the Txs tab
+    // ends up holding `nonce - 1` rows. For a UDC-deployed account the
+    // "deployment" entry is the *deployer's* tx (sender != address), the
+    // account's own nonce 0 is its first invoke and stays in `txs.items`,
+    // so the tab holds the full `nonce` rows.
+    //
+    // Distinguish on `deployment.sender`: when it equals the account
+    // address, the deploy was self-sent; otherwise it was UDC-style.
     let bound = match app.address.info.as_ref().map(|i| felt_to_u64(&i.nonce)) {
-        Some(nonce) => CountBound::Exact(nonce),
+        Some(nonce) => {
+            let self_deployed = matches!(
+                (
+                    app.address.context,
+                    app.address.deployment.as_ref().and_then(|d| d.sender),
+                ),
+                (Some(addr), Some(sender)) if sender == addr
+            );
+            let total = if self_deployed {
+                nonce.saturating_sub(1)
+            } else {
+                nonce
+            };
+            CountBound::Exact(total)
+        }
         None => CountBound::LowerBound { hint: None },
     };
     count_fragment(count, bound)

--- a/tests/enrich_bench_test.rs
+++ b/tests/enrich_bench_test.rs
@@ -450,14 +450,14 @@ async fn bench_pf_sender_txs_heavy() {
 
     for &limit in &[500u32, 2000] {
         // Warm-up run (discarded).
-        let _ = pf.get_sender_txs(addr, limit).await;
+        let _ = pf.get_sender_txs(addr, limit, None, None).await;
 
         let mut samples = Vec::with_capacity(5);
         let mut rows_last = 0usize;
         for _ in 0..5 {
             let t0 = Instant::now();
             let rows = pf
-                .get_sender_txs(addr, limit)
+                .get_sender_txs(addr, limit, None, None)
                 .await
                 .expect("pf get_sender_txs");
             samples.push(t0.elapsed().as_millis());


### PR DESCRIPTION
## Summary

- Adds `before_block` / `from_block` cursor params to pf-query's `/sender-txs` so paginated tx history can be served from the same fast path the initial fetch uses.
- Wires that into `fetch_more_address_txs` (account branch) and both nonce gap fillers, replacing slow Dune `query_account_txs_windowed` calls and the per-block RPC fan-out for small gaps.
- Measured against the address that prompted the work: paginated PF call returns in **~68ms** vs the historical Dune **86s** for the same `before_block` cursor.

## Why

The "fetch more" path on the address view took 86s in a recent log, vs ~70ms for the initial render. Cause was source asymmetry: the initial fetch hits PF `/sender-txs?limit=200` alongside Dune+RPC, but pagination skipped PF entirely (no cursor existed) and waited on the windowed Dune query. Same asymmetry existed in `fill_specific_large_gap` and the per-block RPC scan inside `fill_small_nonce_gaps_phase`.

## Changes

- `crates/pf-query/src/main.rs` — `SenderTxParams` now accepts optional `before_block` (exclusive) and `from_block` (inclusive). SQL gets sentinel-bounded `block_number` predicates so the no-args call is byte-identical.
- `src/data/pathfinder.rs` — `get_sender_txs` takes `Option<u64>` cursors, appended to URL only when set.
- `src/network/address.rs` —
    - `fetch_more_address_txs`: account branch now fires PF in parallel with the RPC events scan and skips the windowed Dune call when PF is available.
    - `fill_specific_large_gap`: PF primary with Dune fallback.
    - `fill_small_nonce_gaps_phase`: single PF range call over the bounding window of all small gaps, replacing the per-block RPC fan-out (and dropping the 200-block cap on the PF path). RPC stays as fallback.
- README route table updated.

## Test plan

- [x] `cargo build --release` (snbeat + pf-query)
- [x] `cargo test --release` — 166 unit + integration tests pass
- [x] `cargo clippy --release` clean
- [x] pf-query deployed to steak; `curl /sender-txs/<addr>?limit=200&before_block=9147313` returns rows strictly older than the cursor in 68ms
- [ ] Open the same address in snbeat, scroll past the first batch, confirm pagination lands quickly
- [ ] Confirm a large nonce gap on a known account (e.g. trigger via on-demand fill) resolves quickly
- [ ] Sanity check small-gap path still backfills missing nonces

🤖 Generated with [Claude Code](https://claude.com/claude-code)