### PR TITLE
Add Trace tab + expand toggle to tx detail view

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -178,10 +178,11 @@ pub enum Action {
     },
     /// Decoded execution trace for a transaction (recursive call tree).
     /// Sent after TransactionLoaded so the user sees the rest of the view
-    /// immediately while the trace populates lazily.
+    /// immediately while the trace populates lazily. `trace = None` signals
+    /// a fetch/decode failure so the UI can clear the "loading…" state.
     TransactionTraceLoaded {
         tx_hash: Felt,
-        trace: crate::decode::trace::DecodedTrace,
+        trace: Option<crate::decode::trace::DecodedTrace>,
     },
     /// Address info loaded.
     AddressInfoLoaded {

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -176,6 +176,13 @@ pub enum Action {
         outside_executions: Vec<(usize, OutsideExecutionInfo)>,
         block_timestamp: Option<u64>,
     },
+    /// Decoded execution trace for a transaction (recursive call tree).
+    /// Sent after TransactionLoaded so the user sees the rest of the view
+    /// immediately while the trace populates lazily.
+    TransactionTraceLoaded {
+        tx_hash: Felt,
+        trace: crate::decode::trace::DecodedTrace,
+    },
     /// Address info loaded.
     AddressInfoLoaded {
         info: SnAddressInfo,

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -107,7 +107,7 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) -> Option<Action> {
         }
         KeyCode::PageDown => handle_cycle(app, -1),
 
-        // Tab / Shift+Tab: cycle address tabs forward/backward (AddressInfo only).
+        // Tab / Shift+Tab: cycle tabs forward/backward.
         KeyCode::Tab => {
             if app.current_view() == View::AddressInfo {
                 app.address.tab = match app.address.tab {
@@ -119,6 +119,9 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) -> Option<Action> {
                     crate::app::AddressTab::ClassHistory => crate::app::AddressTab::Transactions,
                 };
                 return maybe_dispatch_meta_txs_on_entry(app);
+            }
+            if app.current_view() == View::TxDetail {
+                app.tx_detail.active_tab = app.tx_detail.active_tab.next();
             }
             None
         }
@@ -133,6 +136,9 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) -> Option<Action> {
                     crate::app::AddressTab::ClassHistory => crate::app::AddressTab::Events,
                 };
                 return maybe_dispatch_meta_txs_on_entry(app);
+            }
+            if app.current_view() == View::TxDetail {
+                app.tx_detail.active_tab = app.tx_detail.active_tab.prev();
             }
             None
         }
@@ -219,23 +225,35 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) -> Option<Action> {
             None
         }
 
-        // c: toggle calldata display in TxDetail
+        // c: toggle calldata display in TxDetail. The toggle only takes effect
+        // in the Calls tab, so jump there if the user pressed it elsewhere.
         KeyCode::Char('c') if app.current_view() == View::TxDetail => {
+            app.tx_detail.active_tab = crate::app::views::tx_detail::TxTab::Calls;
             app.tx_detail.show_calldata = !app.tx_detail.show_calldata;
             None
         }
 
-        // d: toggle decoded calldata display in TxDetail
+        // d: toggle decoded calldata display in TxDetail (Calls tab).
         KeyCode::Char('d') if app.current_view() == View::TxDetail => {
+            app.tx_detail.active_tab = crate::app::views::tx_detail::TxTab::Calls;
             app.tx_detail.show_decoded_calldata = !app.tx_detail.show_decoded_calldata;
             None
         }
 
-        // o: toggle outside execution intent view in TxDetail
+        // o: toggle outside execution intent view in TxDetail (Calls tab).
         KeyCode::Char('o') if app.current_view() == View::TxDetail => {
             if !app.tx_detail.outside_executions.is_empty() {
+                app.tx_detail.active_tab = crate::app::views::tx_detail::TxTab::Calls;
                 app.tx_detail.show_outside_execution = !app.tx_detail.show_outside_execution;
             }
+            None
+        }
+
+        // e: toggle "expand everything" in TxDetail (Calls + Trace tabs).
+        // Master switch — un-truncates hashes, expands structs/arrays inline,
+        // and forces decoded-calldata + outside-exec intent on.
+        KeyCode::Char('e') if app.current_view() == View::TxDetail => {
+            app.tx_detail.expand_all = !app.tx_detail.expand_all;
             None
         }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -902,7 +902,9 @@ impl App {
                 // away from (or replaced via a re-fetch).
                 let current_hash = self.tx_detail.transaction.as_ref().map(|t| t.hash());
                 if current_hash == Some(tx_hash) {
-                    self.tx_detail.trace = Some(trace);
+                    self.tx_detail.trace = trace;
+                    // Always clear the loading flag, even on failure (None) —
+                    // otherwise the Trace tab gets stuck on "loading…".
                     self.tx_detail.trace_loading = false;
                     // Rebuild nav so trace addresses become reachable in `v` mode.
                     self.build_tx_nav_items();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -457,7 +457,8 @@ impl App {
             }
             View::BlockDetail => self.block_detail.txs.next(),
             View::TxDetail => {
-                self.tx_detail.scroll = self.tx_detail.scroll.saturating_add(1);
+                let s = self.tx_detail.active_scroll_mut();
+                *s = s.saturating_add(1);
             }
             View::ClassInfo => {
                 self.class.scroll = self.class.scroll.saturating_add(1);
@@ -494,7 +495,8 @@ impl App {
             View::Blocks => self.blocks.previous(),
             View::BlockDetail => self.block_detail.txs.previous(),
             View::TxDetail => {
-                self.tx_detail.scroll = self.tx_detail.scroll.saturating_sub(1);
+                let s = self.tx_detail.active_scroll_mut();
+                *s = s.saturating_sub(1);
             }
             View::ClassInfo => {
                 self.class.scroll = self.class.scroll.saturating_sub(1);
@@ -521,7 +523,7 @@ impl App {
             View::Blocks => self.blocks.select_first(),
             View::BlockDetail => self.block_detail.txs.select_first(),
             View::TxDetail => {
-                self.tx_detail.scroll = 0;
+                *self.tx_detail.active_scroll_mut() = 0;
             }
             View::ClassInfo => {
                 self.class.scroll = 0;
@@ -557,7 +559,7 @@ impl App {
             }
             View::BlockDetail => self.block_detail.txs.select_last(),
             View::TxDetail => {
-                self.tx_detail.scroll = 999;
+                *self.tx_detail.active_scroll_mut() = 999;
             } // will be clamped by Paragraph
             View::ClassInfo => {
                 self.class.scroll = 999;
@@ -880,7 +882,12 @@ impl App {
                 self.tx_detail.decoded_calls = decoded_calls;
                 self.tx_detail.outside_executions = outside_executions;
                 self.tx_detail.block_timestamp = block_timestamp;
-                self.tx_detail.scroll = 0;
+                self.tx_detail.events_scroll = 0;
+                self.tx_detail.calls_scroll = 0;
+                self.tx_detail.trace_scroll = 0;
+                self.tx_detail.active_tab = crate::app::views::tx_detail::TxTab::default();
+                self.tx_detail.trace = None;
+                self.tx_detail.trace_loading = true;
                 self.tx_detail.visual_mode = false;
                 self.build_tx_nav_items();
                 self.is_loading = false;
@@ -889,6 +896,17 @@ impl App {
                     self.push_view(View::TxDetail);
                 }
                 self.dispatch_tx_price_fetch();
+            }
+            Action::TransactionTraceLoaded { tx_hash, trace } => {
+                // Drop late-arriving traces for a tx the user has navigated
+                // away from (or replaced via a re-fetch).
+                let current_hash = self.tx_detail.transaction.as_ref().map(|t| t.hash());
+                if current_hash == Some(tx_hash) {
+                    self.tx_detail.trace = Some(trace);
+                    self.tx_detail.trace_loading = false;
+                    // Rebuild nav so trace addresses become reachable in `v` mode.
+                    self.build_tx_nav_items();
+                }
             }
             Action::NavigateToAddress { address } => {
                 // Push view immediately — show cached data while fresh data loads

--- a/src/app/views/tx_detail.rs
+++ b/src/app/views/tx_detail.rs
@@ -7,6 +7,43 @@ use crate::data::types::{SnReceipt, SnTransaction};
 use crate::decode::events::DecodedEvent;
 use crate::decode::functions::RawCall;
 use crate::decode::outside_execution::OutsideExecutionInfo;
+use crate::decode::trace::DecodedTrace;
+
+/// Which body tab is active in the tx detail view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TxTab {
+    #[default]
+    Events,
+    Calls,
+    Trace,
+}
+
+impl TxTab {
+    pub fn next(self) -> Self {
+        match self {
+            Self::Events => Self::Calls,
+            Self::Calls => Self::Trace,
+            Self::Trace => Self::Events,
+        }
+    }
+    pub fn prev(self) -> Self {
+        match self {
+            Self::Events => Self::Trace,
+            Self::Calls => Self::Events,
+            Self::Trace => Self::Calls,
+        }
+    }
+}
+
+/// Which screen region a nav item lives in. Drives auto-scroll + tab-switching
+/// when visual-mode steps to an item outside the active tab.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NavSection {
+    Header,
+    Events,
+    Calls,
+    Trace,
+}
 
 /// All state related to the transaction detail view.
 #[derive(Default)]
@@ -15,12 +52,27 @@ pub struct TxDetailState {
     pub receipt: Option<SnReceipt>,
     pub decoded_events: Vec<DecodedEvent>,
     pub decoded_calls: Vec<RawCall>,
-    pub scroll: u16,
+    /// Which tab is currently active in the body (Events default, Calls, Trace).
+    pub active_tab: TxTab,
+    /// Per-tab scroll offsets so switching tabs preserves scroll position.
+    pub events_scroll: u16,
+    pub calls_scroll: u16,
+    pub trace_scroll: u16,
+    /// Decoded recursive call tree (populated lazily after the main fetch).
+    pub trace: Option<DecodedTrace>,
+    /// True from the moment we trigger the trace fetch until it lands.
+    pub trace_loading: bool,
     /// Navigable items in the current tx (rebuilt on load).
     pub nav_items: Vec<TxNavItem>,
+    /// Section each nav_item belongs to. Aligned with `nav_items` 1:1; used by
+    /// `nav_step()` to switch tabs and pick the right per-tab scroll to update.
+    pub nav_sections: Vec<NavSection>,
     /// Cursor index into nav_items (only meaningful when visual_mode is true).
     pub nav_cursor: usize,
-    /// First line index for each nav_items entry (written by the renderer each frame).
+    /// First line index for each nav_items entry (written by the renderer each
+    /// frame). Line numbers are relative to the section the item is in: header
+    /// items use absolute line within the header paragraph; tab-section items
+    /// use the line within that tab's paragraph.
     pub nav_item_lines: Vec<u16>,
     /// Whether visual mode (item selection) is active.
     pub visual_mode: bool,
@@ -28,6 +80,11 @@ pub struct TxDetailState {
     pub show_calldata: bool,
     /// Whether to show ABI-decoded calldata under each call.
     pub show_decoded_calldata: bool,
+    /// Master "expand everything" toggle (`e`). When true, every truncated
+    /// hash is shown in full, structs/arrays/tuples render inline-expanded,
+    /// and the Calls tab behaves as if `d` (decoded calldata) and `o`
+    /// (outside-exec intent) were also on. Default off — too much noise.
+    pub expand_all: bool,
     /// Detected outside executions: (call_index in decoded_calls, parsed info).
     pub outside_executions: Vec<(usize, OutsideExecutionInfo)>,
     /// Whether to show the expanded outside execution intent view.
@@ -43,24 +100,44 @@ impl TxDetailState {
         self.decoded_events = Vec::new();
         self.decoded_calls = Vec::new();
         self.outside_executions = Vec::new();
-        self.scroll = 0;
+        self.active_tab = TxTab::default();
+        self.events_scroll = 0;
+        self.calls_scroll = 0;
+        self.trace_scroll = 0;
+        self.trace = None;
+        self.trace_loading = false;
         self.visual_mode = false;
         self.show_outside_execution = false;
+        self.expand_all = false;
         self.nav_items = Vec::new();
+        self.nav_sections = Vec::new();
         self.nav_cursor = 0;
         self.nav_item_lines = Vec::new();
         self.block_timestamp = None;
     }
 
     /// Build the list of navigable items for the current transaction.
-    /// Order: block -> sender -> call contracts -> event contracts -> address-typed params.
+    /// Order: header (block, sender, declared class, deployed, call targets,
+    /// outside-exec) → events → trace. Tagging each push with its section
+    /// lets `nav_step()` switch tabs and scroll the right region as the
+    /// cursor cycles.
     pub fn build_nav_items<F>(&mut self, is_known: F)
     where
         F: Fn(&starknet::core::types::Felt) -> bool,
     {
         let mut items: Vec<TxNavItem> = Vec::new();
+        let mut sections: Vec<NavSection> = Vec::new();
         let mut seen: HashSet<starknet::core::types::Felt> = HashSet::new();
 
+        let push = |item: TxNavItem,
+                    section: NavSection,
+                    items: &mut Vec<TxNavItem>,
+                    sections: &mut Vec<NavSection>| {
+            items.push(item);
+            sections.push(section);
+        };
+
+        // === Header ===
         // Block number
         let block_num = self
             .receipt
@@ -68,56 +145,95 @@ impl TxDetailState {
             .map(|r| r.block_number)
             .or_else(|| self.transaction.as_ref().map(|tx| tx.block_number()));
         if let Some(n) = block_num {
-            items.push(TxNavItem::Block(n));
+            push(
+                TxNavItem::Block(n),
+                NavSection::Header,
+                &mut items,
+                &mut sections,
+            );
         }
 
         // Sender
         if let Some(tx) = &self.transaction {
             let sender = tx.sender();
             if seen.insert(sender) {
-                items.push(TxNavItem::Address(sender));
+                push(
+                    TxNavItem::Address(sender),
+                    NavSection::Header,
+                    &mut items,
+                    &mut sections,
+                );
             }
-
             // Class hash for Declare txs
             if let crate::data::types::SnTransaction::Declare(decl) = tx {
-                items.push(TxNavItem::ClassHash(decl.class_hash));
+                push(
+                    TxNavItem::ClassHash(decl.class_hash),
+                    NavSection::Header,
+                    &mut items,
+                    &mut sections,
+                );
             }
         }
 
-        // Deployed contract addresses (via UDC)
+        // === Calls tab ===
+        // Deployed contract addresses (via UDC) — surfaced via the calls tree.
         for addr in crate::decode::events::extract_deployed_addresses(&self.decoded_events) {
             if seen.insert(addr) {
-                items.push(TxNavItem::Address(addr));
+                push(
+                    TxNavItem::Address(addr),
+                    NavSection::Calls,
+                    &mut items,
+                    &mut sections,
+                );
             }
         }
 
         // Call contract addresses
         for call in &self.decoded_calls {
             if seen.insert(call.contract_address) {
-                items.push(TxNavItem::Address(call.contract_address));
+                push(
+                    TxNavItem::Address(call.contract_address),
+                    NavSection::Calls,
+                    &mut items,
+                    &mut sections,
+                );
             }
         }
 
-        // Outside execution intender and inner call addresses
+        // Outside execution intender + inner-call addresses
         for (_, oe) in &self.outside_executions {
             if seen.insert(oe.intender) {
-                items.push(TxNavItem::Address(oe.intender));
+                push(
+                    TxNavItem::Address(oe.intender),
+                    NavSection::Calls,
+                    &mut items,
+                    &mut sections,
+                );
             }
             for inner in &oe.inner_calls {
                 if seen.insert(inner.contract_address) {
-                    items.push(TxNavItem::Address(inner.contract_address));
+                    push(
+                        TxNavItem::Address(inner.contract_address),
+                        NavSection::Calls,
+                        &mut items,
+                        &mut sections,
+                    );
                 }
             }
         }
 
-        // Event contract addresses
+        // === Events tab ===
         for event in &self.decoded_events {
             if seen.insert(event.contract_address) {
-                items.push(TxNavItem::Address(event.contract_address));
+                push(
+                    TxNavItem::Address(event.contract_address),
+                    NavSection::Events,
+                    &mut items,
+                    &mut sections,
+                );
             }
         }
-
-        // Address-typed event params + untyped params that resolve to known labels
+        // Address-typed event params + untyped params that resolve to known labels.
         for event in &self.decoded_events {
             for p in event.decoded_keys.iter().chain(event.decoded_data.iter()) {
                 let type_name = p.type_name.as_deref().unwrap_or("");
@@ -127,17 +243,78 @@ impl TxDetailState {
                     && p.value != starknet::core::types::Felt::ZERO
                     && is_known(&p.value);
                 if (is_address_type || is_known_label) && seen.insert(p.value) {
-                    items.push(TxNavItem::Address(p.value));
+                    push(
+                        TxNavItem::Address(p.value),
+                        NavSection::Events,
+                        &mut items,
+                        &mut sections,
+                    );
                 }
             }
         }
 
+        // === Trace tab ===
+        if let Some(trace) = &self.trace {
+            trace.for_each_call(|call| {
+                if seen.insert(call.contract_address) {
+                    push(
+                        TxNavItem::Address(call.contract_address),
+                        NavSection::Trace,
+                        &mut items,
+                        &mut sections,
+                    );
+                }
+                for p in call
+                    .events
+                    .iter()
+                    .flat_map(|e| e.decoded_keys.iter().chain(e.decoded_data.iter()))
+                {
+                    let type_name = p.type_name.as_deref().unwrap_or("");
+                    let is_address_type = type_name.contains("ContractAddress");
+                    let is_known_label = !is_address_type
+                        && type_name.is_empty()
+                        && p.value != starknet::core::types::Felt::ZERO
+                        && is_known(&p.value);
+                    if (is_address_type || is_known_label) && seen.insert(p.value) {
+                        push(
+                            TxNavItem::Address(p.value),
+                            NavSection::Trace,
+                            &mut items,
+                            &mut sections,
+                        );
+                    }
+                }
+            });
+        }
+
         self.nav_items = items;
+        self.nav_sections = sections;
         self.nav_cursor = 0;
         self.nav_item_lines = Vec::new();
     }
 
-    /// Step the visual-mode cursor by `delta` (wrapping), then scroll to keep it visible.
+    /// Read-only access to the active tab's scroll offset.
+    pub fn active_scroll(&self) -> u16 {
+        match self.active_tab {
+            TxTab::Events => self.events_scroll,
+            TxTab::Calls => self.calls_scroll,
+            TxTab::Trace => self.trace_scroll,
+        }
+    }
+
+    /// Mutable access to the active tab's scroll offset (so `select_next`,
+    /// `select_first`, etc. don't have to know about the tab enum).
+    pub fn active_scroll_mut(&mut self) -> &mut u16 {
+        match self.active_tab {
+            TxTab::Events => &mut self.events_scroll,
+            TxTab::Calls => &mut self.calls_scroll,
+            TxTab::Trace => &mut self.trace_scroll,
+        }
+    }
+
+    /// Step the visual-mode cursor by `delta` (wrapping). If the next item is
+    /// in a different tab, switch to that tab; then scroll the matching
+    /// section so the item is visible (2 lines of context above).
     pub fn nav_step(&mut self, delta: i64) {
         if self.nav_items.is_empty() {
             return;
@@ -145,9 +322,27 @@ impl TxDetailState {
         let len = self.nav_items.len() as i64;
         let next = (self.nav_cursor as i64 + delta).rem_euclid(len) as usize;
         self.nav_cursor = next;
-        // Scroll the view so the selected item is visible (2 lines of context above).
+
+        // Switch tab if needed so the selected item is in the active panel.
+        if let Some(section) = self.nav_sections.get(next).copied() {
+            match section {
+                NavSection::Events => self.active_tab = TxTab::Events,
+                NavSection::Calls => self.active_tab = TxTab::Calls,
+                NavSection::Trace => self.active_tab = TxTab::Trace,
+                NavSection::Header => {} // header is always visible — no tab switch
+            }
+        }
+
+        // Scroll the relevant tab so the item is visible. Header items don't
+        // scroll anything (header is fixed-height).
         if let Some(&line) = self.nav_item_lines.get(next) {
-            self.scroll = line.saturating_sub(2);
+            let target = line.saturating_sub(2);
+            match self.nav_sections.get(next).copied() {
+                Some(NavSection::Events) => self.events_scroll = target,
+                Some(NavSection::Calls) => self.calls_scroll = target,
+                Some(NavSection::Trace) => self.trace_scroll = target,
+                Some(NavSection::Header) | None => {}
+            }
         }
     }
 }

--- a/src/app/views/tx_detail.rs
+++ b/src/app/views/tx_detail.rs
@@ -175,19 +175,20 @@ impl TxDetailState {
             }
         }
 
-        // === Calls tab ===
-        // Deployed contract addresses (via UDC) — surfaced via the calls tree.
+        // Deployed contract addresses (via UDC) — rendered in the header's
+        // "Contracts Deployed" section, so they're navigable from there.
         for addr in crate::decode::events::extract_deployed_addresses(&self.decoded_events) {
             if seen.insert(addr) {
                 push(
                     TxNavItem::Address(addr),
-                    NavSection::Calls,
+                    NavSection::Header,
                     &mut items,
                     &mut sections,
                 );
             }
         }
 
+        // === Calls tab ===
         // Call contract addresses
         for call in &self.decoded_calls {
             if seen.insert(call.contract_address) {
@@ -200,12 +201,14 @@ impl TxDetailState {
             }
         }
 
-        // Outside execution intender + inner-call addresses
+        // Outside execution: the intender is shown in the header's META line
+        // (always visible), so it's a Header-section nav item. Inner calls are
+        // only revealed when the Calls tab toggles `o`, so they belong there.
         for (_, oe) in &self.outside_executions {
             if seen.insert(oe.intender) {
                 push(
                     TxNavItem::Address(oe.intender),
-                    NavSection::Calls,
+                    NavSection::Header,
                     &mut items,
                     &mut sections,
                 );

--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -29,19 +29,23 @@ type SharedTxFut =
     Shared<Pin<Box<dyn Future<Output = std::result::Result<SnTransaction, String>> + Send>>>;
 type SharedRxFut =
     Shared<Pin<Box<dyn Future<Output = std::result::Result<SnReceipt, String>> + Send>>>;
+type SharedTraceFut =
+    Shared<Pin<Box<dyn Future<Output = std::result::Result<TransactionTrace, String>> + Send>>>;
 
 /// Persistent cache backed by SQLite + in-memory LRU.
 /// Wraps any DataSource: checks cache first, fetches from upstream on miss,
 /// writes through to cache on fetch. Persists across restarts.
 ///
-/// Also deduplicates concurrent in-flight `get_transaction` / `get_receipt`
-/// fetches so that N parallel callers for the same hash produce one RPC round
-/// trip, not N. Prevents the user-click-races-background-enrichment storm.
+/// Also deduplicates concurrent in-flight `get_transaction` / `get_receipt` /
+/// `get_trace` fetches so that N parallel callers for the same hash produce
+/// one RPC round trip, not N. Prevents the user-click-races-background-
+/// enrichment storm.
 pub struct CachingDataSource {
     upstream: Arc<dyn DataSource>,
     db: DbPool,
     pending_txs: Mutex<HashMap<Felt, SharedTxFut>>,
     pending_receipts: Mutex<HashMap<Felt, SharedRxFut>>,
+    pending_traces: Mutex<HashMap<Felt, SharedTraceFut>>,
 }
 
 impl CachingDataSource {
@@ -310,6 +314,7 @@ impl CachingDataSource {
             db: pool,
             pending_txs: Mutex::new(HashMap::new()),
             pending_receipts: Mutex::new(HashMap::new()),
+            pending_traces: Mutex::new(HashMap::new()),
         })
     }
 
@@ -1154,10 +1159,44 @@ impl DataSource for CachingDataSource {
             trace!(tx_hash = %format!("{:#x}", hash), "cache hit: trace");
             return Ok(cached);
         }
-        debug!(tx_hash = %format!("{:#x}", hash), "cache miss: trace, fetching from RPC");
-        let fetched = self.upstream.get_trace(hash).await?;
-        self.cache_trace(hash, &fetched);
-        Ok(fetched)
+
+        // Coalesce concurrent misses on the same hash into one RPC, mirroring
+        // the get_transaction / get_receipt pattern. Trace fetches are
+        // expensive (recursive call tree, hundreds of ms), so a re-fetch race
+        // would otherwise issue several full traces before the first lands.
+        let fut = {
+            let mut pending = self.pending_traces.lock().unwrap();
+            if let Some(existing) = pending.get(&hash) {
+                trace!(tx_hash = %format!("{:#x}", hash), "dedup: joining in-flight trace fetch");
+                existing.clone()
+            } else {
+                debug!(tx_hash = %format!("{:#x}", hash), "cache miss: trace, fetching from RPC");
+                let upstream = Arc::clone(&self.upstream);
+                let fut: Pin<
+                    Box<dyn Future<Output = std::result::Result<TransactionTrace, String>> + Send>,
+                > = Box::pin(
+                    async move { upstream.get_trace(hash).await.map_err(|e| e.to_string()) },
+                );
+                let shared = fut.shared();
+                pending.insert(hash, shared.clone());
+                shared
+            }
+        };
+
+        let result = fut.await;
+
+        {
+            let mut pending = self.pending_traces.lock().unwrap();
+            pending.remove(&hash);
+        }
+
+        match result {
+            Ok(fetched) => {
+                self.cache_trace(hash, &fetched);
+                Ok(fetched)
+            }
+            Err(e) => Err(SnbeatError::Rpc(e)),
+        }
     }
 
     async fn get_events_for_address(

--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -10,7 +10,7 @@ use futures::future::Shared;
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::{TransactionBehavior, params};
-use starknet::core::types::{ContractClass, Felt};
+use starknet::core::types::{ContractClass, Felt, TransactionTrace};
 use tracing::{debug, trace, warn};
 
 /// Alias so call sites read cleanly. r2d2 reuses the same `rusqlite::Connection`
@@ -83,6 +83,10 @@ impl CachingDataSource {
                 data TEXT NOT NULL
             );
             CREATE TABLE IF NOT EXISTS receipts (
+                tx_hash TEXT PRIMARY KEY,
+                data TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS tx_traces (
                 tx_hash TEXT PRIMARY KEY,
                 data TEXT NOT NULL
             );
@@ -590,6 +594,32 @@ impl CachingDataSource {
             let hash_hex = format!("{:#x}", receipt.transaction_hash);
             let _ = db.execute(
                 "INSERT OR REPLACE INTO receipts (tx_hash, data) VALUES (?1, ?2)",
+                params![hash_hex, json],
+            );
+        }
+    }
+
+    // --- tx_trace cache ---
+    // Traces are deterministic for finalized txs and the RPC call is expensive
+    // (recursive call tree, hundreds of ms). Stash the JSON-serialized trace
+    // keyed by tx hash so revisits are instant.
+    fn get_cached_trace(&self, hash: Felt) -> Option<TransactionTrace> {
+        let db = self.db.get().ok()?;
+        let hash_hex = format!("{:#x}", hash);
+        let mut stmt = db
+            .prepare("SELECT data FROM tx_traces WHERE tx_hash = ?1")
+            .ok()?;
+        let json: String = stmt.query_row(params![hash_hex], |row| row.get(0)).ok()?;
+        serde_json::from_str(&json).ok()
+    }
+
+    fn cache_trace(&self, hash: Felt, trace: &TransactionTrace) {
+        if let Ok(json) = serde_json::to_string(trace)
+            && let Ok(db) = self.db.get()
+        {
+            let hash_hex = format!("{:#x}", hash);
+            let _ = db.execute(
+                "INSERT OR REPLACE INTO tx_traces (tx_hash, data) VALUES (?1, ?2)",
                 params![hash_hex, json],
             );
         }
@@ -1117,6 +1147,17 @@ impl DataSource for CachingDataSource {
         // Parsed ABIs are cached separately via the decode layer's class_cache.
         debug!(class_hash = %format!("{:#x}", class_hash), "Fetching class from RPC (not cached — parsed ABI cached separately)");
         self.upstream.get_class(class_hash).await
+    }
+
+    async fn get_trace(&self, hash: Felt) -> Result<TransactionTrace> {
+        if let Some(cached) = self.get_cached_trace(hash) {
+            trace!(tx_hash = %format!("{:#x}", hash), "cache hit: trace");
+            return Ok(cached);
+        }
+        debug!(tx_hash = %format!("{:#x}", hash), "cache miss: trace, fetching from RPC");
+        let fetched = self.upstream.get_trace(hash).await?;
+        self.cache_trace(hash, &fetched);
+        Ok(fetched)
     }
 
     async fn get_events_for_address(
@@ -1719,7 +1760,7 @@ impl DataSource for CachingDataSource {
 mod tests {
     use super::*;
     use crate::data::DataSource;
-    use starknet::core::types::ContractClass;
+    use starknet::core::types::{ContractClass, TransactionTrace};
 
     /// Minimal upstream stub — the search_progress / activity_total tests only
     /// touch sync cache-local SQL, so the async upstream methods never fire.
@@ -1752,6 +1793,9 @@ mod tests {
             unimplemented!()
         }
         async fn get_class(&self, _class_hash: Felt) -> Result<ContractClass> {
+            unimplemented!()
+        }
+        async fn get_trace(&self, _hash: Felt) -> Result<TransactionTrace> {
             unimplemented!()
         }
         async fn get_recent_blocks(&self, _count: usize) -> Result<Vec<SnBlock>> {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -6,7 +6,7 @@ pub mod types;
 use async_trait::async_trait;
 use starknet::core::types::Felt;
 
-use starknet::core::types::ContractClass;
+use starknet::core::types::{ContractClass, TransactionTrace};
 
 use crate::error::Result;
 use types::{
@@ -66,6 +66,9 @@ pub trait DataSource: Send + Sync {
         self.get_class_hash(address).await
     }
     async fn get_class(&self, class_hash: Felt) -> Result<ContractClass>;
+    /// Fetch the execution trace of a transaction (recursive call tree with
+    /// nested events, calldata, and results). Used by the tx-detail Trace tab.
+    async fn get_trace(&self, hash: Felt) -> Result<TransactionTrace>;
     async fn get_recent_blocks(&self, count: usize) -> Result<Vec<SnBlock>>;
     /// Fetch recent events emitted by or targeting an address.
     ///

--- a/src/data/rpc.rs
+++ b/src/data/rpc.rs
@@ -3,7 +3,7 @@ use starknet::core::types::requests::CallRequest;
 use starknet::core::types::{
     AddressFilter, BlockId, BlockTag, BlockWithTxs, ContractClass, DeclareTransaction,
     DeployAccountTransaction, EventFilter, ExecutionResult, Felt, FunctionCall, InvokeTransaction,
-    MaybePreConfirmedBlockWithTxs, Transaction, TransactionReceipt,
+    MaybePreConfirmedBlockWithTxs, Transaction, TransactionReceipt, TransactionTrace,
 };
 use starknet::core::utils::get_contract_address;
 use starknet::providers::{
@@ -286,6 +286,13 @@ impl DataSource for RpcDataSource {
     async fn get_class(&self, class_hash: Felt) -> Result<ContractClass> {
         self.provider
             .get_class(BlockId::Tag(BlockTag::Latest), class_hash)
+            .await
+            .map_err(|e| SnbeatError::Provider(e.to_string()))
+    }
+
+    async fn get_trace(&self, hash: Felt) -> Result<TransactionTrace> {
+        self.provider
+            .trace_transaction(hash)
             .await
             .map_err(|e| SnbeatError::Provider(e.to_string()))
     }

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -4,6 +4,7 @@ pub mod class_cache;
 pub mod events;
 pub mod functions;
 pub mod outside_execution;
+pub mod trace;
 
 use std::sync::Arc;
 

--- a/src/decode/trace.rs
+++ b/src/decode/trace.rs
@@ -1,0 +1,293 @@
+//! Decode the recursive call tree returned by `starknet_traceTransaction`.
+//!
+//! Maps `starknet::core::types::TransactionTrace` to a snbeat-flavored
+//! `DecodedTrace` that mirrors the RPC tree but with each node enriched
+//! with ABI-resolved function names, definitions, and decoded events.
+//!
+//! Unlike the multicall-decode path (which has to resolve every contract's
+//! class hash at the tx's block), each `FunctionInvocation` node already
+//! carries its own `class_hash`, so we pre-warm ABIs by class hash directly.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use starknet::core::types::{
+    CallType, EntryPointType, ExecuteInvocation, Felt, FunctionInvocation, OrderedEvent,
+    OrderedMessage, TransactionTrace,
+};
+
+use super::AbiRegistry;
+use super::abi::{FunctionDef, ParsedAbi};
+use super::events::{DecodedEvent, decode_event};
+use crate::data::types::SnEvent;
+
+/// One node in the decoded call tree. Mirrors `FunctionInvocation` with
+/// extra ABI-resolved fields. Field naming matches `RawCall` where possible
+/// so existing render helpers (`param_display`, `price`) work unchanged.
+#[derive(Debug, Clone)]
+pub struct DecodedTraceCall {
+    pub contract_address: Felt,
+    pub class_hash: Felt,
+    pub caller_address: Felt,
+    pub entry_point_selector: Felt,
+    pub entry_point_type: EntryPointType,
+    pub call_type: CallType,
+    pub calldata: Vec<Felt>,
+    pub result: Vec<Felt>,
+    pub is_reverted: bool,
+    pub function_name: Option<String>,
+    pub function_def: Option<FunctionDef>,
+    pub contract_abi: Option<Arc<ParsedAbi>>,
+    pub events: Vec<DecodedEvent>,
+    pub messages: Vec<OrderedMessage>,
+    pub inner: Vec<DecodedTraceCall>,
+}
+
+/// Top-level decoded trace, structured per tx kind.
+#[derive(Debug, Clone, Default)]
+pub struct DecodedTrace {
+    pub validate: Option<DecodedTraceCall>,
+    pub execute: Option<DecodedTraceCall>,
+    pub constructor: Option<DecodedTraceCall>,
+    pub fee_transfer: Option<DecodedTraceCall>,
+    pub l1_handler: Option<DecodedTraceCall>,
+    pub revert_reason: Option<String>,
+}
+
+impl DecodedTrace {
+    /// Iterate over the present root invocations in display order:
+    /// validate → execute (or constructor / l1_handler) → fee_transfer.
+    pub fn roots(&self) -> Vec<(&'static str, &DecodedTraceCall)> {
+        let mut out: Vec<(&'static str, &DecodedTraceCall)> = Vec::new();
+        if let Some(v) = &self.validate {
+            out.push(("validate", v));
+        }
+        if let Some(c) = &self.constructor {
+            out.push(("constructor", c));
+        }
+        if let Some(e) = &self.execute {
+            out.push(("execute", e));
+        }
+        if let Some(h) = &self.l1_handler {
+            out.push(("l1_handler", h));
+        }
+        if let Some(f) = &self.fee_transfer {
+            out.push(("fee_transfer", f));
+        }
+        out
+    }
+
+    /// Walk every node in the tree (depth-first, in display order).
+    pub fn for_each_call<F: FnMut(&DecodedTraceCall)>(&self, mut f: F) {
+        fn walk<F: FnMut(&DecodedTraceCall)>(n: &DecodedTraceCall, f: &mut F) {
+            f(n);
+            for c in &n.inner {
+                walk(c, f);
+            }
+        }
+        for (_, root) in self.roots() {
+            walk(root, &mut f);
+        }
+    }
+}
+
+/// Collect every unique class hash referenced in the trace tree.
+fn collect_class_hashes(inv: &FunctionInvocation, out: &mut HashSet<Felt>) {
+    out.insert(inv.class_hash);
+    for child in &inv.calls {
+        collect_class_hashes(child, out);
+    }
+}
+
+/// Collect every root `FunctionInvocation` reference present in a trace.
+fn root_invocations(trace: &TransactionTrace) -> Vec<&FunctionInvocation> {
+    let mut out: Vec<&FunctionInvocation> = Vec::new();
+    match trace {
+        TransactionTrace::Invoke(t) => {
+            if let Some(v) = t.validate_invocation.as_ref() {
+                out.push(v);
+            }
+            if let ExecuteInvocation::Success(ref e) = t.execute_invocation {
+                out.push(e);
+            }
+            if let Some(f) = t.fee_transfer_invocation.as_ref() {
+                out.push(f);
+            }
+        }
+        TransactionTrace::DeployAccount(t) => {
+            out.push(&t.constructor_invocation);
+            if let Some(v) = t.validate_invocation.as_ref() {
+                out.push(v);
+            }
+            if let Some(f) = t.fee_transfer_invocation.as_ref() {
+                out.push(f);
+            }
+        }
+        TransactionTrace::Declare(t) => {
+            if let Some(v) = t.validate_invocation.as_ref() {
+                out.push(v);
+            }
+            if let Some(f) = t.fee_transfer_invocation.as_ref() {
+                out.push(f);
+            }
+        }
+        TransactionTrace::L1Handler(t) => {
+            if let ExecuteInvocation::Success(ref e) = t.function_invocation {
+                out.push(e);
+            }
+        }
+    }
+    out
+}
+
+/// Pre-warm parsed ABIs for every class hash in the trace, in parallel.
+async fn prewarm_trace_abis(trace: &TransactionTrace, abi_reg: &Arc<AbiRegistry>) {
+    let mut classes: HashSet<Felt> = HashSet::new();
+    for root in root_invocations(trace) {
+        collect_class_hashes(root, &mut classes);
+    }
+
+    let futs: Vec<_> = classes
+        .into_iter()
+        .map(|ch| {
+            let abi_reg = Arc::clone(abi_reg);
+            async move {
+                let _ = abi_reg.get_abi_for_class(&ch).await;
+            }
+        })
+        .collect();
+    futures::future::join_all(futs).await;
+}
+
+/// Decode one invocation node by looking up its class's ABI and decoding events.
+async fn decode_invocation(
+    inv: &FunctionInvocation,
+    tx_hash: Felt,
+    block: u64,
+    abi_reg: &Arc<AbiRegistry>,
+) -> DecodedTraceCall {
+    // Resolve ABI by class hash (already prewarmed).
+    let abi = abi_reg.get_abi_for_class(&inv.class_hash).await;
+
+    // Function metadata. Selector → name lookup falls back to the persistent
+    // selector table when the ABI's own name didn't make it (legacy classes).
+    let mut function_name = abi_reg.get_selector_name(&inv.entry_point_selector);
+    let function_def = abi
+        .as_deref()
+        .and_then(|a| a.get_function(&inv.entry_point_selector));
+    if let Some(f) = function_def
+        && function_name.is_none()
+    {
+        function_name = Some(f.name.clone());
+    }
+    let function_def = function_def.cloned();
+
+    // Decode events emitted directly by this invocation. The trace gives us
+    // OrderedEvent (no from_address) — synthesize an SnEvent for `decode_event`.
+    let mut events = Vec::with_capacity(inv.events.len());
+    for (idx, e) in inv.events.iter().enumerate() {
+        let synth = synth_event(inv.contract_address, e, tx_hash, block, idx as u64);
+        events.push(decode_event(&synth, abi.as_deref()));
+    }
+
+    // Recurse for inner calls. Box::pin to break the recursion in async.
+    let mut inner = Vec::with_capacity(inv.calls.len());
+    for child in &inv.calls {
+        inner.push(Box::pin(decode_invocation(child, tx_hash, block, abi_reg)).await);
+    }
+
+    DecodedTraceCall {
+        contract_address: inv.contract_address,
+        class_hash: inv.class_hash,
+        caller_address: inv.caller_address,
+        entry_point_selector: inv.entry_point_selector,
+        entry_point_type: inv.entry_point_type,
+        call_type: inv.call_type,
+        calldata: inv.calldata.clone(),
+        result: inv.result.clone(),
+        is_reverted: false,
+        function_name,
+        function_def,
+        contract_abi: abi,
+        events,
+        messages: inv.messages.clone(),
+        inner,
+    }
+}
+
+fn synth_event(
+    from_address: Felt,
+    e: &OrderedEvent,
+    tx_hash: Felt,
+    block_number: u64,
+    event_index: u64,
+) -> SnEvent {
+    SnEvent {
+        from_address,
+        keys: e.keys.clone(),
+        data: e.data.clone(),
+        transaction_hash: tx_hash,
+        block_number,
+        event_index,
+    }
+}
+
+/// Decode the full transaction trace tree.
+///
+/// Pre-warms ABIs for every unique class hash in the tree in one parallel
+/// round-trip, then walks the tree to build `DecodedTraceCall` nodes.
+pub async fn decode_trace(
+    trace: &TransactionTrace,
+    tx_hash: Felt,
+    block: u64,
+    abi_reg: &Arc<AbiRegistry>,
+) -> DecodedTrace {
+    prewarm_trace_abis(trace, abi_reg).await;
+
+    let mut out = DecodedTrace::default();
+    match trace {
+        TransactionTrace::Invoke(t) => {
+            if let Some(v) = &t.validate_invocation {
+                out.validate = Some(decode_invocation(v, tx_hash, block, abi_reg).await);
+            }
+            match t.execute_invocation {
+                ExecuteInvocation::Success(ref e) => {
+                    out.execute = Some(decode_invocation(e, tx_hash, block, abi_reg).await);
+                }
+                ExecuteInvocation::Reverted(ref r) => {
+                    out.revert_reason = Some(r.revert_reason.clone());
+                }
+            }
+            if let Some(f) = &t.fee_transfer_invocation {
+                out.fee_transfer = Some(decode_invocation(f, tx_hash, block, abi_reg).await);
+            }
+        }
+        TransactionTrace::DeployAccount(t) => {
+            if let Some(v) = &t.validate_invocation {
+                out.validate = Some(decode_invocation(v, tx_hash, block, abi_reg).await);
+            }
+            out.constructor =
+                Some(decode_invocation(&t.constructor_invocation, tx_hash, block, abi_reg).await);
+            if let Some(f) = &t.fee_transfer_invocation {
+                out.fee_transfer = Some(decode_invocation(f, tx_hash, block, abi_reg).await);
+            }
+        }
+        TransactionTrace::Declare(t) => {
+            if let Some(v) = &t.validate_invocation {
+                out.validate = Some(decode_invocation(v, tx_hash, block, abi_reg).await);
+            }
+            if let Some(f) = &t.fee_transfer_invocation {
+                out.fee_transfer = Some(decode_invocation(f, tx_hash, block, abi_reg).await);
+            }
+        }
+        TransactionTrace::L1Handler(t) => match t.function_invocation {
+            ExecuteInvocation::Success(ref e) => {
+                out.l1_handler = Some(decode_invocation(e, tx_hash, block, abi_reg).await);
+            }
+            ExecuteInvocation::Reverted(ref r) => {
+                out.revert_reason = Some(r.revert_reason.clone());
+            }
+        },
+    }
+    out
+}

--- a/src/decode/trace.rs
+++ b/src/decode/trace.rs
@@ -11,6 +11,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use futures::stream::StreamExt;
 use starknet::core::types::{
     CallType, EntryPointType, ExecuteInvocation, Felt, FunctionInvocation, OrderedEvent,
     OrderedMessage, TransactionTrace,
@@ -52,6 +53,10 @@ pub struct DecodedTrace {
     pub fee_transfer: Option<DecodedTraceCall>,
     pub l1_handler: Option<DecodedTraceCall>,
     pub revert_reason: Option<String>,
+    /// Total nodes in the tree (validate + execute + fee_transfer + nested),
+    /// computed once at decode time so the tabs bar doesn't walk the whole
+    /// tree on every frame just to render the count.
+    pub total_nodes: usize,
 }
 
 impl DecodedTrace {
@@ -140,23 +145,30 @@ fn root_invocations(trace: &TransactionTrace) -> Vec<&FunctionInvocation> {
     out
 }
 
-/// Pre-warm parsed ABIs for every class hash in the trace, in parallel.
+/// Pre-warm parsed ABIs for every class hash in the trace, with bounded
+/// concurrency so a pathological tx (e.g. cross-protocol, many novel
+/// classes) doesn't issue dozens of parallel `getClass` RPCs at once and
+/// trip provider rate limits or jitter.
 async fn prewarm_trace_abis(trace: &TransactionTrace, abi_reg: &Arc<AbiRegistry>) {
+    /// Cap on parallel ABI fetches. ~8 covers typical traces (which dedupe
+    /// to a handful of unique classes anyway, and most are cache hits) while
+    /// staying well below provider per-second limits.
+    const PREWARM_CONCURRENCY: usize = 8;
+
     let mut classes: HashSet<Felt> = HashSet::new();
     for root in root_invocations(trace) {
         collect_class_hashes(root, &mut classes);
     }
 
-    let futs: Vec<_> = classes
-        .into_iter()
-        .map(|ch| {
-            let abi_reg = Arc::clone(abi_reg);
-            async move {
-                let _ = abi_reg.get_abi_for_class(&ch).await;
-            }
-        })
-        .collect();
-    futures::future::join_all(futs).await;
+    futures::stream::iter(classes.into_iter().map(|ch| {
+        let abi_reg = Arc::clone(abi_reg);
+        async move {
+            let _ = abi_reg.get_abi_for_class(&ch).await;
+        }
+    }))
+    .buffer_unordered(PREWARM_CONCURRENCY)
+    .for_each(|_| async {})
+    .await;
 }
 
 /// Decode one invocation node by looking up its class's ABI and decoding events.
@@ -289,5 +301,9 @@ pub async fn decode_trace(
             }
         },
     }
+    // Cache the total node count once so the UI doesn't walk the tree per frame.
+    let mut n = 0usize;
+    out.for_each_call(|_| n += 1);
+    out.total_nodes = n;
     out
 }

--- a/src/network/transaction.rs
+++ b/src/network/transaction.rs
@@ -242,14 +242,19 @@ pub(super) async fn fetch_and_send_trace(
             );
             let _ = tx.send(Action::TransactionTraceLoaded {
                 tx_hash: hash,
-                trace: decoded,
+                trace: Some(decoded),
             });
         }
         Err(e) => {
             error!(tx_hash = %hash_short, error = %e, "Failed to fetch trace");
-            // Non-fatal: the rest of the tx view is already populated. We
-            // surface the failure as a low-priority error instead of an
-            // empty Trace tab so the user knows it didn't silently succeed.
+            // Non-fatal: the rest of the tx view is already populated. Send
+            // a TransactionTraceLoaded with `trace: None` so the UI can clear
+            // the "loading…" state and render an "unavailable" message,
+            // and surface the error itself separately.
+            let _ = tx.send(Action::TransactionTraceLoaded {
+                tx_hash: hash,
+                trace: None,
+            });
             let _ = tx.send(Action::Error(format!("Fetch trace: {e}")));
         }
     }

--- a/src/network/transaction.rs
+++ b/src/network/transaction.rs
@@ -136,6 +136,7 @@ pub(super) async fn decode_and_send_transaction(
     // Block fetches are cached, so repeat calls for the same block are cheap.
     let block_timestamp = ds.get_block(block).await.ok().map(|b| b.timestamp);
 
+    let tx_hash = transaction.hash();
     let _ = action_tx.send(Action::TransactionLoaded {
         transaction,
         receipt,
@@ -144,6 +145,10 @@ pub(super) async fn decode_and_send_transaction(
         outside_executions,
         block_timestamp,
     });
+
+    // Fire-and-forget trace fetch. Sent as a separate Action so the rest of
+    // the tx view paints immediately while the recursive trace decodes.
+    spawn_trace_fetch(tx_hash, block, ds, abi_reg, action_tx);
 }
 
 /// Detect outside execution calls, parse their inner calls, and resolve inner call ABIs.
@@ -213,4 +218,55 @@ pub(super) async fn fetch_and_send_transaction(
             let _ = tx.send(Action::Error(format!("Fetch tx: {e}")));
         }
     }
+}
+
+/// Fetch + decode the trace for `hash` and send `TransactionTraceLoaded`.
+pub(super) async fn fetch_and_send_trace(
+    hash: starknet::core::types::Felt,
+    block: u64,
+    ds: Arc<dyn DataSource>,
+    abi_reg: Arc<AbiRegistry>,
+    tx: mpsc::UnboundedSender<Action>,
+) {
+    let start = std::time::Instant::now();
+    let hash_short = format!("{:#x}", hash);
+    debug!(tx_hash = %hash_short, "Fetching transaction trace");
+
+    match ds.get_trace(hash).await {
+        Ok(trace) => {
+            let decoded = crate::decode::trace::decode_trace(&trace, hash, block, &abi_reg).await;
+            info!(
+                tx_hash = %hash_short,
+                elapsed_ms = start.elapsed().as_millis(),
+                "Trace fetched + decoded"
+            );
+            let _ = tx.send(Action::TransactionTraceLoaded {
+                tx_hash: hash,
+                trace: decoded,
+            });
+        }
+        Err(e) => {
+            error!(tx_hash = %hash_short, error = %e, "Failed to fetch trace");
+            // Non-fatal: the rest of the tx view is already populated. We
+            // surface the failure as a low-priority error instead of an
+            // empty Trace tab so the user knows it didn't silently succeed.
+            let _ = tx.send(Action::Error(format!("Fetch trace: {e}")));
+        }
+    }
+}
+
+/// Helper that spawns `fetch_and_send_trace` as a detached tokio task.
+pub(super) fn spawn_trace_fetch(
+    hash: starknet::core::types::Felt,
+    block: u64,
+    ds: &Arc<dyn DataSource>,
+    abi_reg: &Arc<AbiRegistry>,
+    tx: &mpsc::UnboundedSender<Action>,
+) {
+    let ds = Arc::clone(ds);
+    let abi_reg = Arc::clone(abi_reg);
+    let tx = tx.clone();
+    tokio::spawn(async move {
+        fetch_and_send_trace(hash, block, ds, abi_reg, tx).await;
+    });
 }

--- a/src/network/ws.rs
+++ b/src/network/ws.rs
@@ -862,6 +862,12 @@ mod tests {
         async fn get_class(&self, _class_hash: Felt) -> crate::error::Result<ContractClass> {
             unimplemented!()
         }
+        async fn get_trace(
+            &self,
+            _hash: Felt,
+        ) -> crate::error::Result<starknet::core::types::TransactionTrace> {
+            unimplemented!()
+        }
         async fn get_recent_blocks(&self, _count: usize) -> crate::error::Result<Vec<SnBlock>> {
             unimplemented!()
         }

--- a/src/ui/views/tx_detail.rs
+++ b/src/ui/views/tx_detail.rs
@@ -1,30 +1,30 @@
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Layout};
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
-use starknet::core::types::Felt;
+use ratatui::widgets::{Block, Borders, Paragraph, Tabs, Wrap};
+use starknet::core::types::{CallType, EntryPointType, Felt};
 
 use crate::app::App;
 use crate::app::state::TxNavItem;
+use crate::app::views::tx_detail::TxTab;
 use crate::data::types::{ExecutionStatus, SnTransaction};
 use crate::decode::calldata::{self, DecodedValue};
-use crate::decode::events::DecodedParam;
+use crate::decode::events::{DecodedEvent, DecodedParam};
 use crate::decode::functions::RawCall;
 use crate::decode::outside_execution;
+use crate::decode::trace::DecodedTraceCall;
 use crate::ui::theme;
 use crate::ui::widgets::address_color::AddressColorMap;
 use crate::ui::widgets::hex_display::{format_commas, format_fri, format_strk_u128};
 use crate::ui::widgets::{param_display, price, search_bar, status_bar};
 use crate::utils::felt_to_u128;
 
-pub fn draw(f: &mut Frame, app: &mut App) {
-    let chunks = Layout::vertical([
-        Constraint::Length(1), // search bar
-        Constraint::Min(3),    // scrollable tx detail + events
-        Constraint::Length(1), // status bar
-    ])
-    .split(f.area());
+/// Cap of top-level multicall entries shown in the fixed header before
+/// collapsing the rest into a "... and N more" line.
+const HEADER_CALLS_PREVIEW: usize = 4;
 
+pub fn draw(f: &mut Frame, app: &mut App) {
     let selected: Option<TxNavItem> = if app.tx_detail.visual_mode {
         app.tx_detail
             .nav_items
@@ -33,48 +33,213 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     } else {
         None
     };
-    search_bar::draw_input(f, app, chunks[0]);
-    let nav_line_map = draw_scrollable_detail(f, app, chunks[1], selected.as_ref());
-    app.tx_detail.nav_item_lines = nav_line_map;
-    status_bar::draw(f, app, chunks[2]);
 
+    if app.tx_detail.transaction.is_none() {
+        let chunks = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Min(3),
+            Constraint::Length(1),
+        ])
+        .split(f.area());
+        search_bar::draw_input(f, app, chunks[0]);
+        f.render_widget(
+            Paragraph::new(" Loading transaction...").style(theme::STATUS_LOADING),
+            chunks[1],
+        );
+        status_bar::draw(f, app, chunks[2]);
+        search_bar::draw_dropdown(f, app, chunks[0]);
+        return;
+    }
+
+    let color_map = build_color_map(app);
+    let mut line_map: Vec<Option<u16>> = vec![None; app.tx_detail.nav_items.len()];
+
+    // Build line buffers for header + every tab body up front. Header always
+    // renders; bodies are computed for all three tabs every frame so visual-mode
+    // tab-switches see up-to-date line offsets for the destination tab — without
+    // this, the first `j` after a tab switch would scroll to a stale offset.
+    let header_lines = build_header_lines(app, &color_map, selected.as_ref(), &mut line_map);
+    let events_lines = build_events_lines(app, &color_map, selected.as_ref(), &mut line_map);
+    let calls_lines = build_calls_lines(app, &color_map, selected.as_ref(), &mut line_map);
+    let trace_lines = build_trace_lines(app, &color_map, selected.as_ref(), &mut line_map);
+
+    let header_height = (header_lines.len() as u16).saturating_add(2); // borders
+    // Header is fixed-content; clamp to ~60% of screen so tab body always
+    // gets at least a few rows on small terminals. The tab body Min(5) below
+    // works in tandem with this clamp.
+    let max_header = (f.area().height.saturating_sub(4) * 6 / 10).max(5);
+    let header_height = header_height.min(max_header);
+
+    let chunks = Layout::vertical([
+        Constraint::Length(1),             // search bar
+        Constraint::Length(header_height), // fixed header
+        Constraint::Length(1),             // tabs bar
+        Constraint::Min(5),                // tab body (scrollable)
+        Constraint::Length(1),             // status bar
+    ])
+    .split(f.area());
+
+    search_bar::draw_input(f, app, chunks[0]);
+    draw_header_panel(f, header_lines, chunks[1]);
+    draw_tabs_bar(f, app, chunks[2]);
+    draw_active_tab_body(f, app, chunks[3], events_lines, calls_lines, trace_lines);
+    status_bar::draw(f, app, chunks[4]);
+
+    app.tx_detail.nav_item_lines = line_map.into_iter().map(|o| o.unwrap_or(0)).collect();
     search_bar::draw_dropdown(f, app, chunks[0]);
 }
 
-/// Returns the first-line index for each nav item in `app.tx_detail.nav_items` (same order).
-fn draw_scrollable_detail(
+fn draw_header_panel(f: &mut Frame, lines: Vec<Line<'static>>, area: Rect) {
+    let widget = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(theme::BORDER_FOCUSED_STYLE)
+                .title(Span::styled(" Transaction ", theme::TITLE_STYLE)),
+        )
+        .wrap(Wrap { trim: false });
+    f.render_widget(widget, area);
+}
+
+fn draw_tabs_bar(f: &mut Frame, app: &App, area: Rect) {
+    let events_count = app.tx_detail.decoded_events.len();
+    let calls_count = app.tx_detail.decoded_calls.len();
+    let trace_count = app
+        .tx_detail
+        .trace
+        .as_ref()
+        .map(|t| {
+            let mut n = 0usize;
+            t.for_each_call(|_| n += 1);
+            n
+        })
+        .unwrap_or(0);
+    let trace_label = if app.tx_detail.trace.is_some() {
+        format!("Trace ({trace_count})")
+    } else if app.tx_detail.trace_loading {
+        "Trace (loading…)".to_string()
+    } else {
+        "Trace".to_string()
+    };
+    let titles = vec![
+        Span::raw(format!(" Events ({events_count}) ")),
+        Span::raw(format!(" Calls ({calls_count}) ")),
+        Span::raw(format!(" {trace_label} ")),
+    ];
+    let selected = match app.tx_detail.active_tab {
+        TxTab::Events => 0,
+        TxTab::Calls => 1,
+        TxTab::Trace => 2,
+    };
+    // Active tab uses a filled background for high contrast — much more
+    // visible than the default underline at-a-glance.
+    let highlight = ratatui::style::Style::new()
+        .fg(ratatui::style::Color::Black)
+        .bg(ratatui::style::Color::Cyan)
+        .add_modifier(Modifier::BOLD);
+    let tabs = Tabs::new(titles)
+        .select(selected)
+        .style(theme::SUGGESTION_STYLE)
+        .highlight_style(highlight)
+        .divider(Span::styled("·", theme::BORDER_STYLE))
+        .padding("", "");
+    f.render_widget(tabs, area);
+}
+
+fn draw_active_tab_body(
     f: &mut Frame,
     app: &App,
-    area: ratatui::layout::Rect,
+    area: Rect,
+    events_lines: Vec<Line<'static>>,
+    calls_lines: Vec<Line<'static>>,
+    trace_lines: Vec<Line<'static>>,
+) {
+    let (lines, scroll, title) = match app.tx_detail.active_tab {
+        TxTab::Events => (
+            events_lines,
+            app.tx_detail.events_scroll,
+            " Events (j/k: scroll · v: visual · Tab: next) ",
+        ),
+        TxTab::Calls => (
+            calls_lines,
+            app.tx_detail.calls_scroll,
+            " Calls (c: raw · d: decode · o: intent · e: expand · Tab: next) ",
+        ),
+        TxTab::Trace => (
+            trace_lines,
+            app.tx_detail.trace_scroll,
+            " Trace (j/k: scroll · v: visual · e: expand · Tab: next) ",
+        ),
+    };
+    let widget = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(theme::BORDER_FOCUSED_STYLE)
+                .title(Span::styled(title, theme::TITLE_STYLE)),
+        )
+        .wrap(Wrap { trim: false })
+        .scroll((scroll, 0));
+    f.render_widget(widget, area);
+}
+
+/// Address formatting that honours the `e` (expand_all) toggle.
+/// When expand_all is on we always show the full hex; if the address has a
+/// label (registry or Voyager-sourced), we append `(label)` after the hex
+/// so the tag is still visible — the user gets both pieces of info on one
+/// line and can copy the full hex without losing the human-readable name.
+fn format_addr_expanded(app: &App, felt: &Felt) -> String {
+    let full = format!("{:#x}", felt);
+    if let Some(engine) = &app.search_engine
+        && let Some(name) = engine.registry().resolve(felt)
+    {
+        return format!("{full} ({name})");
+    }
+    if let Some(label) = app.voyager_labels.get(felt)
+        && let Some(name) = &label.name
+    {
+        return format!("{full} ({name})");
+    }
+    full
+}
+
+/// `format_address` with expand-all override.
+fn fmt_addr(app: &App, felt: &Felt) -> String {
+    if app.tx_detail.expand_all {
+        format_addr_expanded(app, felt)
+    } else {
+        app.format_address(felt)
+    }
+}
+
+/// `format_address_full` with expand-all override.
+fn fmt_addr_full(app: &App, felt: &Felt) -> String {
+    if app.tx_detail.expand_all {
+        format_addr_expanded(app, felt)
+    } else {
+        app.format_address_full(felt)
+    }
+}
+
+/// Record `item`'s first-occurrence line position into `map` (if not already set).
+fn record(item: &TxNavItem, cur_line: usize, map: &mut [Option<u16>], nav: &[TxNavItem]) {
+    if let Some(idx) = nav.iter().position(|x| x == item) {
+        map[idx].get_or_insert(cur_line as u16);
+    }
+}
+
+/// Build the fixed header lines (tx metadata, status, top-level calls preview, fee).
+fn build_header_lines(
+    app: &App,
+    color_map: &AddressColorMap,
     selected: Option<&TxNavItem>,
-) -> Vec<u16> {
+    line_map: &mut [Option<u16>],
+) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
     let tx = match &app.tx_detail.transaction {
         Some(t) => t,
-        None => {
-            f.render_widget(
-                Paragraph::new(" Loading transaction...").style(theme::STATUS_LOADING),
-                area,
-            );
-            return vec![];
-        }
+        None => return lines,
     };
-
-    // Build the address color map for this tx view.
-    // Registration order determines slot (= color). Sender is always slot 0.
-    let color_map = build_color_map(app);
-    let registry = app.search_engine.as_ref().map(|e| e.registry());
-
-    let mut lines: Vec<Line> = Vec::new();
-    // Tracks the first line index where each TxNavItem appears (same order as app.tx_detail.nav_items).
-    let mut line_map: Vec<Option<u16>> = vec![None; app.tx_detail.nav_items.len()];
-
-    // Record the current line count as the first occurrence of `item` (if not already recorded).
-    let record =
-        |item: &TxNavItem, lines: &Vec<Line>, map: &mut Vec<Option<u16>>, nav: &[TxNavItem]| {
-            if let Some(idx) = nav.iter().position(|x| x == item) {
-                map[idx].get_or_insert(lines.len() as u16);
-            }
-        };
 
     // === TX HEADER ===
     lines.push(Line::from(vec![
@@ -126,8 +291,8 @@ fn draw_scrollable_detail(
         .unwrap_or_default();
     record(
         &TxNavItem::Block(blk_num),
-        &lines,
-        &mut line_map,
+        lines.len(),
+        line_map,
         &app.tx_detail.nav_items,
     );
     lines.push(Line::from(vec![
@@ -156,11 +321,11 @@ fn draw_scrollable_detail(
     // META TX indicator for outside executions
     if !app.tx_detail.outside_executions.is_empty() {
         for (_, oe) in &app.tx_detail.outside_executions {
-            let intender_style = addr_style(&oe.intender, &color_map, selected);
+            let intender_style = addr_style(&oe.intender, color_map, selected);
             record(
                 &TxNavItem::Address(oe.intender),
-                &lines,
-                &mut line_map,
+                lines.len(),
+                line_map,
                 &app.tx_detail.nav_items,
             );
             lines.push(Line::from(vec![
@@ -168,7 +333,7 @@ fn draw_scrollable_detail(
                 Span::styled("Meta:   ", theme::NORMAL_STYLE),
                 Span::styled(format!("META TX ({})", oe.version), theme::META_TX_STYLE),
                 Span::styled("  Intender: ", theme::NORMAL_STYLE),
-                Span::styled(app.format_address_full(&oe.intender), intender_style),
+                Span::styled(fmt_addr_full(app, &oe.intender), intender_style),
                 Span::styled(format!("  Nonce: {:#x}", oe.nonce), theme::SUGGESTION_STYLE),
             ]));
             lines.push(Line::from(vec![
@@ -190,17 +355,17 @@ fn draw_scrollable_detail(
             )
         })
         .unwrap_or_else(|| "N/A".into());
-    let sender_style = addr_style(&sender, &color_map, selected);
+    let sender_style = addr_style(&sender, color_map, selected);
     record(
         &TxNavItem::Address(sender),
-        &lines,
-        &mut line_map,
+        lines.len(),
+        line_map,
         &app.tx_detail.nav_items,
     );
     lines.push(Line::from(vec![
         addr_marker(&sender, selected),
         Span::styled("Sender: ", theme::NORMAL_STYLE),
-        Span::styled(app.format_address_full(&sender), sender_style),
+        Span::styled(fmt_addr_full(app, &sender), sender_style),
         Span::styled(format!("  Nonce: {}", nonce_str), theme::NORMAL_STYLE),
     ]));
     lines.push(Line::from(vec![
@@ -216,7 +381,7 @@ fn draw_scrollable_detail(
         } else {
             theme::TX_HASH_STYLE
         };
-        record(&ch_item, &lines, &mut line_map, &app.tx_detail.nav_items);
+        record(&ch_item, lines.len(), line_map, &app.tx_detail.nav_items);
         let ch_marker = if selected == Some(&ch_item) {
             Span::styled("►", theme::VISUAL_SELECTED_STYLE)
         } else {
@@ -237,7 +402,7 @@ fn draw_scrollable_detail(
         } else {
             theme::TX_HASH_STYLE
         };
-        record(&ch_item, &lines, &mut line_map, &app.tx_detail.nav_items);
+        record(&ch_item, lines.len(), line_map, &app.tx_detail.nav_items);
         let ch_marker = if selected == Some(&ch_item) {
             Span::styled("►", theme::VISUAL_SELECTED_STYLE)
         } else {
@@ -279,17 +444,17 @@ fn draw_scrollable_detail(
             theme::TITLE_STYLE,
         )));
         for addr in &deployed_addrs {
-            let style = addr_style(addr, &color_map, selected);
+            let style = addr_style(addr, color_map, selected);
             record(
                 &TxNavItem::Address(*addr),
-                &lines,
-                &mut line_map,
+                lines.len(),
+                line_map,
                 &app.tx_detail.nav_items,
             );
             lines.push(Line::from(vec![
                 addr_marker(addr, selected),
                 Span::styled("  ", theme::NORMAL_STYLE),
-                Span::styled(app.format_address_full(addr), style),
+                Span::styled(fmt_addr_full(app, addr), style),
             ]));
             lines.push(Line::from(vec![
                 Span::raw("   "),
@@ -298,34 +463,23 @@ fn draw_scrollable_detail(
         }
     }
 
-    // === DECODED CALLS ===
+    // === TOP-LEVEL CALLS PREVIEW (compact) ===
+    // Show up to HEADER_CALLS_PREVIEW top-level multicall entries as a quick
+    // glance; the full list with c/d/o toggles lives in the Calls tab.
     if !app.tx_detail.decoded_calls.is_empty() {
         lines.push(Line::from(""));
-        let has_oe = !app.tx_detail.outside_executions.is_empty();
-        let oe_hint = if has_oe {
-            if app.tx_detail.show_outside_execution {
-                " [o: hide intent]"
-            } else {
-                " [o: intent]"
-            }
-        } else {
-            ""
-        };
-        let calldata_hint = if app.tx_detail.show_decoded_calldata {
-            format!(" [d: hide decoded] [c: raw]{oe_hint}")
-        } else if app.tx_detail.show_calldata {
-            format!(" [c: hide calldata] [d: decode]{oe_hint}")
-        } else {
-            format!(" [c: raw calldata] [d: decode]{oe_hint}")
-        };
-        lines.push(Line::from(vec![
-            Span::styled(
-                format!(" Calls ({})", app.tx_detail.decoded_calls.len()),
-                theme::TITLE_STYLE,
-            ),
-            Span::styled(calldata_hint, theme::SUGGESTION_STYLE),
-        ]));
-        for (i, call) in app.tx_detail.decoded_calls.iter().enumerate() {
+        lines.push(Line::from(Span::styled(
+            format!(" Calls ({})", app.tx_detail.decoded_calls.len()),
+            theme::TITLE_STYLE,
+        )));
+        let preview_n = app.tx_detail.decoded_calls.len().min(HEADER_CALLS_PREVIEW);
+        for (i, call) in app
+            .tx_detail
+            .decoded_calls
+            .iter()
+            .take(preview_n)
+            .enumerate()
+        {
             let display_name = call.function_name.clone().unwrap_or_else(|| {
                 let hex = format!("{:#x}", call.selector);
                 if hex.len() > 18 {
@@ -334,12 +488,12 @@ fn draw_scrollable_detail(
                     hex
                 }
             });
-            let target = app.format_address(&call.contract_address);
-            let contract_style = addr_style(&call.contract_address, &color_map, selected);
+            let target = fmt_addr(app, &call.contract_address);
+            let contract_style = addr_style(&call.contract_address, color_map, selected);
             record(
                 &TxNavItem::Address(call.contract_address),
-                &lines,
-                &mut line_map,
+                lines.len(),
+                line_map,
                 &app.tx_detail.nav_items,
             );
             lines.push(Line::from(vec![
@@ -353,121 +507,13 @@ fn draw_scrollable_detail(
                     theme::SUGGESTION_STYLE,
                 ),
             ]));
-            // Inline annotation for outside execution calls
-            if let Some((_, oe)) = app
-                .tx_detail
-                .outside_executions
-                .iter()
-                .find(|(idx, _)| *idx == i)
-            {
-                let caller_str = outside_execution::format_caller(&oe.caller);
-                lines.push(Line::from(vec![
-                    Span::raw("        "),
-                    Span::styled(
-                        format!("Outside Execution ({})", oe.version),
-                        theme::META_TX_STYLE,
-                    ),
-                    Span::styled(
-                        format!(
-                            "  nonce: {:#x}  caller: {}  inner calls: {}",
-                            oe.nonce,
-                            caller_str,
-                            oe.inner_calls.len()
-                        ),
-                        theme::SUGGESTION_STYLE,
-                    ),
-                ]));
-            }
-            if app.tx_detail.show_decoded_calldata {
-                render_decoded_calldata(call, app, &color_map, selected, &mut lines);
-            } else if app.tx_detail.show_calldata {
-                for (di, felt) in call.data.iter().enumerate() {
-                    lines.push(Line::from(vec![
-                        Span::raw("        "),
-                        Span::styled(format!("[{di}] {:#x}", felt), theme::SUGGESTION_STYLE),
-                    ]));
-                }
-            }
         }
-    }
-
-    // === OUTSIDE EXECUTION INTENT (toggled with `o`) ===
-    if app.tx_detail.show_outside_execution && !app.tx_detail.outside_executions.is_empty() {
-        lines.push(Line::from(""));
-        lines.push(Line::from(vec![
-            Span::styled(" Outside Execution Intent", theme::TITLE_STYLE),
-            Span::styled(" [o: hide]", theme::SUGGESTION_STYLE),
-        ]));
-        for (_, oe) in &app.tx_detail.outside_executions {
-            let intender_style = addr_style(&oe.intender, &color_map, selected);
-            let caller_str = outside_execution::format_caller(&oe.caller);
-            lines.push(Line::from(vec![
-                Span::styled("   Intender: ", theme::NORMAL_STYLE),
-                Span::styled(app.format_address_full(&oe.intender), intender_style),
-            ]));
-            lines.push(Line::from(vec![
-                Span::raw("             "),
-                Span::styled(format!("{:#x}", oe.intender), intender_style),
-            ]));
-            lines.push(Line::from(vec![
-                Span::styled("   Caller:   ", theme::NORMAL_STYLE),
-                Span::raw(caller_str),
-            ]));
-            lines.push(Line::from(vec![
-                Span::styled("   Nonce:    ", theme::NORMAL_STYLE),
-                Span::styled(format!("{:#x}", oe.nonce), theme::TX_HASH_STYLE),
-            ]));
-            lines.push(Line::from(vec![
-                Span::styled("   Window:   ", theme::NORMAL_STYLE),
-                Span::raw(format!(
-                    "after: {}  before: {}",
-                    oe.execute_after, oe.execute_before
-                )),
-            ]));
-            lines.push(Line::from(""));
+        let remaining = app.tx_detail.decoded_calls.len().saturating_sub(preview_n);
+        if remaining > 0 {
             lines.push(Line::from(Span::styled(
-                format!("   Inner Calls ({})", oe.inner_calls.len()),
-                theme::TITLE_STYLE,
+                format!("    … and {remaining} more (Calls tab)"),
+                theme::SUGGESTION_STYLE,
             )));
-            for (ci, inner_call) in oe.inner_calls.iter().enumerate() {
-                let inner_name = inner_call.function_name.clone().unwrap_or_else(|| {
-                    let hex = format!("{:#x}", inner_call.selector);
-                    if hex.len() > 18 {
-                        format!("{}…", &hex[..18])
-                    } else {
-                        hex
-                    }
-                });
-                let inner_target = app.format_address(&inner_call.contract_address);
-                let inner_style = addr_style(&inner_call.contract_address, &color_map, selected);
-                record(
-                    &TxNavItem::Address(inner_call.contract_address),
-                    &lines,
-                    &mut line_map,
-                    &app.tx_detail.nav_items,
-                );
-                lines.push(Line::from(vec![
-                    addr_marker(&inner_call.contract_address, selected),
-                    Span::styled(format!("    {ci}: "), theme::NORMAL_STYLE),
-                    Span::styled(format!("{:<20}", inner_target), inner_style),
-                    Span::raw(" → "),
-                    Span::styled(inner_name, theme::TX_HASH_STYLE),
-                    Span::styled(
-                        format!(" ({} args)", inner_call.data.len()),
-                        theme::SUGGESTION_STYLE,
-                    ),
-                ]));
-                if app.tx_detail.show_decoded_calldata {
-                    render_decoded_calldata(inner_call, app, &color_map, selected, &mut lines);
-                } else if app.tx_detail.show_calldata {
-                    for (di, felt) in inner_call.data.iter().enumerate() {
-                        lines.push(Line::from(vec![
-                            Span::raw("          "),
-                            Span::styled(format!("[{di}] {:#x}", felt), theme::SUGGESTION_STYLE),
-                        ]));
-                    }
-                }
-            }
         }
     }
 
@@ -562,27 +608,39 @@ fn draw_scrollable_detail(
         ))]));
     }
 
-    // === EVENTS ===
-    lines.push(Line::from(""));
-    let event_count = app.tx_detail.decoded_events.len();
-    lines.push(Line::from(Span::styled(
-        format!(" Events ({event_count})"),
-        theme::TITLE_STYLE,
-    )));
+    lines
+}
 
-    // Group events by contract
+/// Build the Events tab body: group decoded events by contract and render
+/// each event with its decoded params + USD pricing where applicable.
+fn build_events_lines(
+    app: &App,
+    color_map: &AddressColorMap,
+    selected: Option<&TxNavItem>,
+    line_map: &mut [Option<u16>],
+) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let registry = app.search_engine.as_ref().map(|e| e.registry());
+
     let groups = crate::decode::events::group_events_by_contract(&app.tx_detail.decoded_events);
+    if groups.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "   (no events)",
+            theme::SUGGESTION_STYLE,
+        )));
+        return lines;
+    }
     for (gi, group) in groups.iter().enumerate() {
         let is_last_group = gi == groups.len() - 1;
         let branch = if is_last_group { "└─" } else { "├─" };
         let continuation = if is_last_group { "   " } else { "│  " };
 
-        let contract_label = app.format_address_full(&group.contract_address);
-        let contract_style = addr_style(&group.contract_address, &color_map, selected);
+        let contract_label = fmt_addr_full(app, &group.contract_address);
+        let contract_style = addr_style(&group.contract_address, color_map, selected);
         record(
             &TxNavItem::Address(group.contract_address),
-            &lines,
-            &mut line_map,
+            lines.len(),
+            line_map,
             &app.tx_detail.nav_items,
         );
         lines.push(Line::from(vec![
@@ -595,100 +653,565 @@ fn draw_scrollable_detail(
             ),
         ]));
 
-        // One price lookup per event contract — params share the same address.
         let event_prices =
             price::token_prices(app, &group.contract_address, app.tx_detail.block_timestamp);
 
         for (ei, event) in group.events.iter().enumerate() {
             let is_last = ei == group.events.len() - 1;
             let eb = if is_last { "└─" } else { "├─" };
-            let name = event.event_name.as_deref().unwrap_or("Unknown");
+            push_event_line(
+                event,
+                &format!(" {continuation}{eb} "),
+                event_prices,
+                app,
+                color_map,
+                registry,
+                selected,
+                line_map,
+                &app.tx_detail.nav_items,
+                &mut lines,
+            );
+        }
+    }
+    lines
+}
 
-            let all_params: Vec<&DecodedParam> = event
-                .decoded_keys
-                .iter()
-                .chain(event.decoded_data.iter())
-                .collect();
+/// Build the Calls tab body: full multicall list with c/d/o toggles, plus
+/// the Outside Execution Intent expansion when toggled on.
+fn build_calls_lines(
+    app: &App,
+    color_map: &AddressColorMap,
+    selected: Option<&TxNavItem>,
+    line_map: &mut [Option<u16>],
+) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
 
-            let mut event_spans: Vec<Span<'static>> = vec![Span::styled(
-                format!(" {continuation}{eb} "),
-                theme::BORDER_STYLE,
-            )];
+    if app.tx_detail.decoded_calls.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "   (no calls)",
+            theme::SUGGESTION_STYLE,
+        )));
+        return lines;
+    }
 
-            if all_params.is_empty() {
-                event_spans.push(Span::raw(name.to_string()));
+    let has_oe = !app.tx_detail.outside_executions.is_empty();
+    // `e` is a master switch: when on, it forces decoded calldata and
+    // outside-exec intent on regardless of `d`/`o`.
+    let effective_decoded = app.tx_detail.show_decoded_calldata || app.tx_detail.expand_all;
+    let effective_outside = app.tx_detail.show_outside_execution || app.tx_detail.expand_all;
+    let oe_hint = if has_oe {
+        if effective_outside {
+            " [o: hide intent]"
+        } else {
+            " [o: intent]"
+        }
+    } else {
+        ""
+    };
+    let expand_hint = if app.tx_detail.expand_all {
+        " [e: collapse]"
+    } else {
+        " [e: expand]"
+    };
+    let calldata_hint = if effective_decoded {
+        format!(" [d: hide decoded] [c: raw]{oe_hint}{expand_hint}")
+    } else if app.tx_detail.show_calldata {
+        format!(" [c: hide calldata] [d: decode]{oe_hint}{expand_hint}")
+    } else {
+        format!(" [c: raw calldata] [d: decode]{oe_hint}{expand_hint}")
+    };
+    lines.push(Line::from(vec![
+        Span::styled(
+            format!(" Calls ({})", app.tx_detail.decoded_calls.len()),
+            theme::TITLE_STYLE,
+        ),
+        Span::styled(calldata_hint, theme::SUGGESTION_STYLE),
+    ]));
+
+    for (i, call) in app.tx_detail.decoded_calls.iter().enumerate() {
+        let display_name = call.function_name.clone().unwrap_or_else(|| {
+            let hex = format!("{:#x}", call.selector);
+            if !app.tx_detail.expand_all && hex.len() > 18 {
+                format!("{}…", &hex[..18])
             } else {
-                event_spans.push(Span::raw(format!("{name}(")));
-                for (pi, p) in all_params.iter().enumerate() {
-                    // Record address-typed params before the event line is pushed.
-                    if p.type_name
-                        .as_deref()
-                        .unwrap_or("")
-                        .contains("ContractAddress")
-                    {
-                        record(
-                            &TxNavItem::Address(p.value),
-                            &lines,
-                            &mut line_map,
-                            &app.tx_detail.nav_items,
-                        );
-                    }
-                    let mut param_spans = param_display::format_param_styled(
-                        p,
-                        &event.contract_address,
-                        registry,
-                        &color_map,
-                        selected,
-                        &|a| app.format_address(a),
-                    );
-                    event_spans.append(&mut param_spans);
-                    let (today, historic) = event_prices;
-                    if (today.is_some() || historic.is_some())
-                        && let Some((amount, _)) =
-                            price::token_amount_from_param(p, &event.contract_address, registry)
-                    {
-                        event_spans.push(Span::styled(
-                            format_usd_pair(amount, today, historic),
-                            theme::SUGGESTION_STYLE,
-                        ));
-                    }
-                    if pi < all_params.len() - 1 {
-                        event_spans.push(Span::raw(", "));
-                    }
-                }
-                event_spans.push(Span::raw(")"));
+                hex
             }
-
-            lines.push(Line::from(event_spans));
+        });
+        let target = fmt_addr(app, &call.contract_address);
+        let contract_style = addr_style(&call.contract_address, color_map, selected);
+        record(
+            &TxNavItem::Address(call.contract_address),
+            lines.len(),
+            line_map,
+            &app.tx_detail.nav_items,
+        );
+        lines.push(Line::from(vec![
+            addr_marker(&call.contract_address, selected),
+            Span::styled(format!("  {i}: "), theme::NORMAL_STYLE),
+            Span::styled(format!("{:<20}", target), contract_style),
+            Span::raw(" → "),
+            Span::styled(display_name, theme::TX_HASH_STYLE),
+            Span::styled(
+                format!(" ({} args)", call.data.len()),
+                theme::SUGGESTION_STYLE,
+            ),
+        ]));
+        // Inline annotation for outside execution calls
+        if let Some((_, oe)) = app
+            .tx_detail
+            .outside_executions
+            .iter()
+            .find(|(idx, _)| *idx == i)
+        {
+            let caller_str = outside_execution::format_caller(&oe.caller);
+            lines.push(Line::from(vec![
+                Span::raw("        "),
+                Span::styled(
+                    format!("Outside Execution ({})", oe.version),
+                    theme::META_TX_STYLE,
+                ),
+                Span::styled(
+                    format!(
+                        "  nonce: {:#x}  caller: {}  inner calls: {}",
+                        oe.nonce,
+                        caller_str,
+                        oe.inner_calls.len()
+                    ),
+                    theme::SUGGESTION_STYLE,
+                ),
+            ]));
+        }
+        if effective_decoded {
+            render_decoded_calldata(call, app, color_map, selected, &mut lines);
+        } else if app.tx_detail.show_calldata {
+            for (di, felt) in call.data.iter().enumerate() {
+                lines.push(Line::from(vec![
+                    Span::raw("        "),
+                    Span::styled(format!("[{di}] {:#x}", felt), theme::SUGGESTION_STYLE),
+                ]));
+            }
         }
     }
 
-    if app.tx_detail.decoded_events.is_empty() {
-        lines.push(Line::from(Span::styled(
-            "   (no events)",
-            theme::SUGGESTION_STYLE,
-        )));
+    // === OUTSIDE EXECUTION INTENT (toggled with `o`, or forced by `e`) ===
+    if effective_outside && !app.tx_detail.outside_executions.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            Span::styled(" Outside Execution Intent", theme::TITLE_STYLE),
+            Span::styled(" [o: hide]", theme::SUGGESTION_STYLE),
+        ]));
+        for (_, oe) in &app.tx_detail.outside_executions {
+            let intender_style = addr_style(&oe.intender, color_map, selected);
+            let caller_str = outside_execution::format_caller(&oe.caller);
+            lines.push(Line::from(vec![
+                Span::styled("   Intender: ", theme::NORMAL_STYLE),
+                Span::styled(fmt_addr_full(app, &oe.intender), intender_style),
+            ]));
+            lines.push(Line::from(vec![
+                Span::raw("             "),
+                Span::styled(format!("{:#x}", oe.intender), intender_style),
+            ]));
+            lines.push(Line::from(vec![
+                Span::styled("   Caller:   ", theme::NORMAL_STYLE),
+                Span::raw(caller_str),
+            ]));
+            lines.push(Line::from(vec![
+                Span::styled("   Nonce:    ", theme::NORMAL_STYLE),
+                Span::styled(format!("{:#x}", oe.nonce), theme::TX_HASH_STYLE),
+            ]));
+            lines.push(Line::from(vec![
+                Span::styled("   Window:   ", theme::NORMAL_STYLE),
+                Span::raw(format!(
+                    "after: {}  before: {}",
+                    oe.execute_after, oe.execute_before
+                )),
+            ]));
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                format!("   Inner Calls ({})", oe.inner_calls.len()),
+                theme::TITLE_STYLE,
+            )));
+            for (ci, inner_call) in oe.inner_calls.iter().enumerate() {
+                let inner_name = inner_call.function_name.clone().unwrap_or_else(|| {
+                    let hex = format!("{:#x}", inner_call.selector);
+                    if !app.tx_detail.expand_all && hex.len() > 18 {
+                        format!("{}…", &hex[..18])
+                    } else {
+                        hex
+                    }
+                });
+                let inner_target = fmt_addr(app, &inner_call.contract_address);
+                let inner_style = addr_style(&inner_call.contract_address, color_map, selected);
+                record(
+                    &TxNavItem::Address(inner_call.contract_address),
+                    lines.len(),
+                    line_map,
+                    &app.tx_detail.nav_items,
+                );
+                lines.push(Line::from(vec![
+                    addr_marker(&inner_call.contract_address, selected),
+                    Span::styled(format!("    {ci}: "), theme::NORMAL_STYLE),
+                    Span::styled(format!("{:<20}", inner_target), inner_style),
+                    Span::raw(" → "),
+                    Span::styled(inner_name, theme::TX_HASH_STYLE),
+                    Span::styled(
+                        format!(" ({} args)", inner_call.data.len()),
+                        theme::SUGGESTION_STYLE,
+                    ),
+                ]));
+                if effective_decoded {
+                    render_decoded_calldata(inner_call, app, color_map, selected, &mut lines);
+                } else if app.tx_detail.show_calldata {
+                    for (di, felt) in inner_call.data.iter().enumerate() {
+                        lines.push(Line::from(vec![
+                            Span::raw("          "),
+                            Span::styled(format!("[{di}] {:#x}", felt), theme::SUGGESTION_STYLE),
+                        ]));
+                    }
+                }
+            }
+        }
     }
 
-    // Render as scrollable paragraph
-    let title = if app.tx_detail.visual_mode {
-        " Transaction Detail [VISUAL] (j/k: cycle · Enter: open · Esc: exit) "
-    } else {
-        " Transaction Detail (j/k: scroll · v: visual · c: calldata) "
+    lines
+}
+
+/// Build the Trace tab body: recursive call tree with ABI-decoded function
+/// names, decoded params (incl. token amounts + USD), per-node events, and
+/// raw result felts.
+fn build_trace_lines(
+    app: &App,
+    color_map: &AddressColorMap,
+    selected: Option<&TxNavItem>,
+    line_map: &mut [Option<u16>],
+) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let registry = app.search_engine.as_ref().map(|e| e.registry());
+
+    let trace = match &app.tx_detail.trace {
+        Some(t) => t,
+        None => {
+            let msg = if app.tx_detail.trace_loading {
+                "   (trace loading…)"
+            } else {
+                "   (trace unavailable)"
+            };
+            lines.push(Line::from(Span::styled(msg, theme::SUGGESTION_STYLE)));
+            return lines;
+        }
     };
-    let widget = Paragraph::new(lines)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(theme::BORDER_FOCUSED_STYLE)
-                .title(Span::styled(title, theme::TITLE_STYLE)),
-        )
-        .wrap(Wrap { trim: false })
-        .scroll((app.tx_detail.scroll, 0));
+    if let Some(reason) = &trace.revert_reason {
+        lines.push(Line::from(vec![
+            Span::styled(" Revert: ", theme::STATUS_ERROR),
+            Span::raw(reason.clone()),
+        ]));
+        lines.push(Line::from(""));
+    }
 
-    f.render_widget(widget, area);
+    let roots = trace.roots();
+    if roots.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "   (no invocations)",
+            theme::SUGGESTION_STYLE,
+        )));
+        return lines;
+    }
+    for (label, root) in roots {
+        lines.push(Line::from(Span::styled(
+            format!(" {label}"),
+            theme::TITLE_STYLE,
+        )));
+        render_trace_call(
+            root,
+            "",
+            true,
+            app,
+            color_map,
+            registry,
+            selected,
+            line_map,
+            &app.tx_detail.nav_items,
+            &mut lines,
+        );
+        lines.push(Line::from(""));
+    }
+    lines
+}
 
-    line_map.into_iter().map(|o| o.unwrap_or(0)).collect()
+/// Render a single trace node and its descendants.
+#[allow(clippy::too_many_arguments)]
+fn render_trace_call(
+    call: &DecodedTraceCall,
+    prefix: &str,
+    is_last: bool,
+    app: &App,
+    color_map: &AddressColorMap,
+    registry: Option<&crate::registry::AddressRegistry>,
+    selected: Option<&TxNavItem>,
+    line_map: &mut [Option<u16>],
+    nav_items: &[TxNavItem],
+    lines: &mut Vec<Line<'static>>,
+) {
+    let branch = if is_last { "└─" } else { "├─" };
+    let next_prefix = format!("{prefix}{}", if is_last { "   " } else { "│  " });
+    // Body lines (fn / → / events) get a leading space so they line up under
+    // the header's content column — the header reserves column 1 for the
+    // visual-mode marker (`►` or space), and body lines match that offset.
+    let body_prefix = format!(" {next_prefix}");
+
+    // Header line: branch + contract label + optional kind tag (only when
+    // non-default; the default CALL/EXTERNAL combo is just visual noise).
+    let label = fmt_addr_full(app, &call.contract_address);
+    let style = addr_style(&call.contract_address, color_map, selected);
+    record(
+        &TxNavItem::Address(call.contract_address),
+        lines.len(),
+        line_map,
+        nav_items,
+    );
+    let mut spans: Vec<Span<'static>> = vec![
+        addr_marker(&call.contract_address, selected),
+        Span::styled(format!("{prefix}{branch} "), theme::BORDER_STYLE),
+        Span::styled(label, style),
+    ];
+    if let Some(kind) = call_kind_tag(call.call_type, call.entry_point_type) {
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(kind, theme::SUGGESTION_STYLE));
+    }
+    if call.is_reverted {
+        spans.push(Span::styled("  REVERTED", theme::STATUS_REVERTED));
+    }
+    lines.push(Line::from(spans));
+
+    // Function call line: fn_name(decoded args)
+    let fn_label = call.function_name.clone().unwrap_or_else(|| {
+        let hex = format!("{:#x}", call.entry_point_selector);
+        if !app.tx_detail.expand_all && hex.len() > 18 {
+            format!("{}…", &hex[..18])
+        } else {
+            hex
+        }
+    });
+    let mut fn_spans: Vec<Span<'static>> = vec![
+        Span::styled(format!("{body_prefix}fn "), theme::BORDER_STYLE),
+        Span::styled(fn_label, theme::TX_HASH_STYLE),
+    ];
+    if let (Some(func_def), Some(abi)) = (&call.function_def, &call.contract_abi) {
+        let decoded = calldata::decode_calldata(&call.calldata, &func_def.inputs, abi);
+        let prices =
+            price::token_prices(app, &call.contract_address, app.tx_detail.block_timestamp);
+        fn_spans.push(Span::raw("("));
+        for (pi, p) in decoded.iter().enumerate() {
+            if pi > 0 {
+                fn_spans.push(Span::raw(", "));
+            }
+            if let Some(name) = &p.name {
+                fn_spans.push(Span::styled(format!("{name}: "), theme::SUGGESTION_STYLE));
+            }
+            render_value_spans(&p.value, app, color_map, selected, &mut fn_spans);
+            // USD pair if param matches a tracked token's u256 amount.
+            if let Some((amount, _)) =
+                decoded_value_token_amount(&p.value, &call.contract_address, registry)
+                && (prices.0.is_some() || prices.1.is_some())
+            {
+                fn_spans.push(Span::styled(
+                    format_usd_pair(amount, prices.0, prices.1),
+                    theme::SUGGESTION_STYLE,
+                ));
+            }
+        }
+        fn_spans.push(Span::raw(")"));
+    } else {
+        fn_spans.push(Span::styled(
+            format!("({} felts)", call.calldata.len()),
+            theme::SUGGESTION_STYLE,
+        ));
+    }
+    lines.push(Line::from(fn_spans));
+
+    // Result line(s): raw felts (return-value decoding is a follow-up).
+    if !call.result.is_empty() {
+        let limit = if app.tx_detail.expand_all {
+            call.result.len()
+        } else {
+            4
+        };
+        let preview: Vec<String> = call
+            .result
+            .iter()
+            .take(limit)
+            .map(|f| format!("{:#x}", f))
+            .collect();
+        let extra = call.result.len().saturating_sub(preview.len());
+        let suffix = if extra > 0 {
+            format!(", … +{extra}")
+        } else {
+            String::new()
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!("{body_prefix}→ "), theme::BORDER_STYLE),
+            Span::styled(
+                format!("[{}]{suffix}", preview.join(", ")),
+                theme::SUGGESTION_STYLE,
+            ),
+        ]));
+    }
+
+    // Events + inner calls share the same child-list under this node, so
+    // their tree branches share a column. Treat them as one combined list
+    // when picking ├─ vs └─ so only the very last entry gets └─.
+    let prices = price::token_prices(app, &call.contract_address, app.tx_detail.block_timestamp);
+    let total_children = call.events.len() + call.inner.len();
+    let mut child_idx = 0usize;
+    for event in call.events.iter() {
+        let is_last_child = child_idx == total_children - 1;
+        let eb = if is_last_child { "└─" } else { "├─" };
+        push_event_line(
+            event,
+            &format!("{body_prefix}{eb} "),
+            prices,
+            app,
+            color_map,
+            registry,
+            selected,
+            line_map,
+            nav_items,
+            lines,
+        );
+        child_idx += 1;
+    }
+
+    for child in call.inner.iter() {
+        let is_last_child = child_idx == total_children - 1;
+        render_trace_call(
+            child,
+            &next_prefix,
+            is_last_child,
+            app,
+            color_map,
+            registry,
+            selected,
+            line_map,
+            nav_items,
+            lines,
+        );
+        child_idx += 1;
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn push_event_line(
+    event: &DecodedEvent,
+    prefix: &str,
+    prices: (Option<f64>, Option<f64>),
+    app: &App,
+    color_map: &AddressColorMap,
+    registry: Option<&crate::registry::AddressRegistry>,
+    selected: Option<&TxNavItem>,
+    line_map: &mut [Option<u16>],
+    nav_items: &[TxNavItem],
+    lines: &mut Vec<Line<'static>>,
+) {
+    let name = event.event_name.as_deref().unwrap_or("Unknown");
+    let all_params: Vec<&DecodedParam> = event
+        .decoded_keys
+        .iter()
+        .chain(event.decoded_data.iter())
+        .collect();
+
+    let mut spans: Vec<Span<'static>> = vec![Span::styled(prefix.to_string(), theme::BORDER_STYLE)];
+
+    if all_params.is_empty() {
+        spans.push(Span::raw(name.to_string()));
+    } else {
+        spans.push(Span::raw(format!("{name}(")));
+        for (pi, p) in all_params.iter().enumerate() {
+            if p.type_name
+                .as_deref()
+                .unwrap_or("")
+                .contains("ContractAddress")
+            {
+                record(
+                    &TxNavItem::Address(p.value),
+                    lines.len(),
+                    line_map,
+                    nav_items,
+                );
+            }
+            let mut param_spans = param_display::format_param_styled(
+                p,
+                &event.contract_address,
+                registry,
+                color_map,
+                selected,
+                &|a| fmt_addr(app, a),
+                app.tx_detail.expand_all,
+            );
+            spans.append(&mut param_spans);
+            let (today, historic) = prices;
+            if (today.is_some() || historic.is_some())
+                && let Some((amount, _)) =
+                    price::token_amount_from_param(p, &event.contract_address, registry)
+            {
+                spans.push(Span::styled(
+                    format_usd_pair(amount, today, historic),
+                    theme::SUGGESTION_STYLE,
+                ));
+            }
+            if pi < all_params.len() - 1 {
+                spans.push(Span::raw(", "));
+            }
+        }
+        spans.push(Span::raw(")"));
+    }
+
+    lines.push(Line::from(spans));
+}
+
+/// Compact tag like "(LIBRARY_CALL)", "(CONSTRUCTOR)", or "(L1_HANDLER)".
+/// Returns None for the common case `(CALL, EXTERNAL)` so the trace stays
+/// uncluttered — that's the default for ~every node and adds no signal.
+fn call_kind_tag(c: CallType, t: EntryPointType) -> Option<String> {
+    match (c, t) {
+        (CallType::Call, EntryPointType::External) => None,
+        (CallType::Call, EntryPointType::L1Handler) => Some("(L1_HANDLER)".into()),
+        (CallType::Call, EntryPointType::Constructor) => Some("(CONSTRUCTOR)".into()),
+        (CallType::LibraryCall, EntryPointType::External) => Some("(LIBRARY_CALL)".into()),
+        (CallType::LibraryCall, t) => Some(format!("(LIBRARY_CALL {})", entry_type_str(t))),
+        (CallType::Delegate, t) => Some(format!("(DELEGATE {})", entry_type_str(t))),
+    }
+}
+
+fn entry_type_str(t: EntryPointType) -> &'static str {
+    match t {
+        EntryPointType::External => "EXTERNAL",
+        EntryPointType::L1Handler => "L1_HANDLER",
+        EntryPointType::Constructor => "CONSTRUCTOR",
+    }
+}
+
+/// If `value` is a u256 amount on a tracked token, return `(amount_f64, decimals)`.
+/// Mirrors `price::token_amount_from_param` but accepts a `DecodedValue` so the
+/// trace tab can use the same USD-pair formatting as events without needing to
+/// re-shape the trace's calldata as `DecodedParam`.
+fn decoded_value_token_amount(
+    value: &DecodedValue,
+    contract_address: &Felt,
+    registry: Option<&crate::registry::AddressRegistry>,
+) -> Option<(f64, u8)> {
+    // Re-pack a u256 DecodedValue into the (low, Some(high)) shape that the
+    // existing helper consumes (which expects Felt-encoded halves).
+    let (low, high) = match value {
+        DecodedValue::U256 { low, high } => (*low, *high),
+        _ => return None,
+    };
+    let synth = DecodedParam {
+        name: None,
+        type_name: Some("u256".into()),
+        value: Felt::from(low),
+        value_high: Some(Felt::from(high)),
+    };
+    price::token_amount_from_param(&synth, contract_address, registry)
 }
 
 /// Returns the style to use for an address span, applying visual-mode highlight when selected.
@@ -835,9 +1358,10 @@ fn render_value_spans(
     selected: Option<&TxNavItem>,
     spans: &mut Vec<Span<'static>>,
 ) {
+    let expand = app.tx_detail.expand_all;
     match value {
         DecodedValue::Address(felt) => {
-            let label = app.format_address(felt);
+            let label = fmt_addr(app, felt);
             let style = if matches!(selected, Some(TxNavItem::Address(a)) if *a == *felt) {
                 theme::VISUAL_SELECTED_STYLE
             } else {
@@ -846,7 +1370,7 @@ fn render_value_spans(
             spans.push(Span::styled(label, style));
         }
         DecodedValue::String(s) => {
-            let display = if s.len() > 60 {
+            let display = if !expand && s.len() > 60 {
                 format!("\"{}...\"", &s[..57])
             } else {
                 format!("\"{s}\"")
@@ -858,10 +1382,22 @@ fn render_value_spans(
         }
         DecodedValue::Struct { name, fields } => {
             let short = name.rsplit("::").next().unwrap_or(name);
-            spans.push(Span::styled(
-                format!("{short} {{ {} fields }}", fields.len()),
-                theme::TX_HASH_STYLE,
-            ));
+            if expand {
+                spans.push(Span::styled(format!("{short} {{ "), theme::TX_HASH_STYLE));
+                for (i, (fname, fval)) in fields.iter().enumerate() {
+                    if i > 0 {
+                        spans.push(Span::raw(", "));
+                    }
+                    spans.push(Span::styled(format!("{fname}: "), theme::SUGGESTION_STYLE));
+                    render_value_spans(fval, app, color_map, selected, spans);
+                }
+                spans.push(Span::styled(" }", theme::TX_HASH_STYLE));
+            } else {
+                spans.push(Span::styled(
+                    format!("{short} {{ {} fields }}", fields.len()),
+                    theme::TX_HASH_STYLE,
+                ));
+            }
         }
         DecodedValue::Enum {
             name,
@@ -869,23 +1405,57 @@ fn render_value_spans(
             value: inner,
         } => {
             let short = name.rsplit("::").next().unwrap_or(name);
-            let suffix = if inner.is_some() { "(...)" } else { "" };
-            spans.push(Span::styled(
-                format!("{short}::{variant}{suffix}"),
-                theme::TX_HASH_STYLE,
-            ));
+            if expand {
+                spans.push(Span::styled(
+                    format!("{short}::{variant}"),
+                    theme::TX_HASH_STYLE,
+                ));
+                if let Some(inner) = inner {
+                    spans.push(Span::raw("("));
+                    render_value_spans(inner, app, color_map, selected, spans);
+                    spans.push(Span::raw(")"));
+                }
+            } else {
+                let suffix = if inner.is_some() { "(...)" } else { "" };
+                spans.push(Span::styled(
+                    format!("{short}::{variant}{suffix}"),
+                    theme::TX_HASH_STYLE,
+                ));
+            }
         }
         DecodedValue::Array(items) => {
-            spans.push(Span::styled(
-                format!("[{} items]", items.len()),
-                theme::TX_HASH_STYLE,
-            ));
+            if expand {
+                spans.push(Span::styled("[", theme::TX_HASH_STYLE));
+                for (i, item) in items.iter().enumerate() {
+                    if i > 0 {
+                        spans.push(Span::raw(", "));
+                    }
+                    render_value_spans(item, app, color_map, selected, spans);
+                }
+                spans.push(Span::styled("]", theme::TX_HASH_STYLE));
+            } else {
+                spans.push(Span::styled(
+                    format!("[{} items]", items.len()),
+                    theme::TX_HASH_STYLE,
+                ));
+            }
         }
         DecodedValue::Tuple(items) => {
-            spans.push(Span::styled(
-                format!("({} items)", items.len()),
-                theme::TX_HASH_STYLE,
-            ));
+            if expand {
+                spans.push(Span::styled("(", theme::TX_HASH_STYLE));
+                for (i, item) in items.iter().enumerate() {
+                    if i > 0 {
+                        spans.push(Span::raw(", "));
+                    }
+                    render_value_spans(item, app, color_map, selected, spans);
+                }
+                spans.push(Span::styled(")", theme::TX_HASH_STYLE));
+            } else {
+                spans.push(Span::styled(
+                    format!("({} items)", items.len()),
+                    theme::TX_HASH_STYLE,
+                ));
+            }
         }
         // Simple values: use Display
         other => {

--- a/src/ui/views/tx_detail.rs
+++ b/src/ui/views/tx_detail.rs
@@ -221,6 +221,41 @@ fn fmt_addr_full(app: &App, felt: &Felt) -> String {
     }
 }
 
+/// Render a revert reason. By default we collapse to a single ellipsised
+/// preview so the fixed-height header doesn't get pushed off-screen by a
+/// wrapped multi-line cairo panic. With `expand` on, we split on `\n` and
+/// push each segment as its own line so the header layout still accounts
+/// for the row count.
+fn push_revert_lines(reason: &str, expand: bool, lines: &mut Vec<Line<'static>>) {
+    /// Single-line ellipsis cutoff. Picked to leave room for terminal padding
+    /// and the " Revert: " label on a typical 120-col terminal.
+    const REVERT_PREVIEW_CHARS: usize = 100;
+
+    if expand {
+        let segments: Vec<&str> = reason.split('\n').collect();
+        for (i, seg) in segments.iter().enumerate() {
+            let prefix = if i == 0 { " Revert: " } else { "         " };
+            lines.push(Line::from(vec![
+                Span::styled(prefix, theme::STATUS_ERROR),
+                Span::raw(seg.to_string()),
+            ]));
+        }
+        return;
+    }
+
+    let single_line = reason.replace('\n', " ");
+    let display = if single_line.chars().count() > REVERT_PREVIEW_CHARS {
+        let truncated: String = single_line.chars().take(REVERT_PREVIEW_CHARS).collect();
+        format!("{truncated}… (e: full)")
+    } else {
+        single_line
+    };
+    lines.push(Line::from(vec![
+        Span::styled(" Revert: ", theme::STATUS_ERROR),
+        Span::raw(display),
+    ]));
+}
+
 /// Record `item`'s first-occurrence line position into `map` (if not already set).
 fn record(item: &TxNavItem, cur_line: usize, map: &mut [Option<u16>], nav: &[TxNavItem]) {
     if let Some(idx) = nav.iter().position(|x| x == item) {
@@ -427,10 +462,7 @@ fn build_header_lines(
             Span::styled(status_text, style),
         ]));
         if let ExecutionStatus::Reverted(reason) = &receipt.execution_status {
-            lines.push(Line::from(vec![
-                Span::styled(" Revert: ", theme::STATUS_ERROR),
-                Span::raw(reason.clone()),
-            ]));
+            push_revert_lines(reason, app.tx_detail.expand_all, &mut lines);
         }
     }
 
@@ -901,10 +933,7 @@ fn build_trace_lines(
         }
     };
     if let Some(reason) = &trace.revert_reason {
-        lines.push(Line::from(vec![
-            Span::styled(" Revert: ", theme::STATUS_ERROR),
-            Span::raw(reason.clone()),
-        ]));
+        push_revert_lines(reason, app.tx_detail.expand_all, &mut lines);
         lines.push(Line::from(""));
     }
 

--- a/src/ui/views/tx_detail.rs
+++ b/src/ui/views/tx_detail.rs
@@ -7,7 +7,7 @@ use starknet::core::types::{CallType, EntryPointType, Felt};
 
 use crate::app::App;
 use crate::app::state::TxNavItem;
-use crate::app::views::tx_detail::TxTab;
+use crate::app::views::tx_detail::{NavSection, TxTab};
 use crate::data::types::{ExecutionStatus, SnTransaction};
 use crate::decode::calldata::{self, DecodedValue};
 use crate::decode::events::{DecodedEvent, DecodedParam};
@@ -54,14 +54,37 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     let color_map = build_color_map(app);
     let mut line_map: Vec<Option<u16>> = vec![None; app.tx_detail.nav_items.len()];
 
-    // Build line buffers for header + every tab body up front. Header always
-    // renders; bodies are computed for all three tabs every frame so visual-mode
-    // tab-switches see up-to-date line offsets for the destination tab — without
-    // this, the first `j` after a tab switch would scroll to a stale offset.
+    // Header always renders, so it's always rebuilt. Tab bodies are computed
+    // for all three tabs only in visual mode — that's when cross-tab cursor
+    // navigation needs up-to-date line offsets for every tab. Outside visual
+    // mode only the active tab is visible, so we skip building the others to
+    // avoid recomputing large traces on every frame.
     let header_lines = build_header_lines(app, &color_map, selected.as_ref(), &mut line_map);
-    let events_lines = build_events_lines(app, &color_map, selected.as_ref(), &mut line_map);
-    let calls_lines = build_calls_lines(app, &color_map, selected.as_ref(), &mut line_map);
-    let trace_lines = build_trace_lines(app, &color_map, selected.as_ref(), &mut line_map);
+    let (events_lines, calls_lines, trace_lines) = if app.tx_detail.visual_mode {
+        (
+            build_events_lines(app, &color_map, selected.as_ref(), &mut line_map),
+            build_calls_lines(app, &color_map, selected.as_ref(), &mut line_map),
+            build_trace_lines(app, &color_map, selected.as_ref(), &mut line_map),
+        )
+    } else {
+        match app.tx_detail.active_tab {
+            TxTab::Events => (
+                build_events_lines(app, &color_map, selected.as_ref(), &mut line_map),
+                Vec::new(),
+                Vec::new(),
+            ),
+            TxTab::Calls => (
+                Vec::new(),
+                build_calls_lines(app, &color_map, selected.as_ref(), &mut line_map),
+                Vec::new(),
+            ),
+            TxTab::Trace => (
+                Vec::new(),
+                Vec::new(),
+                build_trace_lines(app, &color_map, selected.as_ref(), &mut line_map),
+            ),
+        }
+    };
 
     let header_height = (header_lines.len() as u16).saturating_add(2); // borders
     // Header is fixed-content; clamp to ~60% of screen so tab body always
@@ -108,11 +131,7 @@ fn draw_tabs_bar(f: &mut Frame, app: &App, area: Rect) {
         .tx_detail
         .trace
         .as_ref()
-        .map(|t| {
-            let mut n = 0usize;
-            t.for_each_call(|_| n += 1);
-            n
-        })
+        .map(|t| t.total_nodes)
         .unwrap_or(0);
     let trace_label = if app.tx_detail.trace.is_some() {
         format!("Trace ({trace_count})")
@@ -256,9 +275,23 @@ fn push_revert_lines(reason: &str, expand: bool, lines: &mut Vec<Line<'static>>)
     ]));
 }
 
-/// Record `item`'s first-occurrence line position into `map` (if not already set).
-fn record(item: &TxNavItem, cur_line: usize, map: &mut [Option<u16>], nav: &[TxNavItem]) {
-    if let Some(idx) = nav.iter().position(|x| x == item) {
+/// Record `item`'s first-occurrence line position into `map`, but only when
+/// the item belongs to `section`. The caller passes the section currently
+/// being rendered; items rendered as part of another section's pre-rollup
+/// (e.g. a call-target shown in the header's top-level Calls preview but
+/// owned by `NavSection::Calls`) are skipped here so the per-tab line index
+/// isn't clobbered by a header line position.
+fn record(
+    item: &TxNavItem,
+    cur_line: usize,
+    map: &mut [Option<u16>],
+    nav: &[TxNavItem],
+    sections: &[NavSection],
+    section: NavSection,
+) {
+    if let Some(idx) = nav.iter().position(|x| x == item)
+        && sections.get(idx).copied() == Some(section)
+    {
         map[idx].get_or_insert(cur_line as u16);
     }
 }
@@ -329,6 +362,8 @@ fn build_header_lines(
         lines.len(),
         line_map,
         &app.tx_detail.nav_items,
+        &app.tx_detail.nav_sections,
+        NavSection::Header,
     );
     lines.push(Line::from(vec![
         block_marker(blk_num, selected),
@@ -362,6 +397,8 @@ fn build_header_lines(
                 lines.len(),
                 line_map,
                 &app.tx_detail.nav_items,
+                &app.tx_detail.nav_sections,
+                NavSection::Header,
             );
             lines.push(Line::from(vec![
                 addr_marker(&oe.intender, selected),
@@ -396,6 +433,8 @@ fn build_header_lines(
         lines.len(),
         line_map,
         &app.tx_detail.nav_items,
+        &app.tx_detail.nav_sections,
+        NavSection::Header,
     );
     lines.push(Line::from(vec![
         addr_marker(&sender, selected),
@@ -416,7 +455,14 @@ fn build_header_lines(
         } else {
             theme::TX_HASH_STYLE
         };
-        record(&ch_item, lines.len(), line_map, &app.tx_detail.nav_items);
+        record(
+            &ch_item,
+            lines.len(),
+            line_map,
+            &app.tx_detail.nav_items,
+            &app.tx_detail.nav_sections,
+            NavSection::Header,
+        );
         let ch_marker = if selected == Some(&ch_item) {
             Span::styled("►", theme::VISUAL_SELECTED_STYLE)
         } else {
@@ -437,7 +483,14 @@ fn build_header_lines(
         } else {
             theme::TX_HASH_STYLE
         };
-        record(&ch_item, lines.len(), line_map, &app.tx_detail.nav_items);
+        record(
+            &ch_item,
+            lines.len(),
+            line_map,
+            &app.tx_detail.nav_items,
+            &app.tx_detail.nav_sections,
+            NavSection::Header,
+        );
         let ch_marker = if selected == Some(&ch_item) {
             Span::styled("►", theme::VISUAL_SELECTED_STYLE)
         } else {
@@ -482,6 +535,8 @@ fn build_header_lines(
                 lines.len(),
                 line_map,
                 &app.tx_detail.nav_items,
+                &app.tx_detail.nav_sections,
+                NavSection::Header,
             );
             lines.push(Line::from(vec![
                 addr_marker(addr, selected),
@@ -527,6 +582,8 @@ fn build_header_lines(
                 lines.len(),
                 line_map,
                 &app.tx_detail.nav_items,
+                &app.tx_detail.nav_sections,
+                NavSection::Header,
             );
             lines.push(Line::from(vec![
                 addr_marker(&call.contract_address, selected),
@@ -674,6 +731,8 @@ fn build_events_lines(
             lines.len(),
             line_map,
             &app.tx_detail.nav_items,
+            &app.tx_detail.nav_sections,
+            NavSection::Events,
         );
         lines.push(Line::from(vec![
             addr_marker(&group.contract_address, selected),
@@ -701,6 +760,8 @@ fn build_events_lines(
                 selected,
                 line_map,
                 &app.tx_detail.nav_items,
+                &app.tx_detail.nav_sections,
+                NavSection::Events,
                 &mut lines,
             );
         }
@@ -776,6 +837,8 @@ fn build_calls_lines(
             lines.len(),
             line_map,
             &app.tx_detail.nav_items,
+            &app.tx_detail.nav_sections,
+            NavSection::Calls,
         );
         lines.push(Line::from(vec![
             addr_marker(&call.contract_address, selected),
@@ -879,6 +942,8 @@ fn build_calls_lines(
                     lines.len(),
                     line_map,
                     &app.tx_detail.nav_items,
+                    &app.tx_detail.nav_sections,
+                    NavSection::Calls,
                 );
                 lines.push(Line::from(vec![
                     addr_marker(&inner_call.contract_address, selected),
@@ -960,6 +1025,7 @@ fn build_trace_lines(
             selected,
             line_map,
             &app.tx_detail.nav_items,
+            &app.tx_detail.nav_sections,
             &mut lines,
         );
         lines.push(Line::from(""));
@@ -979,6 +1045,7 @@ fn render_trace_call(
     selected: Option<&TxNavItem>,
     line_map: &mut [Option<u16>],
     nav_items: &[TxNavItem],
+    nav_sections: &[NavSection],
     lines: &mut Vec<Line<'static>>,
 ) {
     let branch = if is_last { "└─" } else { "├─" };
@@ -997,6 +1064,8 @@ fn render_trace_call(
         lines.len(),
         line_map,
         nav_items,
+        nav_sections,
+        NavSection::Trace,
     );
     let mut spans: Vec<Span<'static>> = vec![
         addr_marker(&call.contract_address, selected),
@@ -1105,6 +1174,8 @@ fn render_trace_call(
             selected,
             line_map,
             nav_items,
+            nav_sections,
+            NavSection::Trace,
             lines,
         );
         child_idx += 1;
@@ -1122,6 +1193,7 @@ fn render_trace_call(
             selected,
             line_map,
             nav_items,
+            nav_sections,
             lines,
         );
         child_idx += 1;
@@ -1139,6 +1211,8 @@ fn push_event_line(
     selected: Option<&TxNavItem>,
     line_map: &mut [Option<u16>],
     nav_items: &[TxNavItem],
+    nav_sections: &[NavSection],
+    section: NavSection,
     lines: &mut Vec<Line<'static>>,
 ) {
     let name = event.event_name.as_deref().unwrap_or("Unknown");
@@ -1165,6 +1239,8 @@ fn push_event_line(
                     lines.len(),
                     line_map,
                     nav_items,
+                    nav_sections,
+                    section,
                 );
             }
             let mut param_spans = param_display::format_param_styled(

--- a/src/ui/widgets/event_tree.rs
+++ b/src/ui/widgets/event_tree.rs
@@ -87,6 +87,7 @@ fn format_event(event: &DecodedEvent, app: &App) -> String {
             &event.contract_address,
             registry,
             &format_addr,
+            false,
         ));
     }
     for p in &event.decoded_data {
@@ -95,6 +96,7 @@ fn format_event(event: &DecodedEvent, app: &App) -> String {
             &event.contract_address,
             registry,
             &format_addr,
+            false,
         ));
     }
 

--- a/src/ui/widgets/param_display.rs
+++ b/src/ui/widgets/param_display.rs
@@ -17,8 +17,9 @@ pub fn format_param(
     contract_address: &Felt,
     registry: Option<&AddressRegistry>,
     format_addr: &dyn Fn(&Felt) -> String,
+    expand: bool,
 ) -> String {
-    let value_str = format_param_value(p, contract_address, registry, format_addr);
+    let value_str = format_param_value(p, contract_address, registry, format_addr, expand);
     match &p.name {
         Some(name) => format!("{name}: {value_str}"),
         None => value_str,
@@ -36,6 +37,7 @@ pub fn format_param_styled(
     color_map: &AddressColorMap,
     selected: Option<&TxNavItem>,
     format_addr: &dyn Fn(&Felt) -> String,
+    expand: bool,
 ) -> Vec<Span<'static>> {
     let type_name = p.type_name.as_deref().unwrap_or("");
     let name_prefix = p
@@ -62,7 +64,7 @@ pub fn format_param_styled(
     }
 
     // All other types: compute the string value and return unstyled
-    let value_str = format_param_value(p, contract_address, registry, format_addr);
+    let value_str = format_param_value(p, contract_address, registry, format_addr, expand);
     vec![Span::raw(format!("{name_prefix}{value_str}"))]
 }
 
@@ -71,6 +73,7 @@ fn format_param_value(
     contract_address: &Felt,
     registry: Option<&AddressRegistry>,
     format_addr: &dyn Fn(&Felt) -> String,
+    expand: bool,
 ) -> String {
     let type_name = p.type_name.as_deref().unwrap_or("");
 
@@ -101,7 +104,11 @@ fn format_param_value(
         }
     }
 
-    format_felt_short(&p.value)
+    if expand {
+        format!("{:#x}", p.value)
+    } else {
+        format_felt_short(&p.value)
+    }
 }
 
 /// Format a u256 value as a human-readable token amount with the given decimals.

--- a/tests/cache_pool_bench_test.rs
+++ b/tests/cache_pool_bench_test.rs
@@ -38,7 +38,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use starknet::core::types::{ContractClass, Felt};
+use starknet::core::types::{ContractClass, Felt, TransactionTrace};
 use tokio::sync::Notify;
 
 use snbeat::data::cache::CachingDataSource;
@@ -85,6 +85,9 @@ impl DataSource for NullUpstream {
         unimplemented!()
     }
     async fn get_class(&self, _class_hash: Felt) -> Result<ContractClass> {
+        unimplemented!()
+    }
+    async fn get_trace(&self, _hash: Felt) -> Result<TransactionTrace> {
         unimplemented!()
     }
     async fn get_recent_blocks(&self, _count: usize) -> Result<Vec<SnBlock>> {

--- a/tests/rpc_test.rs
+++ b/tests/rpc_test.rs
@@ -117,3 +117,46 @@ async fn test_balance_of_call() {
     );
     println!("Sequencer ETH balance (raw): {:#x}", result[0]);
 }
+
+#[tokio::test]
+#[ignore = "requires APP_RPC_URL"]
+async fn test_trace_transaction_decode() {
+    use snbeat::data::DataSource;
+    use snbeat::data::rpc::RpcDataSource;
+    use snbeat::decode::AbiRegistry;
+    use snbeat::decode::class_cache::ClassCache;
+    use std::sync::Arc;
+
+    dotenvy::dotenv().ok();
+    let rpc_url = std::env::var("APP_RPC_URL").expect("APP_RPC_URL");
+
+    // Reference tx from issue #29.
+    let hash = Felt::from_hex("0x3175dc5e465e3cd02a144a29e287031f6cbf477a4c009ad171efdef55a5250f")
+        .unwrap();
+
+    let ds: Arc<dyn DataSource> = Arc::new(RpcDataSource::new(&rpc_url));
+    let trace = ds.get_trace(hash).await.expect("get_trace failed");
+
+    // In-memory ABI cache (no SQLite needed for this smoke test).
+    let conn = rusqlite::Connection::open_in_memory().expect("open in-memory sqlite");
+    let class_cache = ClassCache::new(conn, 256);
+    let abi_reg = Arc::new(AbiRegistry::new(Arc::clone(&ds), class_cache));
+
+    let receipt = ds.get_receipt(hash).await.expect("receipt failed");
+    let block = receipt.block_number;
+    let decoded = snbeat::decode::trace::decode_trace(&trace, hash, block, &abi_reg).await;
+
+    let mut total = 0usize;
+    decoded.for_each_call(|_| total += 1);
+    assert!(total >= 5, "expected ≥5 nodes in trace tree, got {total}");
+    assert!(
+        decoded.execute.is_some(),
+        "INVOKE tx should have an execute root"
+    );
+    println!(
+        "Decoded trace: {total} total nodes, validate={}, execute={}, fee_transfer={}",
+        decoded.validate.is_some(),
+        decoded.execute.is_some(),
+        decoded.fee_transfer.is_some()
+    );
+}


### PR DESCRIPTION
## Summary
- Splits the tx detail screen into a fixed header + tabs (**Events** / **Calls** / **Trace**); top stays compact (metadata + top-4 multicall preview + fee), scrollable bodies live below.
- New **Trace** tab renders the recursive call tree from `starknet_traceTransaction` — ABI-resolved function names, decoded calldata (with token-amount + USD pairs), inner events per node, and result felts.
- New `e` master expand toggle: un-truncates every hash, expands struct/enum/array/tuple inline, shows full result felts, implies `d`+`o` in Calls tab, and renders tagged addresses as `0xfullhex (Label)`.
- Visual mode (`v`) walks header → active tab in one unified list and auto-switches tabs as the cursor steps across sections.
- Closes #29.

## Implementation notes
- `src/decode/trace.rs`: maps `TransactionTrace` → `DecodedTrace`/`DecodedTraceCall`. Pre-warms ABIs by `class_hash` (provided on every `FunctionInvocation`) so it doesn't need the per-address class-hash resolve the multicall path uses. Inner events synthesise `SnEvent` and reuse `decode_event` for full label + price treatment.
- `Action::TransactionTraceLoaded` is fired in the background after `TransactionLoaded`, so the rest of the view paints immediately while the recursive trace decodes.
- Traces are persisted to the SQLite cache (`tx_traces` table) keyed by tx hash — finalised traces are deterministic and the RPC call is expensive, so revisits are instant.
- `param_display::format_param[_styled]` gained an `expand` flag so non-address felts render full hex when `e` is on.

## Test plan
- [x] `cargo build --release`, `cargo test`, `cargo clippy --all-targets`, `cargo fmt` all clean.
- [x] New ignored integration test `test_trace_transaction_decode` (`tests/rpc_test.rs`) decodes the example tx end-to-end against the configured `APP_RPC_URL`.
- [x] Open the example tx, switch to **Trace**, confirm the cascading tree renders with decoded fn names + token amounts.
- [x] Press `Tab` / `BackTab` to cycle Events → Calls → Trace.
- [x] Press `v` and step `j`/`k` — confirm cursor walks across header/active tab and auto-switches tabs as needed.
- [x] Press `e` on Calls or Trace — confirm full hex everywhere, tagged addresses render as `0x… (Label)`, struct/array summaries blow out inline.
- [x] Try an outside-execution / AVNU tx — Calls tab `o` toggle still works; Trace renders inner calls.
- [ ] Try a reverted tx — Trace shows revert reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)