### PR TITLE
Make nonce gap row a selectable, Enter-triggered fill

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -639,7 +639,7 @@ fn handle_enter(app: &mut App) -> Option<Action> {
         View::AddressInfo => {
             match app.address.tab {
                 crate::app::AddressTab::Transactions => {
-                    if app.address.gap_selected {
+                    if app.address.gap_selected.is_some() {
                         app.dispatch_address_gap_fill();
                         return None;
                     }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -639,6 +639,10 @@ fn handle_enter(app: &mut App) -> Option<Action> {
         View::AddressInfo => {
             match app.address.tab {
                 crate::app::AddressTab::Transactions => {
+                    if app.address.gap_selected {
+                        app.dispatch_address_gap_fill();
+                        return None;
+                    }
                     let hash = app.address.txs.selected_item()?.hash;
                     return app.navigate_to(NavTarget::Transaction(hash));
                 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -368,7 +368,7 @@ impl App {
         let Some(address) = self.address.context else {
             return;
         };
-        let offset = self.address.txs.state.offset();
+        let offset = self.address.txs_render_state.offset();
         let hashes: Vec<_> = self
             .address
             .txs
@@ -393,7 +393,7 @@ impl App {
     pub fn address_list_scroll_by(&mut self, delta: i64) {
         match self.address.tab {
             AddressTab::Transactions => {
-                self.address.txs.scroll_by(delta);
+                self.address.tx_list_scroll_by(delta);
                 self.maybe_fetch_more_address_txs();
                 self.maybe_enrich_visible_address_txs();
             }
@@ -465,7 +465,7 @@ impl App {
             }
             View::AddressInfo => match self.address.tab {
                 AddressTab::Transactions => {
-                    self.address.txs.next();
+                    self.address.tx_list_next();
                     self.maybe_fetch_more_address_txs();
                     self.maybe_enrich_visible_address_txs();
                 }
@@ -503,7 +503,7 @@ impl App {
             }
             View::AddressInfo => match self.address.tab {
                 AddressTab::Transactions => {
-                    self.address.txs.previous();
+                    self.address.tx_list_previous();
                     self.maybe_enrich_visible_address_txs();
                 }
                 AddressTab::Calls => self.address.calls.previous(),
@@ -530,7 +530,7 @@ impl App {
             }
             View::AddressInfo => match self.address.tab {
                 AddressTab::Transactions => {
-                    self.address.txs.select_first();
+                    self.address.tx_list_select_first();
                     self.maybe_enrich_visible_address_txs();
                 }
                 AddressTab::Calls => self.address.calls.select_first(),
@@ -566,7 +566,7 @@ impl App {
             }
             View::AddressInfo => match self.address.tab {
                 AddressTab::Transactions => {
-                    self.address.txs.select_last();
+                    self.address.tx_list_select_last();
                     self.maybe_fetch_more_address_txs();
                     self.maybe_enrich_visible_address_txs();
                 }
@@ -621,26 +621,9 @@ impl App {
             return;
         }
 
-        // Priority 1: on-demand fill of a deferred large nonce gap (issue #10).
-        // Only fires once per gap; the handler clears `unfilled_gap` on completion.
-        if let Some(gap) = self.address.unfilled_gap.as_ref()
-            && !gap.fill_dispatched
-            && let Some(address) = self.address.context
-        {
-            let gap_clone = gap.clone();
-            if let Some(g) = self.address.unfilled_gap.as_mut() {
-                g.fill_dispatched = true;
-            }
-            self.address.fetching_more_txs = true;
-            let _ = self.action_tx.send(Action::FillAddressNonceGaps {
-                address,
-                known_txs: self.address.txs.items.clone(),
-                gap: gap_clone,
-            });
-            return;
-        }
-
-        // Priority 2: chronological pagination (older than oldest known block).
+        // Chronological pagination (older than oldest known block). Note: large
+        // nonce gaps (issue #10) are NOT auto-filled here — the user must press
+        // Enter on the gap row in the Transactions tab to dispatch the fill.
         // Don't fetch if no source thinks there's more data.
         if !self.address.has_more_data()
             && self.address.oldest_event_block.is_some()
@@ -659,6 +642,33 @@ impl App {
                 is_contract: self.address.is_contract,
             });
         }
+    }
+
+    /// Dispatch an on-demand nonce-gap fill for the currently selected gap row
+    /// in the address Transactions tab. Returns `true` if a fill was sent.
+    /// No-op if there's no current gap, no current address, or a fill is
+    /// already in flight for this gap.
+    pub fn dispatch_address_gap_fill(&mut self) -> bool {
+        let Some(address) = self.address.context else {
+            return false;
+        };
+        let Some(gap) = self.address.unfilled_gap.as_ref() else {
+            return false;
+        };
+        if gap.fill_dispatched {
+            return false;
+        }
+        let gap_clone = gap.clone();
+        if let Some(g) = self.address.unfilled_gap.as_mut() {
+            g.fill_dispatched = true;
+        }
+        self.address.fetching_more_txs = true;
+        let _ = self.action_tx.send(Action::FillAddressNonceGaps {
+            address,
+            known_txs: self.address.txs.items.clone(),
+            gap: gap_clone,
+        });
+        true
     }
 
     pub fn clear_block_detail(&mut self) {
@@ -1084,7 +1094,7 @@ impl App {
 
                 // Lazily enrich visible txs that are missing endpoint/timestamp data
                 if let Some(address) = self.address.context {
-                    let offset = self.address.txs.state.offset();
+                    let offset = self.address.txs_render_state.offset();
                     let hashes: Vec<_> = self
                         .address
                         .txs
@@ -1427,7 +1437,7 @@ impl App {
 
                 // Trigger enrichment for visible window
                 if !self.address.txs.items.is_empty() {
-                    let offset = self.address.txs.state.offset();
+                    let offset = self.address.txs_render_state.offset();
                     let hashes: Vec<_> = self
                         .address
                         .txs

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -677,6 +677,49 @@ impl App {
         true
     }
 
+    /// Refresh the address's nonce-gap list, then auto-dispatch fills for any
+    /// "tiny" gaps (≤ `AUTO_FILL_MAX_MISSING` missing nonces). Tiny gaps
+    /// shouldn't require user action — a 1-nonce hole in a sparse account is
+    /// trivial to fill and surfacing it as a "press Enter" row would just be
+    /// noise. Capped at `MAX_AUTO_FILLS_PER_REFRESH` per call to avoid
+    /// flooding the backends on accounts with many scattered holes;
+    /// remaining tiny gaps fire on the next refresh.
+    fn refresh_address_gaps_and_auto_fill(&mut self) {
+        use crate::app::views::address_info::{AUTO_FILL_MAX_MISSING, MAX_AUTO_FILLS_PER_REFRESH};
+        self.address.refresh_unfilled_gaps();
+        let Some(address) = self.address.context else {
+            return;
+        };
+        let to_fill: Vec<_> = self
+            .address
+            .unfilled_gaps
+            .iter()
+            .filter(|g| !g.fill_dispatched && g.missing_count <= AUTO_FILL_MAX_MISSING)
+            .take(MAX_AUTO_FILLS_PER_REFRESH)
+            .cloned()
+            .collect();
+        if to_fill.is_empty() {
+            return;
+        }
+        let known_txs = self.address.txs.items.clone();
+        for gap in to_fill {
+            if let Some(g) = self
+                .address
+                .unfilled_gaps
+                .iter_mut()
+                .find(|g| g.lo_nonce == gap.lo_nonce)
+            {
+                g.fill_dispatched = true;
+            }
+            self.address.fetching_more_txs = true;
+            let _ = self.action_tx.send(Action::FillAddressNonceGaps {
+                address,
+                known_txs: known_txs.clone(),
+                gap,
+            });
+        }
+    }
+
     pub fn clear_block_detail(&mut self) {
         self.block_detail.clear();
     }
@@ -1127,7 +1170,7 @@ impl App {
                     {
                         let current_nonce = crate::utils::felt_to_u64(&info.nonce);
                         if current_nonce > 0 {
-                            self.address.refresh_unfilled_gaps();
+                            self.refresh_address_gaps_and_auto_fill();
                             self.address.sanity_check_dispatched = true;
                             let _ = self.action_tx.send(Action::EnrichAddressEndpoints {
                                 address,
@@ -1340,7 +1383,7 @@ impl App {
                 // batch lands above the cached set). `refresh_unfilled_gaps`
                 // preserves `fill_dispatched` per `lo_nonce`, so any in-flight
                 // fill keeps its state.
-                self.address.refresh_unfilled_gaps();
+                self.refresh_address_gaps_and_auto_fill();
                 if any_gap_fill_inflight {
                     self.address.fetching_more_txs = false;
                 }
@@ -1503,7 +1546,7 @@ impl App {
                             && let Some(info) = &self.address.info
                         {
                             let current_nonce = crate::utils::felt_to_u64(&info.nonce);
-                            self.address.refresh_unfilled_gaps();
+                            self.refresh_address_gaps_and_auto_fill();
                             self.address.sanity_check_dispatched = true;
                             let _ = self.action_tx.send(Action::EnrichAddressEndpoints {
                                 address,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -646,22 +646,28 @@ impl App {
 
     /// Dispatch an on-demand nonce-gap fill for the currently selected gap row
     /// in the address Transactions tab. Returns `true` if a fill was sent.
-    /// No-op if there's no current gap, no current address, or a fill is
-    /// already in flight for this gap.
+    /// No-op if no gap is selected, no fill is in flight already, or there
+    /// is no current address.
     pub fn dispatch_address_gap_fill(&mut self) -> bool {
         let Some(address) = self.address.context else {
             return false;
         };
-        let Some(gap) = self.address.unfilled_gap.as_ref() else {
+        let Some(sel_lo) = self.address.gap_selected else {
+            return false;
+        };
+        let Some(gap) = self
+            .address
+            .unfilled_gaps
+            .iter_mut()
+            .find(|g| g.lo_nonce == sel_lo)
+        else {
             return false;
         };
         if gap.fill_dispatched {
             return false;
         }
         let gap_clone = gap.clone();
-        if let Some(g) = self.address.unfilled_gap.as_mut() {
-            g.fill_dispatched = true;
-        }
+        gap.fill_dispatched = true;
         self.address.fetching_more_txs = true;
         let _ = self.action_tx.send(Action::FillAddressNonceGaps {
             address,
@@ -1111,9 +1117,9 @@ impl App {
                             .send(Action::EnrichAddressTxs { address, hashes });
                     }
 
-                    // Detect any large nonce gap in cached data and defer it to
-                    // on-demand fill (issue #10). Endpoint enrichment + small gap
-                    // fill still run immediately from cache.
+                    // Detect any large nonce gaps in cached data and defer
+                    // them to on-demand fill (issue #10). Endpoint enrichment
+                    // + small gap fill still run immediately from cache.
                     if !self.address.is_contract
                         && !self.address.txs.items.is_empty()
                         && !self.address.sanity_check_dispatched
@@ -1121,7 +1127,7 @@ impl App {
                     {
                         let current_nonce = crate::utils::felt_to_u64(&info.nonce);
                         if current_nonce > 0 {
-                            self.address.unfilled_gap = self.address.detect_unfilled_gap();
+                            self.address.refresh_unfilled_gaps();
                             self.address.sanity_check_dispatched = true;
                             let _ = self.action_tx.send(Action::EnrichAddressEndpoints {
                                 address,
@@ -1326,24 +1332,16 @@ impl App {
                 if self.address.context != Some(address) {
                     return;
                 }
-                // If a deferred gap-fill was in-flight, unblock the pagination
-                // trigger now that results have landed.
-                let was_gap_fill = self
-                    .address
-                    .unfilled_gap
-                    .as_ref()
-                    .is_some_and(|g| g.fill_dispatched);
-                // Merge enrichment data (upgrades existing entries)
+                let any_gap_fill_inflight =
+                    self.address.unfilled_gaps.iter().any(|g| g.fill_dispatched);
                 self.address.merge_tx_summaries(updates);
-                // If a gap fill was in flight, re-run detection so we either
-                // clear the gap (filled) or update it to the residual gap.
-                if was_gap_fill {
-                    self.address.unfilled_gap = self.address.detect_unfilled_gap().map(|mut g| {
-                        // Preserve dispatched state so we don't re-fire for the
-                        // same (or similar) gap; require refresh ('r') to retry.
-                        g.fill_dispatched = true;
-                        g
-                    });
+                // Re-run detection so newly-arrived txs can both close existing
+                // gaps and surface new ones (e.g. when a fresh top-of-list
+                // batch lands above the cached set). `refresh_unfilled_gaps`
+                // preserves `fill_dispatched` per `lo_nonce`, so any in-flight
+                // fill keeps its state.
+                self.address.refresh_unfilled_gaps();
+                if any_gap_fill_inflight {
                     self.address.fetching_more_txs = false;
                 }
                 // Persist enriched txs to cache so they survive restarts
@@ -1498,14 +1496,14 @@ impl App {
                         self.is_loading = false;
                         self.loading_detail = None;
 
-                        // Post-display: detect any large nonce gap and defer it for
-                        // on-demand fill (issue #10). Small gaps + endpoint
-                        // enrichment still run automatically.
+                        // Post-display: detect any large nonce gaps and defer
+                        // them for on-demand fill (issue #10). Small gaps +
+                        // endpoint enrichment still run automatically.
                         if !self.address.is_contract
                             && let Some(info) = &self.address.info
                         {
                             let current_nonce = crate::utils::felt_to_u64(&info.nonce);
-                            self.address.unfilled_gap = self.address.detect_unfilled_gap();
+                            self.address.refresh_unfilled_gaps();
                             self.address.sanity_check_dispatched = true;
                             let _ = self.action_tx.send(Action::EnrichAddressEndpoints {
                                 address,

--- a/src/app/views/address_info.rs
+++ b/src/app/views/address_info.rs
@@ -21,6 +21,14 @@ use crate::ui::widgets::stateful_list::StatefulList;
 /// they stay aligned — drift between the two causes silent data loss.
 pub const SMALL_GAP_SPAN_BLOCKS: u64 = 50;
 
+/// Maximum number of txs an on-demand fill pulls per Enter press. Keeping
+/// this small (matching the chronological pagination chunk in `app/mod.rs`)
+/// makes large-gap fills lazy: each Enter shrinks the gap from its newer
+/// edge, leaving a residual gap row that the user can fill again. Without
+/// this cap, a 33k-tx gap would fire one giant Dune/Pathfinder query per
+/// Enter, which is exactly the behavior we want to avoid.
+pub const LARGE_GAP_FILL_CHUNK_TXS: u32 = 50;
+
 /// Passive UI hint derived from the event-window helper's last fetch.
 /// Shared across the Calls / Events / MetaTxs tabs because all three
 /// project from the same `address_events` + `address_search_progress`
@@ -454,19 +462,24 @@ impl AddressInfoState {
         out
     }
 
-    /// Re-detect gaps and store them, preserving `fill_dispatched` for any
-    /// gap whose `lo_nonce` already had a fill in flight. Drops the gap
-    /// selection if the previously-selected gap no longer exists.
+    /// Re-detect gaps and store them. `fill_dispatched` is preserved only for
+    /// gaps whose `(lo_nonce, hi_nonce)` is unchanged from the previous list —
+    /// a shifted `hi_nonce` is evidence the fill response just landed
+    /// (lazy fills always shrink the gap from the newer edge), so we clear
+    /// the flag and let the user press Enter again for the next chunk.
+    /// Drops the gap selection if the previously-selected gap no longer exists.
     pub fn refresh_unfilled_gaps(&mut self) {
-        let dispatched_los: std::collections::HashSet<u64> = self
+        let prev_inflight: std::collections::HashMap<u64, u64> = self
             .unfilled_gaps
             .iter()
             .filter(|g| g.fill_dispatched)
-            .map(|g| g.lo_nonce)
+            .map(|g| (g.lo_nonce, g.hi_nonce))
             .collect();
         let mut next = self.detect_unfilled_gaps();
         for g in next.iter_mut() {
-            if dispatched_los.contains(&g.lo_nonce) {
+            if let Some(prev_hi) = prev_inflight.get(&g.lo_nonce)
+                && *prev_hi == g.hi_nonce
+            {
                 g.fill_dispatched = true;
             }
         }
@@ -784,13 +797,37 @@ mod tests {
     }
 
     #[test]
-    fn refresh_preserves_dispatched_flag() {
+    fn refresh_preserves_dispatched_flag_when_gap_unchanged() {
         let mut state = state_with(vec![summary(10, 100), summary(21, 2000)]);
         state.unfilled_gaps = state.detect_unfilled_gaps();
         state.unfilled_gaps[0].fill_dispatched = true;
         state.refresh_unfilled_gaps();
         assert_eq!(state.unfilled_gaps.len(), 1);
         assert!(state.unfilled_gaps[0].fill_dispatched);
+    }
+
+    #[test]
+    fn refresh_clears_dispatched_flag_when_gap_shrinks() {
+        // Mimics a lazy fill landing: the chunk arrived from the top of the
+        // gap (nonces just below `hi_nonce`), shrinking the gap from its
+        // newer edge. Same `lo_nonce`, lower `hi_nonce` → flag should clear
+        // so the user can Enter on the residual to load the next chunk.
+        let mut state = state_with(vec![summary(10, 100), summary(21, 2000)]);
+        state.unfilled_gaps = state.detect_unfilled_gaps();
+        state.unfilled_gaps[0].fill_dispatched = true;
+
+        // Add a contiguous chunk at the top of the gap (nonces 18, 19, 20).
+        // Their blocks are close to 2000 (top edge) but the older boundary
+        // gap (10..18) still has a wide block span → still deferred.
+        state.txs.items.push(summary(18, 1980));
+        state.txs.items.push(summary(19, 1990));
+        state.txs.items.push(summary(20, 1995));
+        state.refresh_unfilled_gaps();
+
+        assert_eq!(state.unfilled_gaps.len(), 1);
+        assert_eq!(state.unfilled_gaps[0].lo_nonce, 10);
+        assert_eq!(state.unfilled_gaps[0].hi_nonce, 18);
+        assert!(!state.unfilled_gaps[0].fill_dispatched);
     }
 
     #[test]

--- a/src/app/views/address_info.rs
+++ b/src/app/views/address_info.rs
@@ -29,6 +29,22 @@ pub const SMALL_GAP_SPAN_BLOCKS: u64 = 50;
 /// Enter, which is exactly the behavior we want to avoid.
 pub const LARGE_GAP_FILL_CHUNK_TXS: u32 = 50;
 
+/// Detected gaps with no more than this many missing nonces are filled
+/// automatically (no Enter required). They still go through the deferred-fill
+/// machinery — we just dispatch the fill on the user's behalf so a 1-tx hole
+/// in a sparse account never surfaces as a "press Enter" row. Larger gaps
+/// stay deferred so we don't burn Dune/Pathfinder queries on multi-thousand
+/// tx ranges the user might not care about.
+pub const AUTO_FILL_MAX_MISSING: u64 = 1;
+
+/// Cap on the number of tiny gaps auto-dispatched per refresh. A very-active
+/// address can have dozens of 1-nonce holes scattered across its history;
+/// firing every one at once would saturate Pathfinder and (on the Dune
+/// fallback) blow through quota. Remaining tiny gaps still appear as
+/// deferred rows, and the next refresh picks them up after the dispatched
+/// chunk lands.
+pub const MAX_AUTO_FILLS_PER_REFRESH: usize = 5;
+
 /// Passive UI hint derived from the event-window helper's last fetch.
 /// Shared across the Calls / Events / MetaTxs tabs because all three
 /// project from the same `address_events` + `address_search_progress`
@@ -840,5 +856,172 @@ mod tests {
         state.refresh_unfilled_gaps();
         assert!(state.unfilled_gaps.is_empty());
         assert!(state.gap_selected.is_none());
+    }
+
+    /// Build a state with a single deferred gap between hi/lo nonces. Tx list
+    /// is sorted nonce-descending, matching the live-render layout.
+    fn state_one_gap() -> AddressInfoState {
+        // Nonces 100, 99, 30, 29 — gap between 30 and 99 (block span 4790).
+        let mut state = state_with(vec![
+            summary(100, 5000),
+            summary(99, 4990),
+            summary(30, 200),
+            summary(29, 190),
+        ]);
+        state.refresh_unfilled_gaps();
+        assert_eq!(state.unfilled_gaps.len(), 1);
+        state.txs.state.select(Some(0));
+        state
+    }
+
+    #[test]
+    fn next_lands_on_gap_when_crossing_forward() {
+        let mut state = state_one_gap();
+        // Start at nonce 99 (tx idx 1), the tx just above the gap.
+        state.txs.state.select(Some(1));
+        state.tx_list_next();
+        assert_eq!(state.gap_selected, Some(30));
+        assert_eq!(state.txs.state.selected(), Some(1));
+    }
+
+    #[test]
+    fn next_off_gap_lands_on_lo_nonce_tx_no_dispatch() {
+        let mut state = state_one_gap();
+        state.gap_selected = Some(30);
+        state.tx_list_next();
+        // Cleared gap selection, landed on the lo_nonce tx (nonce 30, idx 2).
+        assert_eq!(state.gap_selected, None);
+        assert_eq!(state.txs.state.selected(), Some(2));
+        // Crucially, no fill_dispatched — Enter alone triggers fills.
+        assert!(!state.unfilled_gaps[0].fill_dispatched);
+    }
+
+    #[test]
+    fn previous_lands_on_gap_when_crossing_backward() {
+        let mut state = state_one_gap();
+        // Start at nonce 30 (tx idx 2), the tx just below the gap.
+        state.txs.state.select(Some(2));
+        state.tx_list_previous();
+        assert_eq!(state.gap_selected, Some(30));
+        assert_eq!(state.txs.state.selected(), Some(2));
+    }
+
+    #[test]
+    fn previous_off_gap_lands_on_hi_nonce_tx() {
+        let mut state = state_one_gap();
+        state.gap_selected = Some(30);
+        state.tx_list_previous();
+        assert_eq!(state.gap_selected, None);
+        assert_eq!(state.txs.state.selected(), Some(1));
+    }
+
+    #[test]
+    fn scroll_by_clamps_on_gap_forward() {
+        let mut state = state_one_gap();
+        state.txs.state.select(Some(0));
+        state.tx_list_scroll_by(10);
+        // Should clamp on the gap row, not jump past it.
+        assert_eq!(state.gap_selected, Some(30));
+    }
+
+    #[test]
+    fn scroll_by_clamps_on_gap_backward() {
+        let mut state = state_one_gap();
+        state.txs.state.select(Some(3));
+        state.tx_list_scroll_by(-10);
+        assert_eq!(state.gap_selected, Some(30));
+    }
+
+    #[test]
+    fn select_first_clamps_on_gap_from_below() {
+        let mut state = state_one_gap();
+        state.txs.state.select(Some(3));
+        state.tx_list_select_first();
+        assert_eq!(state.gap_selected, Some(30));
+    }
+
+    #[test]
+    fn select_last_clamps_on_gap_from_above() {
+        let mut state = state_one_gap();
+        state.txs.state.select(Some(0));
+        state.tx_list_select_last();
+        assert_eq!(state.gap_selected, Some(30));
+    }
+
+    #[test]
+    fn navigation_is_a_noop_with_no_gap() {
+        let mut state = state_with(vec![summary(10, 100), summary(11, 102)]);
+        state.refresh_unfilled_gaps();
+        assert!(state.unfilled_gaps.is_empty());
+        state.txs.state.select(Some(0));
+        state.tx_list_next();
+        assert_eq!(state.gap_selected, None);
+        assert_eq!(state.txs.state.selected(), Some(1));
+    }
+
+    /// Two deferred gaps — single-step navigation should pause at each.
+    fn state_two_gaps() -> AddressInfoState {
+        // Nonces 200, 199, 100, 99, 30, 29 — gaps between 100..199 and 30..99.
+        let mut state = state_with(vec![
+            summary(200, 9010),
+            summary(199, 9000),
+            summary(100, 5000),
+            summary(99, 4990),
+            summary(30, 200),
+            summary(29, 190),
+        ]);
+        state.refresh_unfilled_gaps();
+        assert_eq!(state.unfilled_gaps.len(), 2);
+        state.txs.state.select(Some(0));
+        state
+    }
+
+    #[test]
+    fn scroll_by_clamps_on_first_of_multiple_gaps_forward() {
+        let mut state = state_two_gaps();
+        state.tx_list_scroll_by(20);
+        // First gap encountered going down from the top is the upper one.
+        assert_eq!(state.gap_selected, Some(100));
+    }
+
+    #[test]
+    fn scroll_by_from_first_gap_clamps_on_second() {
+        let mut state = state_two_gaps();
+        state.gap_selected = Some(100);
+        state.tx_list_scroll_by(20);
+        assert_eq!(state.gap_selected, Some(30));
+    }
+
+    #[test]
+    fn step_walks_through_each_gap() {
+        let mut state = state_two_gaps();
+        // Start on the tx just above the upper gap (nonce 199, idx 1).
+        state.txs.state.select(Some(1));
+        state.tx_list_next(); // lands on upper gap
+        assert_eq!(state.gap_selected, Some(100));
+        state.tx_list_next(); // off gap → tx with nonce 100 (idx 2)
+        assert_eq!(state.gap_selected, None);
+        assert_eq!(state.txs.state.selected(), Some(2));
+        state.tx_list_next(); // tx idx 3 (nonce 99) — just above lower gap
+        assert_eq!(state.txs.state.selected(), Some(3));
+        state.tx_list_next(); // lands on lower gap
+        assert_eq!(state.gap_selected, Some(30));
+    }
+
+    #[test]
+    fn rendered_selected_tracks_gap_and_tx_state() {
+        let mut state = state_two_gaps();
+        // Tx idx 0 (nonce 200) → rendered 0.
+        state.txs.state.select(Some(0));
+        assert_eq!(state.tx_list_rendered_selected(), Some(0));
+        // Tx idx 3 (nonce 99) → rendered 4 (one upper-gap row in front of it).
+        state.txs.state.select(Some(3));
+        assert_eq!(state.tx_list_rendered_selected(), Some(4));
+        // Selecting the upper gap → rendered 2.
+        state.gap_selected = Some(100);
+        assert_eq!(state.tx_list_rendered_selected(), Some(2));
+        // Selecting the lower gap → rendered 5.
+        state.gap_selected = Some(30);
+        assert_eq!(state.tx_list_rendered_selected(), Some(5));
     }
 }

--- a/src/app/views/address_info.rs
+++ b/src/app/views/address_info.rs
@@ -113,8 +113,17 @@ pub struct AddressInfoState {
     pub sanity_check_dispatched: bool,
     /// Detected large nonce gap that has NOT been auto-filled (issue #10).
     /// Set after the initial load settles; filled on-demand when the user
-    /// scrolls near the bottom of the list.
+    /// presses Enter on the gap row.
     pub unfilled_gap: Option<UnfilledGap>,
+    /// True when the rendered gap row (rather than any tx) is currently selected.
+    /// The gap row is a synthetic, standalone entry in the rendered list; the
+    /// underlying `txs.state.selected()` does not move while this flag is set.
+    pub gap_selected: bool,
+    /// ListState fed to ratatui for the Transactions tab. Indexed against the
+    /// rendered list (txs + optional gap row), so it diverges from `txs.state`
+    /// whenever a gap is showing. Persisted across frames to keep the viewport
+    /// offset stable.
+    pub txs_render_state: ratatui::widgets::ListState,
     /// Meta-transactions (SNIP-9 outside executions) where this address is the intender.
     pub meta_txs: StatefulList<MetaTxIntenderSummary>,
     /// Pagination flag for MetaTxs tab (prevent duplicate fetches).
@@ -185,6 +194,8 @@ impl Default for AddressInfoState {
             ws_subscribed: false,
             sanity_check_dispatched: false,
             unfilled_gap: None,
+            gap_selected: false,
+            txs_render_state: ratatui::widgets::ListState::default(),
             meta_txs: StatefulList::new(),
             fetching_meta_txs: false,
             meta_tx_cursor_block: None,
@@ -222,6 +233,8 @@ impl AddressInfoState {
         self.ws_subscribed = false;
         self.sanity_check_dispatched = false;
         self.unfilled_gap = None;
+        self.gap_selected = false;
+        self.txs_render_state = ratatui::widgets::ListState::default();
         self.meta_txs = StatefulList::new();
         self.fetching_meta_txs = false;
         self.meta_tx_cursor_block = None;
@@ -444,6 +457,154 @@ impl AddressInfoState {
             return None;
         }
         Some(gap)
+    }
+
+    /// Index in `txs.items` of the tx that sits just below the rendered gap
+    /// row (i.e. the one with `nonce == gap.lo_nonce`). Returns `None` when
+    /// there is no detected gap or the lo-nonce tx isn't in the visible list.
+    pub fn gap_pos(&self) -> Option<usize> {
+        let gap = self.unfilled_gap.as_ref()?;
+        self.txs.items.iter().position(|t| t.nonce == gap.lo_nonce)
+    }
+
+    /// Rendered (gap-aware) selection index for the Transactions list — the
+    /// position the gap row + tx rows occupy in the rendered viewport.
+    pub fn tx_list_rendered_selected(&self) -> Option<usize> {
+        let gap = self.gap_pos();
+        if self.gap_selected {
+            return gap;
+        }
+        let tx_idx = self.txs.state.selected()?;
+        Some(match gap {
+            Some(g) if tx_idx >= g => tx_idx + 1,
+            _ => tx_idx,
+        })
+    }
+
+    /// Step the tx-list selection down. If the next step would cross the gap
+    /// row, selection lands on the gap row instead. From the gap row, advances
+    /// to the tx below it (no fill is dispatched — Enter is the only trigger).
+    pub fn tx_list_next(&mut self) {
+        if self.txs.items.is_empty() {
+            return;
+        }
+        let gap = self.gap_pos();
+        if self.gap_selected {
+            self.gap_selected = false;
+            if let Some(g) = gap {
+                let target = g.min(self.txs.items.len() - 1);
+                self.txs.state.select(Some(target));
+            } else {
+                self.txs.next();
+            }
+            return;
+        }
+        if let Some(g) = gap {
+            let cur = self.txs.state.selected().unwrap_or(0);
+            if cur + 1 == g {
+                self.gap_selected = true;
+                return;
+            }
+        }
+        self.txs.next();
+    }
+
+    /// Step the tx-list selection up. Symmetric to `tx_list_next` w.r.t. the
+    /// gap row.
+    pub fn tx_list_previous(&mut self) {
+        if self.txs.items.is_empty() {
+            return;
+        }
+        let gap = self.gap_pos();
+        if self.gap_selected {
+            self.gap_selected = false;
+            if let Some(g) = gap {
+                let target = g.saturating_sub(1);
+                self.txs.state.select(Some(target));
+            } else {
+                self.txs.previous();
+            }
+            return;
+        }
+        if let Some(g) = gap {
+            let cur = self.txs.state.selected().unwrap_or(0);
+            if cur == g {
+                self.gap_selected = true;
+                return;
+            }
+        }
+        self.txs.previous();
+    }
+
+    pub fn tx_list_select_first(&mut self) {
+        self.gap_selected = false;
+        self.txs.select_first();
+    }
+
+    /// Jump to the last tx. If the cursor is currently above the gap row, the
+    /// jump clamps on the gap so the user can decide whether to load it or
+    /// step past with another keypress.
+    pub fn tx_list_select_last(&mut self) {
+        if self.txs.items.is_empty() {
+            return;
+        }
+        if let Some(g) = self.gap_pos() {
+            let above_gap =
+                !self.gap_selected && self.txs.state.selected().is_none_or(|cur| cur < g);
+            if above_gap {
+                self.gap_selected = true;
+                return;
+            }
+        }
+        self.gap_selected = false;
+        self.txs.select_last();
+    }
+
+    /// Scroll the tx-list selection by `delta`. If the gap row sits between
+    /// the current selection and the target, selection clamps on the gap row.
+    pub fn tx_list_scroll_by(&mut self, delta: i64) {
+        if self.txs.items.is_empty() || delta == 0 {
+            return;
+        }
+        let gap = self.gap_pos();
+        let last_tx = self.txs.items.len() as i64 - 1;
+        let cur_tx = self.txs.state.selected().unwrap_or(0) as i64;
+        let cur_rendered = match (self.gap_selected, gap) {
+            (true, Some(g)) => g as i64,
+            (false, Some(g)) if cur_tx >= g as i64 => cur_tx + 1,
+            _ => cur_tx,
+        };
+        let rendered_last = last_tx + if gap.is_some() { 1 } else { 0 };
+        let target_rendered = (cur_rendered + delta).clamp(0, rendered_last);
+        let final_rendered = match gap {
+            Some(g) => {
+                let g = g as i64;
+                if cur_rendered != g && (cur_rendered < g) != (target_rendered < g) {
+                    g
+                } else {
+                    target_rendered
+                }
+            }
+            None => target_rendered,
+        };
+        match gap {
+            Some(g) if final_rendered == g as i64 => {
+                self.gap_selected = true;
+            }
+            Some(g) => {
+                self.gap_selected = false;
+                let tx_idx = if final_rendered < g as i64 {
+                    final_rendered as usize
+                } else {
+                    (final_rendered - 1) as usize
+                };
+                self.txs.state.select(Some(tx_idx));
+            }
+            None => {
+                self.gap_selected = false;
+                self.txs.state.select(Some(final_rendered as usize));
+            }
+        }
     }
 }
 

--- a/src/app/views/address_info.rs
+++ b/src/app/views/address_info.rs
@@ -17,7 +17,7 @@ use crate::ui::widgets::stateful_list::StatefulList;
 /// Maximum block span a nonce gap can cover before we stop auto-filling it
 /// via RPC block scans. Gaps wider than this are deferred to on-demand Dune
 /// queries (`run_nonce_gap_fill`). Shared between the detector
-/// (`detect_unfilled_gap`) and the filler (`fill_small_nonce_gaps_phase`) so
+/// (`detect_unfilled_gaps`) and the filler (`fill_small_nonce_gaps_phase`) so
 /// they stay aligned — drift between the two causes silent data loss.
 pub const SMALL_GAP_SPAN_BLOCKS: u64 = 50;
 
@@ -111,14 +111,17 @@ pub struct AddressInfoState {
     pub ws_subscribed: bool,
     /// Whether the post-display sanity check has already been dispatched.
     pub sanity_check_dispatched: bool,
-    /// Detected large nonce gap that has NOT been auto-filled (issue #10).
-    /// Set after the initial load settles; filled on-demand when the user
-    /// presses Enter on the gap row.
-    pub unfilled_gap: Option<UnfilledGap>,
-    /// True when the rendered gap row (rather than any tx) is currently selected.
-    /// The gap row is a synthetic, standalone entry in the rendered list; the
-    /// underlying `txs.state.selected()` does not move while this flag is set.
-    pub gap_selected: bool,
+    /// Detected large nonce gaps that have NOT been auto-filled (issue #10).
+    /// Each gap renders as its own row between the bordering txs; the user
+    /// presses Enter on a gap row to dispatch its fill.
+    pub unfilled_gaps: Vec<UnfilledGap>,
+    /// `Some(lo_nonce)` when the rendered gap row whose `lo_nonce` matches is
+    /// currently selected. The gap row is a synthetic, standalone entry in the
+    /// rendered list; the underlying `txs.state.selected()` does not move
+    /// while this is set. Identifying by `lo_nonce` (instead of vec index)
+    /// keeps the selection stable across re-detection passes that reorder the
+    /// gap list.
+    pub gap_selected: Option<u64>,
     /// ListState fed to ratatui for the Transactions tab. Indexed against the
     /// rendered list (txs + optional gap row), so it diverges from `txs.state`
     /// whenever a gap is showing. Persisted across frames to keep the viewport
@@ -193,8 +196,8 @@ impl Default for AddressInfoState {
             rpc_has_more: false,
             ws_subscribed: false,
             sanity_check_dispatched: false,
-            unfilled_gap: None,
-            gap_selected: false,
+            unfilled_gaps: Vec::new(),
+            gap_selected: None,
             txs_render_state: ratatui::widgets::ListState::default(),
             meta_txs: StatefulList::new(),
             fetching_meta_txs: false,
@@ -232,8 +235,8 @@ impl AddressInfoState {
         self.rpc_has_more = false;
         self.ws_subscribed = false;
         self.sanity_check_dispatched = false;
-        self.unfilled_gap = None;
-        self.gap_selected = false;
+        self.unfilled_gaps.clear();
+        self.gap_selected = None;
         self.txs_render_state = ratatui::widgets::ListState::default();
         self.meta_txs = StatefulList::new();
         self.fetching_meta_txs = false;
@@ -401,19 +404,17 @@ impl AddressInfoState {
             .sort_by(|a, b| b.block_number.cmp(&a.block_number));
     }
 
-    /// Scan the current tx list for a "large" nonce gap that we want to defer
-    /// filling until the user asks for it.
+    /// Scan the current tx list for *all* large nonce gaps that should be
+    /// deferred until the user asks for them.
     ///
-    /// Returns `Some(gap)` when the biggest contiguous missing-nonce run is large
-    /// enough to justify deferring (either many missing entries, or a wide block
-    /// span). Small gaps are left to the normal enrichment path and return `None`
-    /// so the caller can auto-fill them.
-    pub fn detect_unfilled_gap(&self) -> Option<UnfilledGap> {
-        // Only meaningful for account txs (contracts don't have sequential nonces).
+    /// Each returned gap has at least one missing nonce *and* a block span
+    /// wider than `SMALL_GAP_SPAN_BLOCKS` (the RPC small-gap path's reach —
+    /// narrower gaps stay on the auto-fill path). Sorted by `lo_nonce`
+    /// ascending so renderers/tests have a stable order.
+    pub fn detect_unfilled_gaps(&self) -> Vec<UnfilledGap> {
         if self.is_contract {
-            return None;
+            return Vec::new();
         }
-        // Build sorted (nonce, block) pairs for txs that have landed in a block.
         let mut pairs: Vec<(u64, u64)> = self
             .txs
             .items
@@ -422,12 +423,11 @@ impl AddressInfoState {
             .map(|t| (t.nonce, t.block_number))
             .collect();
         if pairs.len() < 2 {
-            return None;
+            return Vec::new();
         }
         pairs.sort_by_key(|(n, _)| *n);
 
-        // Find the biggest missing-nonce run.
-        let mut best: Option<UnfilledGap> = None;
+        let mut out = Vec::new();
         for w in pairs.windows(2) {
             let (lo_nonce, lo_block) = w[0];
             let (hi_nonce, hi_block) = w[1];
@@ -435,176 +435,198 @@ impl AddressInfoState {
             if missing == 0 {
                 continue;
             }
-            let keep = best.as_ref().is_none_or(|b| missing > b.missing_count);
-            if keep {
-                best = Some(UnfilledGap {
-                    lo_nonce,
-                    hi_nonce,
-                    lo_block,
-                    hi_block,
-                    missing_count: missing,
-                    fill_dispatched: false,
-                });
+            // `fill_small_nonce_gaps_phase` only covers spans ≤ SMALL_GAP_SPAN_BLOCKS
+            // via RPC scans; anything wider must be filled via Dune on demand
+            // or it would be silently dropped.
+            let span = hi_block.saturating_sub(lo_block);
+            if span <= SMALL_GAP_SPAN_BLOCKS {
+                continue;
+            }
+            out.push(UnfilledGap {
+                lo_nonce,
+                hi_nonce,
+                lo_block,
+                hi_block,
+                missing_count: missing,
+                fill_dispatched: false,
+            });
+        }
+        out
+    }
+
+    /// Re-detect gaps and store them, preserving `fill_dispatched` for any
+    /// gap whose `lo_nonce` already had a fill in flight. Drops the gap
+    /// selection if the previously-selected gap no longer exists.
+    pub fn refresh_unfilled_gaps(&mut self) {
+        let dispatched_los: std::collections::HashSet<u64> = self
+            .unfilled_gaps
+            .iter()
+            .filter(|g| g.fill_dispatched)
+            .map(|g| g.lo_nonce)
+            .collect();
+        let mut next = self.detect_unfilled_gaps();
+        for g in next.iter_mut() {
+            if dispatched_los.contains(&g.lo_nonce) {
+                g.fill_dispatched = true;
             }
         }
-        let gap = best?;
-
-        // Defer any gap the RPC small-gap path can't handle. `fill_small_nonce_gaps_phase`
-        // only scans spans ≤ `SMALL_GAP_SPAN_BLOCKS` — anything wider must be
-        // filled via Dune on-demand or it would otherwise be dropped silently.
-        let span = gap.hi_block.saturating_sub(gap.lo_block);
-        if span <= SMALL_GAP_SPAN_BLOCKS {
-            return None;
+        self.unfilled_gaps = next;
+        if let Some(sel) = self.gap_selected
+            && !self.unfilled_gaps.iter().any(|g| g.lo_nonce == sel)
+        {
+            self.gap_selected = None;
         }
-        Some(gap)
     }
 
-    /// Index in `txs.items` of the tx that sits just below the rendered gap
-    /// row (i.e. the one with `nonce == gap.lo_nonce`). Returns `None` when
-    /// there is no detected gap or the lo-nonce tx isn't in the visible list.
-    pub fn gap_pos(&self) -> Option<usize> {
-        let gap = self.unfilled_gap.as_ref()?;
-        self.txs.items.iter().position(|t| t.nonce == gap.lo_nonce)
+    /// Render-order positions for the gap rows: pairs of `(tx_idx, lo_nonce)`
+    /// sorted by `tx_idx` ascending. Each gap renders immediately above the
+    /// tx whose nonce equals `lo_nonce`. Gaps whose `lo_nonce` tx isn't in
+    /// `txs.items` are filtered out (defensive — usually all match).
+    pub fn gap_render_positions(&self) -> Vec<(usize, u64)> {
+        let mut out: Vec<(usize, u64)> = self
+            .unfilled_gaps
+            .iter()
+            .filter_map(|g| {
+                self.txs
+                    .items
+                    .iter()
+                    .position(|t| t.nonce == g.lo_nonce)
+                    .map(|p| (p, g.lo_nonce))
+            })
+            .collect();
+        out.sort_by_key(|(p, _)| *p);
+        out
     }
 
-    /// Rendered (gap-aware) selection index for the Transactions list — the
-    /// position the gap row + tx rows occupy in the rendered viewport.
+    fn rendered_len(&self, gaps: &[(usize, u64)]) -> usize {
+        self.txs.items.len() + gaps.len()
+    }
+
+    fn tx_pos_to_rendered(tx_pos: usize, gaps: &[(usize, u64)]) -> usize {
+        tx_pos + gaps.iter().filter(|(p, _)| *p <= tx_pos).count()
+    }
+
+    fn gap_rendered_idx(gaps: &[(usize, u64)], idx_in_gaps: usize) -> usize {
+        gaps[idx_in_gaps].0 + idx_in_gaps
+    }
+
+    fn rendered_to_tx_pos(r: usize, gaps: &[(usize, u64)]) -> usize {
+        let gaps_before = gaps
+            .iter()
+            .enumerate()
+            .filter(|(g_idx, (p, _))| p + g_idx < r)
+            .count();
+        r - gaps_before
+    }
+
+    /// Rendered (gap-aware) selection index for the Transactions list.
     pub fn tx_list_rendered_selected(&self) -> Option<usize> {
-        let gap = self.gap_pos();
-        if self.gap_selected {
-            return gap;
+        let gaps = self.gap_render_positions();
+        if let Some(sel_lo) = self.gap_selected
+            && let Some(g_idx) = gaps.iter().position(|(_, lo)| *lo == sel_lo)
+        {
+            return Some(Self::gap_rendered_idx(&gaps, g_idx));
         }
         let tx_idx = self.txs.state.selected()?;
-        Some(match gap {
-            Some(g) if tx_idx >= g => tx_idx + 1,
-            _ => tx_idx,
-        })
+        Some(Self::tx_pos_to_rendered(tx_idx, &gaps))
     }
 
-    /// Step the tx-list selection down. If the next step would cross the gap
-    /// row, selection lands on the gap row instead. From the gap row, advances
-    /// to the tx below it (no fill is dispatched — Enter is the only trigger).
+    /// Currently-selected gap, if the gap row is the active selection.
+    pub fn selected_gap(&self) -> Option<&UnfilledGap> {
+        let lo = self.gap_selected?;
+        self.unfilled_gaps.iter().find(|g| g.lo_nonce == lo)
+    }
+
+    fn current_rendered(&self, gaps: &[(usize, u64)]) -> usize {
+        if let Some(sel_lo) = self.gap_selected
+            && let Some(g_idx) = gaps.iter().position(|(_, lo)| *lo == sel_lo)
+        {
+            return Self::gap_rendered_idx(gaps, g_idx);
+        }
+        let t = self.txs.state.selected().unwrap_or(0);
+        Self::tx_pos_to_rendered(t, gaps)
+    }
+
+    /// First gap rendered idx that lies strictly between `cur` and `target`
+    /// (target inclusive). Returns `None` if no gap is crossed.
+    fn first_gap_crossed(gaps: &[(usize, u64)], cur: usize, target: usize) -> Option<usize> {
+        if cur == target {
+            return None;
+        }
+        if target > cur {
+            gaps.iter().enumerate().find_map(|(g_idx, (p, _))| {
+                let r = p + g_idx;
+                (r > cur && r <= target).then_some(r)
+            })
+        } else {
+            gaps.iter().enumerate().rev().find_map(|(g_idx, (p, _))| {
+                let r = p + g_idx;
+                (r < cur && r >= target).then_some(r)
+            })
+        }
+    }
+
+    /// Apply a target rendered index to state — selects the gap row when the
+    /// index lands on one, otherwise selects the corresponding tx.
+    fn apply_rendered(&mut self, r: usize, gaps: &[(usize, u64)]) {
+        for (g_idx, (p, lo)) in gaps.iter().enumerate() {
+            if p + g_idx == r {
+                self.gap_selected = Some(*lo);
+                return;
+            }
+        }
+        self.gap_selected = None;
+        let t = Self::rendered_to_tx_pos(r, gaps);
+        self.txs.state.select(Some(t));
+    }
+
+    /// Move selection by `delta` rows in the rendered list, clamping on the
+    /// first gap row crossed.
+    fn tx_list_step(&mut self, delta: i64) {
+        if self.txs.items.is_empty() || delta == 0 {
+            return;
+        }
+        let gaps = self.gap_render_positions();
+        let rendered_max = self.rendered_len(&gaps).saturating_sub(1);
+        let cur = self.current_rendered(&gaps);
+        let target = ((cur as i64) + delta).clamp(0, rendered_max as i64) as usize;
+        let final_r = Self::first_gap_crossed(&gaps, cur, target).unwrap_or(target);
+        self.apply_rendered(final_r, &gaps);
+    }
+
     pub fn tx_list_next(&mut self) {
-        if self.txs.items.is_empty() {
-            return;
-        }
-        let gap = self.gap_pos();
-        if self.gap_selected {
-            self.gap_selected = false;
-            if let Some(g) = gap {
-                let target = g.min(self.txs.items.len() - 1);
-                self.txs.state.select(Some(target));
-            } else {
-                self.txs.next();
-            }
-            return;
-        }
-        if let Some(g) = gap {
-            let cur = self.txs.state.selected().unwrap_or(0);
-            if cur + 1 == g {
-                self.gap_selected = true;
-                return;
-            }
-        }
-        self.txs.next();
+        self.tx_list_step(1);
     }
 
-    /// Step the tx-list selection up. Symmetric to `tx_list_next` w.r.t. the
-    /// gap row.
     pub fn tx_list_previous(&mut self) {
+        self.tx_list_step(-1);
+    }
+
+    /// Jump toward the first row, clamping on the first gap row crossed.
+    pub fn tx_list_select_first(&mut self) {
         if self.txs.items.is_empty() {
             return;
         }
-        let gap = self.gap_pos();
-        if self.gap_selected {
-            self.gap_selected = false;
-            if let Some(g) = gap {
-                let target = g.saturating_sub(1);
-                self.txs.state.select(Some(target));
-            } else {
-                self.txs.previous();
-            }
-            return;
-        }
-        if let Some(g) = gap {
-            let cur = self.txs.state.selected().unwrap_or(0);
-            if cur == g {
-                self.gap_selected = true;
-                return;
-            }
-        }
-        self.txs.previous();
+        let gaps = self.gap_render_positions();
+        let cur = self.current_rendered(&gaps);
+        let final_r = Self::first_gap_crossed(&gaps, cur, 0).unwrap_or(0);
+        self.apply_rendered(final_r, &gaps);
     }
 
-    pub fn tx_list_select_first(&mut self) {
-        self.gap_selected = false;
-        self.txs.select_first();
-    }
-
-    /// Jump to the last tx. If the cursor is currently above the gap row, the
-    /// jump clamps on the gap so the user can decide whether to load it or
-    /// step past with another keypress.
+    /// Jump toward the last row, clamping on the first gap row crossed.
     pub fn tx_list_select_last(&mut self) {
         if self.txs.items.is_empty() {
             return;
         }
-        if let Some(g) = self.gap_pos() {
-            let above_gap =
-                !self.gap_selected && self.txs.state.selected().is_none_or(|cur| cur < g);
-            if above_gap {
-                self.gap_selected = true;
-                return;
-            }
-        }
-        self.gap_selected = false;
-        self.txs.select_last();
+        let gaps = self.gap_render_positions();
+        let rendered_max = self.rendered_len(&gaps).saturating_sub(1);
+        let cur = self.current_rendered(&gaps);
+        let final_r = Self::first_gap_crossed(&gaps, cur, rendered_max).unwrap_or(rendered_max);
+        self.apply_rendered(final_r, &gaps);
     }
 
-    /// Scroll the tx-list selection by `delta`. If the gap row sits between
-    /// the current selection and the target, selection clamps on the gap row.
     pub fn tx_list_scroll_by(&mut self, delta: i64) {
-        if self.txs.items.is_empty() || delta == 0 {
-            return;
-        }
-        let gap = self.gap_pos();
-        let last_tx = self.txs.items.len() as i64 - 1;
-        let cur_tx = self.txs.state.selected().unwrap_or(0) as i64;
-        let cur_rendered = match (self.gap_selected, gap) {
-            (true, Some(g)) => g as i64,
-            (false, Some(g)) if cur_tx >= g as i64 => cur_tx + 1,
-            _ => cur_tx,
-        };
-        let rendered_last = last_tx + if gap.is_some() { 1 } else { 0 };
-        let target_rendered = (cur_rendered + delta).clamp(0, rendered_last);
-        let final_rendered = match gap {
-            Some(g) => {
-                let g = g as i64;
-                if cur_rendered != g && (cur_rendered < g) != (target_rendered < g) {
-                    g
-                } else {
-                    target_rendered
-                }
-            }
-            None => target_rendered,
-        };
-        match gap {
-            Some(g) if final_rendered == g as i64 => {
-                self.gap_selected = true;
-            }
-            Some(g) => {
-                self.gap_selected = false;
-                let tx_idx = if final_rendered < g as i64 {
-                    final_rendered as usize
-                } else {
-                    (final_rendered - 1) as usize
-                };
-                self.txs.state.select(Some(tx_idx));
-            }
-            None => {
-                self.gap_selected = false;
-                self.txs.state.select(Some(final_rendered as usize));
-            }
-        }
+        self.tx_list_step(delta);
     }
 }
 
@@ -669,14 +691,14 @@ mod tests {
     #[test]
     fn no_gap_when_contiguous() {
         let state = state_with(vec![summary(10, 100), summary(11, 102), summary(12, 104)]);
-        assert!(state.detect_unfilled_gap().is_none());
+        assert!(state.detect_unfilled_gaps().is_empty());
     }
 
     #[test]
     fn no_gap_for_small_span() {
         // Gap spans only 30 blocks — RPC small-gap path handles this.
         let state = state_with(vec![summary(10, 100), summary(16, 130)]);
-        assert!(state.detect_unfilled_gap().is_none());
+        assert!(state.detect_unfilled_gaps().is_empty());
     }
 
     #[test]
@@ -684,7 +706,9 @@ mod tests {
         // Only 2 missing nonces but span = 100 blocks > SMALL_GAP_SPAN_BLOCKS.
         // This is the medium-gap case that would otherwise be silently dropped.
         let state = state_with(vec![summary(10, 100), summary(13, 200)]);
-        let g = state.detect_unfilled_gap().expect("wide-span gap expected");
+        let gaps = state.detect_unfilled_gaps();
+        assert_eq!(gaps.len(), 1);
+        let g = &gaps[0];
         assert_eq!(g.lo_nonce, 10);
         assert_eq!(g.hi_nonce, 13);
         assert_eq!(g.missing_count, 2);
@@ -693,45 +717,44 @@ mod tests {
 
     #[test]
     fn detects_gap_by_block_span() {
-        // Large block span well above the RPC small-gap limit.
         let state = state_with(vec![summary(10, 100), summary(21, 2000)]);
-        let g = state.detect_unfilled_gap().expect("wide-span gap expected");
-        assert_eq!(g.lo_nonce, 10);
-        assert_eq!(g.hi_nonce, 21);
-        assert_eq!(g.missing_count, 10);
+        let gaps = state.detect_unfilled_gaps();
+        assert_eq!(gaps.len(), 1);
+        assert_eq!(gaps[0].lo_nonce, 10);
+        assert_eq!(gaps[0].hi_nonce, 21);
+        assert_eq!(gaps[0].missing_count, 10);
     }
 
     #[test]
     fn gap_threshold_boundary() {
-        // Exactly at the threshold: span == SMALL_GAP_SPAN_BLOCKS → no defer.
+        // Exactly at the threshold: span == SMALL_GAP_SPAN_BLOCKS → not deferred.
         let state = state_with(vec![
             summary(10, 100),
             summary(12, 100 + SMALL_GAP_SPAN_BLOCKS),
         ]);
-        assert!(state.detect_unfilled_gap().is_none());
+        assert!(state.detect_unfilled_gaps().is_empty());
 
-        // One over: span == SMALL_GAP_SPAN_BLOCKS + 1 → deferred.
+        // One over → deferred.
         let state = state_with(vec![
             summary(10, 100),
             summary(12, 100 + SMALL_GAP_SPAN_BLOCKS + 1),
         ]);
-        assert!(state.detect_unfilled_gap().is_some());
+        assert_eq!(state.detect_unfilled_gaps().len(), 1);
     }
 
     #[test]
     fn contract_addresses_never_report_gap() {
         let mut state = state_with(vec![summary(10, 100), summary(200, 500)]);
         state.is_contract = true;
-        assert!(state.detect_unfilled_gap().is_none());
+        assert!(state.detect_unfilled_gaps().is_empty());
     }
 
     #[test]
-    fn reset_clears_unfilled_gap() {
-        // Guards the 'r'-refresh path: `NavigateToAddress` calls `reset()`, and
-        // the UI hint "retry with 'r'" only works if this wipes
-        // `unfilled_gap` + `fill_dispatched` so the next load re-detects.
+    fn reset_clears_unfilled_gaps() {
+        // Guards the 'r'-refresh path: `NavigateToAddress` calls `reset()`,
+        // and the next load re-detects from scratch.
         let mut state = state_with(vec![summary(10, 100), summary(21, 2000)]);
-        state.unfilled_gap = Some(UnfilledGap {
+        state.unfilled_gaps.push(UnfilledGap {
             lo_nonce: 10,
             hi_nonce: 21,
             lo_block: 100,
@@ -741,23 +764,44 @@ mod tests {
         });
         state.sanity_check_dispatched = true;
         state.clear();
-        assert!(state.unfilled_gap.is_none());
+        assert!(state.unfilled_gaps.is_empty());
         assert!(!state.sanity_check_dispatched);
     }
 
     #[test]
-    fn biggest_gap_wins_when_multiple() {
+    fn detects_every_qualifying_gap() {
         let state = state_with(vec![
             summary(10, 100),
-            summary(20, 110),   // 9 missing
-            summary(200, 5000), // 179 missing — winner
+            summary(20, 1100),  // 9 missing, span 1000 → deferred
+            summary(22, 1110),  // 1 missing, span 10 → small (skipped)
+            summary(200, 5000), // 177 missing, span 3890 → deferred
             summary(201, 5001),
         ]);
-        let g = state
-            .detect_unfilled_gap()
-            .expect("should pick biggest gap");
-        assert_eq!(g.lo_nonce, 20);
-        assert_eq!(g.hi_nonce, 200);
-        assert_eq!(g.missing_count, 179);
+        let gaps = state.detect_unfilled_gaps();
+        assert_eq!(gaps.len(), 2);
+        let los: Vec<u64> = gaps.iter().map(|g| g.lo_nonce).collect();
+        assert_eq!(los, vec![10, 22]);
+    }
+
+    #[test]
+    fn refresh_preserves_dispatched_flag() {
+        let mut state = state_with(vec![summary(10, 100), summary(21, 2000)]);
+        state.unfilled_gaps = state.detect_unfilled_gaps();
+        state.unfilled_gaps[0].fill_dispatched = true;
+        state.refresh_unfilled_gaps();
+        assert_eq!(state.unfilled_gaps.len(), 1);
+        assert!(state.unfilled_gaps[0].fill_dispatched);
+    }
+
+    #[test]
+    fn refresh_drops_stale_gap_selection() {
+        let mut state = state_with(vec![summary(10, 100), summary(21, 2000)]);
+        state.unfilled_gaps = state.detect_unfilled_gaps();
+        state.gap_selected = Some(10);
+        // Replace tx data so the gap closes.
+        state.txs.items = (10..=21).map(|n| summary(n, 100 + n)).collect();
+        state.refresh_unfilled_gaps();
+        assert!(state.unfilled_gaps.is_empty());
+        assert!(state.gap_selected.is_none());
     }
 }

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -2218,9 +2218,10 @@ pub(super) async fn run_nonce_gap_fill(
         "Gap fill: filling large nonce gap on demand"
     );
 
+    let chunk = crate::app::views::address_info::LARGE_GAP_FILL_CHUNK_TXS;
     let _ = action_tx.send(Action::LoadingStatus(format!(
-        "Filling gap of {} txs...",
-        gap.missing_count
+        "Filling gap (up to {} txs of {})...",
+        chunk, gap.missing_count
     )));
 
     let found = fill_specific_large_gap(address, &known_txs, &gap, dune, pf, action_tx).await;
@@ -2466,22 +2467,28 @@ async fn fill_specific_large_gap(
 ) -> Vec<crate::data::types::AddressTxSummary> {
     let from = gap.lo_block;
     let to = gap.hi_block;
+    let chunk = crate::app::views::address_info::LARGE_GAP_FILL_CHUNK_TXS;
     let known_hashes: std::collections::HashSet<_> = known_txs.iter().map(|t| t.hash).collect();
 
     // Pathfinder primary. `before_block` is exclusive in the pf-query API,
     // so pass `to + 1` to keep the gap's upper bound inclusive — matching
-    // the Dune BETWEEN semantics this used to use.
+    // the Dune BETWEEN semantics this used to use. We cap at
+    // `LARGE_GAP_FILL_CHUNK_TXS` so multi-thousand-tx gaps fill lazily,
+    // one Enter at a time; pf-query orders results `block_number DESC`,
+    // so each chunk shrinks the gap from its newer edge.
     if let Some(pf_c) = pf.as_ref() {
         info!(
             from,
             to,
             span = to.saturating_sub(from),
-            "Gap fill: querying Pathfinder for blocks {}..{}",
+            chunk,
+            "Gap fill: querying Pathfinder for blocks {}..{} (limit {})",
             from,
-            to
+            to,
+            chunk
         );
         match pf_c
-            .get_sender_txs(address, 1000, Some(to.saturating_add(1)), Some(from))
+            .get_sender_txs(address, chunk, Some(to.saturating_add(1)), Some(from))
             .await
         {
             Ok(entries) => {
@@ -2526,13 +2533,15 @@ async fn fill_specific_large_gap(
         from,
         to,
         span = to.saturating_sub(from),
-        "Gap fill: querying Dune for blocks {}..{}",
+        chunk,
+        "Gap fill: querying Dune for blocks {}..{} (limit {})",
         from,
-        to
+        to,
+        chunk
     );
 
     match dune_c
-        .query_account_txs_windowed(address, from, to, 1000)
+        .query_account_txs_windowed(address, from, to, chunk)
         .await
     {
         Ok(dune_txs) => {

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -2249,8 +2249,11 @@ pub(super) async fn run_nonce_gap_fill(
         enrich_all_empty_endpoints(address, &combined, ds, pf.as_ref(), abi_reg, action_tx).await;
     } else {
         info!("Gap fill: no txs returned for this range");
-        let _ = action_tx.send(Action::LoadingStatus(String::new()));
     }
+    // Always clear the loading status so the "Filling gap…" line doesn't
+    // linger after the response (it used to only clear on the empty-result
+    // branch — successful fills left it hanging until the next status push).
+    let _ = action_tx.send(Action::LoadingStatus(String::new()));
 
     debug!(
         address = %format!("{:#x}", address),

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -484,102 +484,92 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
         return;
     }
 
-    // If a large nonce gap is deferred, remember its (hi_nonce → lo_nonce)
-    // boundary so we can render a divider above the row where the jump occurs.
-    let gap_boundary: Option<(u64, u64, u64, bool)> = app
+    // Position (in `txs.items`) where the gap row should be rendered just
+    // above. `None` when no deferred gap is showing, or the lo-nonce tx isn't
+    // in the loaded list yet.
+    let gap_pos = app.address.gap_pos();
+    let gap_info: Option<(u64, bool)> = app
         .address
         .unfilled_gap
         .as_ref()
-        .map(|g| (g.hi_nonce, g.lo_nonce, g.missing_count, g.fill_dispatched));
+        .map(|g| (g.missing_count, g.fill_dispatched));
 
-    let mut prev_nonce: Option<u64> = None;
-    let items: Vec<ListItem> = app
-        .address
-        .txs
-        .items
-        .iter()
-        .map(|tx| {
-            let fee_str = format_strk_u128(tx.total_fee_fri)
-                .trim_end_matches(" STRK")
-                .to_string();
-            let tip_str = if tx.tip > 0 {
-                format_fri(tx.tip as u128)
+    let mut items: Vec<ListItem> =
+        Vec::with_capacity(app.address.txs.items.len() + if gap_pos.is_some() { 1 } else { 0 });
+    for (idx, tx) in app.address.txs.items.iter().enumerate() {
+        if Some(idx) == gap_pos
+            && let Some((missing, dispatched)) = gap_info
+        {
+            let msg = if dispatched {
+                format!(" ── gap of {missing} txs — loading / press r to retry ──")
             } else {
-                "0".to_string()
+                format!(" ── {missing} txs hidden — press Enter to load ──")
             };
-            let age = format_age(tx.timestamp);
-            let endpoint = if tx.endpoint_names.chars().count() > 30 {
-                let truncated: String = tx.endpoint_names.chars().take(29).collect();
-                format!("{truncated}…")
-            } else {
-                tx.endpoint_names.clone()
-            };
-            let contracts_display = format_called_contracts(app, &tx.called_contracts);
+            items.push(ListItem::new(Line::from(Span::styled(
+                msg,
+                theme::SUGGESTION_STYLE,
+            ))));
+        }
 
-            let status_style = match tx.status.as_str() {
-                "OK" => theme::STATUS_OK,
-                "REV" => theme::STATUS_REVERTED,
-                _ => theme::SUGGESTION_STYLE,
-            };
+        let fee_str = format_strk_u128(tx.total_fee_fri)
+            .trim_end_matches(" STRK")
+            .to_string();
+        let tip_str = if tx.tip > 0 {
+            format_fri(tx.tip as u128)
+        } else {
+            "0".to_string()
+        };
+        let age = format_age(tx.timestamp);
+        let endpoint = if tx.endpoint_names.chars().count() > 30 {
+            let truncated: String = tx.endpoint_names.chars().take(29).collect();
+            format!("{truncated}…")
+        } else {
+            tx.endpoint_names.clone()
+        };
+        let contracts_display = format_called_contracts(app, &tx.called_contracts);
 
-            let type_style = match tx.tx_type.as_str() {
-                "INVOKE" => theme::TX_TYPE_INVOKE,
-                "DECLARE" => theme::TX_TYPE_DECLARE,
-                "DEPLOY_ACCOUNT" | "DEPLOY" => theme::TX_TYPE_DEPLOY,
-                "L1_HANDLER" => theme::TX_TYPE_L1HANDLER,
-                _ => theme::NORMAL_STYLE,
-            };
+        let status_style = match tx.status.as_str() {
+            "OK" => theme::STATUS_OK,
+            "REV" => theme::STATUS_REVERTED,
+            _ => theme::SUGGESTION_STYLE,
+        };
 
-            let main_line = Line::from(vec![
-                Span::styled(format!(" {:<8}", tx.nonce), theme::NORMAL_STYLE),
-                Span::styled(format!("{:<15}", tx.tx_type), type_style),
-                Span::styled(
-                    format!("{:<14}", short_hash(&tx.hash)),
-                    theme::TX_HASH_STYLE,
-                ),
-                Span::styled(format!("{:<30}", contracts_display), theme::LABEL_STYLE),
-                Span::styled(format!("{:<31}", endpoint), theme::LABEL_STYLE),
-                Span::styled(format!("{:<17}", fee_str), theme::TX_FEE_STYLE),
-                Span::styled(format!("{:<17}", tip_str), theme::SUGGESTION_STYLE),
-                Span::styled(
-                    format!("#{:<9}", tx.block_number),
-                    theme::BLOCK_NUMBER_STYLE,
-                ),
-                Span::styled(format!("{:<4}", &tx.status), status_style),
-                Span::styled(age, theme::BLOCK_AGE_STYLE),
-            ]);
+        let type_style = match tx.tx_type.as_str() {
+            "INVOKE" => theme::TX_TYPE_INVOKE,
+            "DECLARE" => theme::TX_TYPE_DECLARE,
+            "DEPLOY_ACCOUNT" | "DEPLOY" => theme::TX_TYPE_DEPLOY,
+            "L1_HANDLER" => theme::TX_TYPE_L1HANDLER,
+            _ => theme::NORMAL_STYLE,
+        };
 
-            // Insert a dimmed divider above the row that sits on the far side
-            // of the unfilled gap (i.e. when we're about to step from hi_nonce
-            // down to lo_nonce in the descending list).
-            let separator: Option<Line> = match (prev_nonce, gap_boundary) {
-                (Some(prev), Some((hi, lo, missing, dispatched)))
-                    if prev == hi && tx.nonce == lo =>
-                {
-                    let msg = if dispatched {
-                        format!(" ── gap of {missing} txs — loading / retry with 'r' ──")
-                    } else {
-                        format!(" ── {missing} txs hidden — scroll down to load ──")
-                    };
-                    Some(Line::from(Span::styled(msg, theme::SUGGESTION_STYLE)))
-                }
-                _ => None,
-            };
-            prev_nonce = Some(tx.nonce);
-
-            let lines = match separator {
-                Some(sep) => vec![sep, main_line],
-                None => vec![main_line],
-            };
-            ListItem::new(lines)
-        })
-        .collect();
+        let main_line = Line::from(vec![
+            Span::styled(format!(" {:<8}", tx.nonce), theme::NORMAL_STYLE),
+            Span::styled(format!("{:<15}", tx.tx_type), type_style),
+            Span::styled(
+                format!("{:<14}", short_hash(&tx.hash)),
+                theme::TX_HASH_STYLE,
+            ),
+            Span::styled(format!("{:<30}", contracts_display), theme::LABEL_STYLE),
+            Span::styled(format!("{:<31}", endpoint), theme::LABEL_STYLE),
+            Span::styled(format!("{:<17}", fee_str), theme::TX_FEE_STYLE),
+            Span::styled(format!("{:<17}", tip_str), theme::SUGGESTION_STYLE),
+            Span::styled(
+                format!("#{:<9}", tx.block_number),
+                theme::BLOCK_NUMBER_STYLE,
+            ),
+            Span::styled(format!("{:<4}", &tx.status), status_style),
+            Span::styled(age, theme::BLOCK_AGE_STYLE),
+        ]);
+        items.push(ListItem::new(main_line));
+    }
 
     let gap_suffix = match &app.address.unfilled_gap {
-        Some(g) if !g.fill_dispatched => format!(
-            " — {} older txs deferred (scroll down to load) ",
-            g.missing_count
-        ),
+        Some(g) if !g.fill_dispatched => {
+            format!(
+                " — {} older txs deferred (Enter on gap row to load) ",
+                g.missing_count
+            )
+        }
         Some(g) => format!(" — gap of {} txs (press r to retry) ", g.missing_count),
         None => String::new(),
     };
@@ -600,7 +590,11 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
         .highlight_style(theme::SELECTED_STYLE.add_modifier(Modifier::BOLD))
         .highlight_symbol(">> ");
 
-    f.render_stateful_widget(list, list_area, &mut app.address.txs.state);
+    // Sync rendered selection (gap-aware) into the persistent render state.
+    app.address
+        .txs_render_state
+        .select(app.address.tx_list_rendered_selected());
+    f.render_stateful_widget(list, list_area, &mut app.address.txs_render_state);
 }
 
 /// Render the contracts-called column: up to the first two contract labels

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -484,31 +484,36 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
         return;
     }
 
-    // Position (in `txs.items`) where the gap row should be rendered just
-    // above. `None` when no deferred gap is showing, or the lo-nonce tx isn't
-    // in the loaded list yet.
-    let gap_pos = app.address.gap_pos();
-    let gap_info: Option<(u64, bool)> = app
-        .address
-        .unfilled_gap
-        .as_ref()
-        .map(|g| (g.missing_count, g.fill_dispatched));
+    // (tx_idx, lo_nonce) for each gap, sorted by tx_idx ascending. Each gap
+    // renders as its own ListItem above the lo_nonce tx.
+    let gap_positions = app.address.gap_render_positions();
+    let mut next_gap = gap_positions.iter().peekable();
+    let gap_info_for_lo = |lo: u64| -> Option<(u64, bool)> {
+        app.address
+            .unfilled_gaps
+            .iter()
+            .find(|g| g.lo_nonce == lo)
+            .map(|g| (g.missing_count, g.fill_dispatched))
+    };
 
     let mut items: Vec<ListItem> =
-        Vec::with_capacity(app.address.txs.items.len() + if gap_pos.is_some() { 1 } else { 0 });
+        Vec::with_capacity(app.address.txs.items.len() + gap_positions.len());
     for (idx, tx) in app.address.txs.items.iter().enumerate() {
-        if Some(idx) == gap_pos
-            && let Some((missing, dispatched)) = gap_info
+        while let Some(&&(p, lo)) = next_gap.peek()
+            && p == idx
         {
-            let msg = if dispatched {
-                format!(" ── gap of {missing} txs — loading / press r to retry ──")
-            } else {
-                format!(" ── {missing} txs hidden — press Enter to load ──")
-            };
-            items.push(ListItem::new(Line::from(Span::styled(
-                msg,
-                theme::SUGGESTION_STYLE,
-            ))));
+            if let Some((missing, dispatched)) = gap_info_for_lo(lo) {
+                let msg = if dispatched {
+                    format!(" ── gap of {missing} txs — loading / press r to retry ──")
+                } else {
+                    format!(" ── {missing} txs hidden — press Enter to load ──")
+                };
+                items.push(ListItem::new(Line::from(Span::styled(
+                    msg,
+                    theme::SUGGESTION_STYLE,
+                ))));
+            }
+            next_gap.next();
         }
 
         let fee_str = format_strk_u128(tx.total_fee_fri)
@@ -563,15 +568,28 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
         items.push(ListItem::new(main_line));
     }
 
-    let gap_suffix = match &app.address.unfilled_gap {
-        Some(g) if !g.fill_dispatched => {
+    let gap_suffix = if app.address.unfilled_gaps.is_empty() {
+        String::new()
+    } else {
+        let total_missing: u64 = app
+            .address
+            .unfilled_gaps
+            .iter()
+            .map(|g| g.missing_count)
+            .sum();
+        let n = app.address.unfilled_gaps.len();
+        let any_pending = app.address.unfilled_gaps.iter().any(|g| !g.fill_dispatched);
+        if any_pending {
             format!(
-                " — {} older txs deferred (Enter on gap row to load) ",
-                g.missing_count
+                " — {n} gap{plural} ({total_missing} txs deferred, Enter on a gap row to load) ",
+                plural = if n == 1 { "" } else { "s" }
+            )
+        } else {
+            format!(
+                " — {n} gap{plural} ({total_missing} txs, press r to retry) ",
+                plural = if n == 1 { "" } else { "s" }
             )
         }
-        Some(g) => format!(" — gap of {} txs (press r to retry) ", g.missing_count),
-        None => String::new(),
     };
     let count = tx_count_fragment(app);
     let title = if app.is_loading {


### PR DESCRIPTION
## Summary
- Render the deferred nonce-gap divider as its own standalone row in the address Transactions tab, instead of bundling it into the ListItem of the tx below.
- Replace the implicit "scroll near bottom of list" auto-fill trigger with an explicit one: pressing Enter on the gap row dispatches the fill.
- Navigation (`j`/`k`/`Ctrl+D`/`Ctrl+U`/`G`) clamps on the gap row when crossing; another step past it scrolls onward without dispatching, so users can still reach the oldest known tx without burning a fill.

## Why
The current "── N txs hidden — scroll down to load ──" UX has two issues:
1. Selecting the divider line actually highlighted the tx below it (the divider was a sub-line of that tx's ListItem).
2. The expected user action wasn't clear — was the user supposed to scroll to the divider line, or all the way to the bottom of the list? In practice the trigger was the latter, but the message implied the former.

After this PR the gap row is its own selectable item, and the trigger is a deliberate Enter press — making the action discoverable and avoiding fills the user didn't want.

## Test plan
- [ ] Navigate to an address with a deferred nonce gap (e.g. one whose loaded tx history skips many nonces).
- [ ] `j`/`k`: confirm selection lands on the gap row instead of the tx below it; one more keypress steps past with no fill.
- [ ] `Ctrl+D` / `G`: confirm selection clamps on the gap row when crossing it from above; one more press scrolls onward without dispatching.
- [ ] Press `Enter` on the gap row: confirm the divider flips to "loading…" and the fill dispatches once.
- [ ] After the fill lands, confirm txs merge in and the gap divider either disappears or shows the residual gap with retry hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)