### PR TITLE
Add user-defined labels for transaction hashes

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -430,7 +430,7 @@ fn handle_search_mode(app: &mut App, key: KeyEvent) -> Option<Action> {
             let query = if !app.search_suggestions.is_empty()
                 && app.search_selected < app.search_suggestions.len()
             {
-                format!("{:#x}", app.search_suggestions[app.search_selected].address)
+                format!("{:#x}", app.search_suggestions[app.search_selected].felt)
             } else {
                 app.search_input.clone()
             };

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -827,6 +827,23 @@ impl App {
         }
     }
 
+    /// Format a tx hash using the registry (user label if present, short hash otherwise).
+    pub fn format_tx_hash(&self, hash: &starknet::core::types::Felt) -> String {
+        if let Some(engine) = &self.search_engine {
+            engine.registry().format_tx_hash(hash)
+        } else {
+            crate::ui::widgets::hex_display::short_hash(hash)
+        }
+    }
+
+    /// Whether this tx hash has a user-supplied label.
+    pub fn is_known_tx(&self, hash: &starknet::core::types::Felt) -> bool {
+        self.search_engine
+            .as_ref()
+            .map(|e| e.registry().is_known_tx(hash))
+            .unwrap_or(false)
+    }
+
     /// Format an address showing both user and global labels (for detail views).
     /// Falls back to a Voyager-sourced label when the registry has no entry.
     pub fn format_address_full(&self, address: &starknet::core::types::Felt) -> String {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -827,21 +827,10 @@ impl App {
         }
     }
 
-    /// Format a tx hash using the registry (user label if present, short hash otherwise).
-    pub fn format_tx_hash(&self, hash: &starknet::core::types::Felt) -> String {
-        if let Some(engine) = &self.search_engine {
-            engine.registry().format_tx_hash(hash)
-        } else {
-            crate::ui::widgets::hex_display::short_hash(hash)
-        }
-    }
-
-    /// Whether this tx hash has a user-supplied label.
-    pub fn is_known_tx(&self, hash: &starknet::core::types::Felt) -> bool {
-        self.search_engine
-            .as_ref()
-            .map(|e| e.registry().is_known_tx(hash))
-            .unwrap_or(false)
+    /// Resolve a tx hash to its user label, if any. Single registry lookup —
+    /// callers can derive both the displayed string and a style from the result.
+    pub fn resolve_tx(&self, hash: &starknet::core::types::Felt) -> Option<&str> {
+        self.search_engine.as_ref()?.registry().resolve_tx(hash)
     }
 
     /// Format an address showing both user and global labels (for detail views).

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -255,7 +255,9 @@ impl AddressRegistry {
     }
 
     /// Look up an entry by exact label name (case-insensitive). Returns the
-    /// felt (address or tx hash) and its kind so callers can route navigation.
+    /// matched felt (address or tx hash). On a name collision between an
+    /// address label and a tx label, the address wins (insertion order is
+    /// preserved by the stable sort that builds the index).
     pub fn resolve_by_name(&self, name: &str) -> Option<Felt> {
         let lower = name.to_lowercase();
         let index = self.search_index.read().unwrap();
@@ -296,31 +298,12 @@ impl AddressRegistry {
         self.resolve(address).is_some()
     }
 
-    /// Check if a tx hash has a user label.
-    pub fn is_known_tx(&self, hash: &Felt) -> bool {
-        self.resolve_tx(hash).is_some()
-    }
-
     /// Format an address for display: label if known, truncated hex otherwise.
     pub fn format_address(&self, address: &Felt) -> String {
         if let Some(name) = self.resolve(address) {
             format!("[{}]", name)
         } else {
             let hex = format!("{:#x}", address);
-            if hex.len() > 14 {
-                format!("{}..{}", &hex[..6], &hex[hex.len() - 4..])
-            } else {
-                hex
-            }
-        }
-    }
-
-    /// Format a tx hash: user label if present, short hash otherwise.
-    pub fn format_tx_hash(&self, hash: &Felt) -> String {
-        if let Some(name) = self.resolve_tx(hash) {
-            format!("[{}]", name)
-        } else {
-            let hex = format!("{:#x}", hash);
             if hex.len() > 14 {
                 format!("{}..{}", &hex[..6], &hex[hex.len() - 4..])
             } else {
@@ -374,7 +357,9 @@ fn format_search_result(entry: &SearchEntry) -> String {
         EntryKind::Address => "",
         EntryKind::Transaction => " [tx]",
     };
-    format!("{}{} ({})", entry.display_name, kind_tag, short)
+    // The kind tag goes after the closing paren so `extract_name_from_display`
+    // (which splits on " (") still recovers the bare label name for Tab-complete.
+    format!("{} ({}){}", entry.display_name, short, kind_tag)
 }
 
 fn make_result(entry: &SearchEntry) -> SearchResult {

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -9,14 +9,24 @@ use tracing::info;
 
 use crate::error::Result;
 use known_addresses::{KnownAddress, load_known_addresses};
-use user_labels::{UserLabel, load_user_labels};
+use user_labels::{UserLabel, UserTxLabel, load_user_labels};
 
-/// Unified address registry over user labels + known addresses.
+/// What kind of on-chain entity a search entry/result points at. Drives
+/// downstream navigation (address view vs transaction detail view).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntryKind {
+    Address,
+    Transaction,
+}
+
+/// Unified address + tx-hash registry over user labels + known addresses.
 /// User labels take priority over known addresses.
 /// Pre-builds a search index for fast prefix/substring matching.
 pub struct AddressRegistry {
-    /// User labels (highest priority)
+    /// User address labels (highest priority)
     user: Vec<UserLabel>,
+    /// User transaction labels
+    tx_labels: Vec<UserTxLabel>,
     /// Known addresses (curated)
     known: Vec<KnownAddress>,
     /// Search index: sorted entries for fast lookup.
@@ -28,19 +38,23 @@ pub struct AddressRegistry {
 struct SearchEntry {
     name_lower: String,
     display_name: String,
-    address: Felt,
+    /// Address or tx hash, depending on `kind`.
+    felt: Felt,
     hex_lower: String,
     is_user: bool,
     /// Lowercase tags for search matching (user labels only).
     tags_lower: Vec<String>,
+    kind: EntryKind,
 }
 
 /// A search result returned to the UI.
 #[derive(Debug, Clone)]
 pub struct SearchResult {
     pub display: String,
-    pub address: Felt,
+    /// Address or tx hash, depending on `kind`.
+    pub felt: Felt,
     pub is_user: bool,
+    pub kind: EntryKind,
 }
 
 /// Metadata for a resolved address.
@@ -56,10 +70,10 @@ impl AddressRegistry {
     /// Load from user labels file and bundled known addresses.
     /// Returns (registry, optional_warning) — warning is set when labels file is corrupt.
     pub fn load(user_labels_path: &Path) -> Result<(Self, Option<String>)> {
-        let (user, warning) = load_user_labels(user_labels_path)?;
+        let (user, tx_labels, warning) = load_user_labels(user_labels_path)?;
         let known = load_known_addresses()?;
 
-        let mut search_index = Vec::with_capacity(user.len() + known.len());
+        let mut search_index = Vec::with_capacity(user.len() + tx_labels.len() + known.len());
 
         // User labels first (higher priority in search results)
         for label in &user {
@@ -67,10 +81,25 @@ impl AddressRegistry {
             search_index.push(SearchEntry {
                 name_lower: label.name.to_lowercase(),
                 display_name: label.name.clone(),
-                address: label.address,
+                felt: label.address,
                 hex_lower: hex.to_lowercase(),
                 is_user: true,
                 tags_lower: label.tags.iter().map(|t| t.to_lowercase()).collect(),
+                kind: EntryKind::Address,
+            });
+        }
+
+        // User tx labels: same priority as address labels (the user added them)
+        for label in &tx_labels {
+            let hex = format!("{:#x}", label.hash);
+            search_index.push(SearchEntry {
+                name_lower: label.name.to_lowercase(),
+                display_name: label.name.clone(),
+                felt: label.hash,
+                hex_lower: hex.to_lowercase(),
+                is_user: true,
+                tags_lower: Vec::new(),
+                kind: EntryKind::Transaction,
             });
         }
 
@@ -84,10 +113,11 @@ impl AddressRegistry {
             search_index.push(SearchEntry {
                 name_lower: addr.name.to_lowercase(),
                 display_name: addr.name.clone(),
-                address: addr.address,
+                felt: addr.address,
                 hex_lower: hex.to_lowercase(),
                 is_user: false,
                 tags_lower: Vec::new(),
+                kind: EntryKind::Address,
             });
         }
 
@@ -96,6 +126,7 @@ impl AddressRegistry {
 
         info!(
             user = user.len(),
+            tx_labels = tx_labels.len(),
             known = known.len(),
             index = search_index.len(),
             "Address registry loaded"
@@ -104,6 +135,7 @@ impl AddressRegistry {
         Ok((
             Self {
                 user,
+                tx_labels,
                 known,
                 search_index: RwLock::new(search_index),
             },
@@ -122,6 +154,14 @@ impl AddressRegistry {
             return Some(&addr.name);
         }
         None
+    }
+
+    /// Resolve a transaction hash to its user-supplied display name.
+    pub fn resolve_tx(&self, hash: &Felt) -> Option<&str> {
+        self.tx_labels
+            .iter()
+            .find(|t| t.hash == *hash)
+            .map(|t| t.name.as_str())
     }
 
     /// Get metadata for an address.
@@ -167,11 +207,7 @@ impl AddressRegistry {
         // Prefix matches first (highest relevance)
         for entry in index.iter() {
             if entry.name_lower.starts_with(&query_lower) {
-                results.push(SearchResult {
-                    display: format_search_result(entry),
-                    address: entry.address,
-                    is_user: entry.is_user,
-                });
+                results.push(make_result(entry));
             }
             if results.len() >= limit {
                 return results;
@@ -180,7 +216,10 @@ impl AddressRegistry {
 
         // Then substring matches (name or tags)
         for entry in index.iter() {
-            if results.iter().any(|r| r.address == entry.address) {
+            if results
+                .iter()
+                .any(|r| r.felt == entry.felt && r.kind == entry.kind)
+            {
                 continue;
             }
             let name_match = entry.name_lower.contains(&query_lower);
@@ -189,11 +228,7 @@ impl AddressRegistry {
                 .iter()
                 .any(|t| t.starts_with(&query_lower) || t.contains(&query_lower));
             if name_match || tag_match {
-                results.push(SearchResult {
-                    display: format_search_result(entry),
-                    address: entry.address,
-                    is_user: entry.is_user,
-                });
+                results.push(make_result(entry));
             }
             if results.len() >= limit {
                 return results;
@@ -204,13 +239,11 @@ impl AddressRegistry {
         if query_lower.starts_with("0x") {
             for entry in index.iter() {
                 if entry.hex_lower.starts_with(&query_lower)
-                    && !results.iter().any(|r| r.address == entry.address)
+                    && !results
+                        .iter()
+                        .any(|r| r.felt == entry.felt && r.kind == entry.kind)
                 {
-                    results.push(SearchResult {
-                        display: format_search_result(entry),
-                        address: entry.address,
-                        is_user: entry.is_user,
-                    });
+                    results.push(make_result(entry));
                 }
                 if results.len() >= limit {
                     return results;
@@ -221,32 +254,35 @@ impl AddressRegistry {
         results
     }
 
-    /// Look up an address by exact label name (case-insensitive).
+    /// Look up an entry by exact label name (case-insensitive). Returns the
+    /// felt (address or tx hash) and its kind so callers can route navigation.
     pub fn resolve_by_name(&self, name: &str) -> Option<Felt> {
         let lower = name.to_lowercase();
         let index = self.search_index.read().unwrap();
-        index
-            .iter()
-            .find(|e| e.name_lower == lower)
-            .map(|e| e.address)
+        index.iter().find(|e| e.name_lower == lower).map(|e| e.felt)
     }
 
     /// Add a Voyager-sourced label to the search index.
     /// Skips if the address already has an entry (user/known labels take priority).
     pub fn add_voyager_label(&self, address: Felt, name: &str) {
         let mut index = self.search_index.write().unwrap();
-        // Don't duplicate if address already indexed
-        if index.iter().any(|e| e.address == address) {
+        // Don't duplicate if address already indexed (only check Address-kind
+        // entries — a tx label sharing the same felt by accident is fine).
+        if index
+            .iter()
+            .any(|e| e.kind == EntryKind::Address && e.felt == address)
+        {
             return;
         }
         let hex = format!("{:#x}", address);
         let entry = SearchEntry {
             name_lower: name.to_lowercase(),
             display_name: name.to_string(),
-            address,
+            felt: address,
             hex_lower: hex.to_lowercase(),
             is_user: false,
             tags_lower: Vec::new(),
+            kind: EntryKind::Address,
         };
         // Insert sorted by name
         let pos = index
@@ -260,12 +296,31 @@ impl AddressRegistry {
         self.resolve(address).is_some()
     }
 
+    /// Check if a tx hash has a user label.
+    pub fn is_known_tx(&self, hash: &Felt) -> bool {
+        self.resolve_tx(hash).is_some()
+    }
+
     /// Format an address for display: label if known, truncated hex otherwise.
     pub fn format_address(&self, address: &Felt) -> String {
         if let Some(name) = self.resolve(address) {
             format!("[{}]", name)
         } else {
             let hex = format!("{:#x}", address);
+            if hex.len() > 14 {
+                format!("{}..{}", &hex[..6], &hex[hex.len() - 4..])
+            } else {
+                hex
+            }
+        }
+    }
+
+    /// Format a tx hash: user label if present, short hash otherwise.
+    pub fn format_tx_hash(&self, hash: &Felt) -> String {
+        if let Some(name) = self.resolve_tx(hash) {
+            format!("[{}]", name)
+        } else {
+            let hex = format!("{:#x}", hash);
             if hex.len() > 14 {
                 format!("{}..{}", &hex[..6], &hex[hex.len() - 4..])
             } else {
@@ -315,5 +370,18 @@ fn format_search_result(entry: &SearchEntry) -> String {
     } else {
         hex.clone()
     };
-    format!("{} ({})", entry.display_name, short)
+    let kind_tag = match entry.kind {
+        EntryKind::Address => "",
+        EntryKind::Transaction => " [tx]",
+    };
+    format!("{}{} ({})", entry.display_name, kind_tag, short)
+}
+
+fn make_result(entry: &SearchEntry) -> SearchResult {
+    SearchResult {
+        display: format_search_result(entry),
+        felt: entry.felt,
+        is_user: entry.is_user,
+        kind: entry.kind,
+    }
 }

--- a/src/registry/user_labels.rs
+++ b/src/registry/user_labels.rs
@@ -45,13 +45,19 @@ pub struct UserLabel {
     pub tags: Vec<String>,
 }
 
-/// Load user labels from a TOML file. Returns (labels, optional_warning).
+#[derive(Debug, Clone)]
+pub struct UserTxLabel {
+    pub hash: Felt,
+    pub name: String,
+}
+
+/// Load user labels from a TOML file. Returns (address_labels, tx_labels, optional_warning).
 /// On missing file: empty labels, no warning.
 /// On corrupt/malformed file: empty labels + warning string.
-pub fn load_user_labels(path: &Path) -> Result<(Vec<UserLabel>, Option<String>)> {
+pub fn load_user_labels(path: &Path) -> Result<(Vec<UserLabel>, Vec<UserTxLabel>, Option<String>)> {
     if !path.exists() {
         debug!(path = %path.display(), "User labels file not found, using empty");
-        return Ok((Vec::new(), None));
+        return Ok((Vec::new(), Vec::new(), None));
     }
 
     let content = std::fs::read_to_string(path)
@@ -63,7 +69,7 @@ pub fn load_user_labels(path: &Path) -> Result<(Vec<UserLabel>, Option<String>)>
             let msg =
                 format!("labels.toml is corrupted (TOML parse error: {e}) — no user labels loaded");
             warn!("{}", msg);
-            return Ok((Vec::new(), Some(msg)));
+            return Ok((Vec::new(), Vec::new(), Some(msg)));
         }
     };
 
@@ -87,6 +93,25 @@ pub fn load_user_labels(path: &Path) -> Result<(Vec<UserLabel>, Option<String>)>
         });
     }
 
-    debug!(count = labels.len(), "Loaded user labels");
-    Ok((labels, None))
+    let mut tx_labels = Vec::new();
+    for (hex, name) in &file.transactions {
+        let felt = match Felt::from_hex(hex) {
+            Ok(f) => f,
+            Err(e) => {
+                warn!(tx = hex, error = %e, "Invalid tx hash in labels file, skipping");
+                continue;
+            }
+        };
+        tx_labels.push(UserTxLabel {
+            hash: felt,
+            name: name.clone(),
+        });
+    }
+
+    debug!(
+        addresses = labels.len(),
+        transactions = tx_labels.len(),
+        "Loaded user labels"
+    );
+    Ok((labels, tx_labels, None))
 }

--- a/src/search/parser.rs
+++ b/src/search/parser.rs
@@ -7,7 +7,8 @@ use crate::registry::AddressRegistry;
 pub enum SearchQuery {
     /// Pure decimal number → block number.
     BlockNumber(u64),
-    /// Resolved from a known label → address.
+    /// Resolved from a known label → address or tx hash. The label kind isn't
+    /// carried here; downstream `resolve_search` infers it by querying RPC.
     Label(String, Felt),
     /// Hex that could be a tx hash or address — needs RPC to disambiguate.
     Ambiguous(Felt),

--- a/src/search/parser.rs
+++ b/src/search/parser.rs
@@ -43,7 +43,7 @@ pub fn classify(input: &str, registry: &AddressRegistry) -> Result<SearchQuery, 
         // Try as a partial name match — if exactly one result, use it
         let results = registry.search(trimmed, 2);
         if results.len() == 1 {
-            return Ok(SearchQuery::Label(trimmed.to_string(), results[0].address));
+            return Ok(SearchQuery::Label(trimmed.to_string(), results[0].felt));
         }
         return Err(format!("Cannot parse: {trimmed}"));
     };

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -10,7 +10,7 @@ use crate::app::state::TxNavItem;
 use crate::app::{AddressTab, App};
 use crate::data::types::TokenBalance;
 use crate::ui::theme;
-use crate::ui::widgets::hex_display::{format_fri, format_strk_u128, short_hash};
+use crate::ui::widgets::hex_display::{format_fri, format_strk_u128};
 use crate::ui::widgets::price;
 use crate::ui::widgets::{search_bar, status_bar};
 use crate::utils::{felt_to_u64, felt_to_u128};
@@ -547,13 +547,23 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
             _ => theme::NORMAL_STYLE,
         };
 
+        let tx_hash_label = app.format_tx_hash(&tx.hash);
+        let tx_hash_display = if tx_hash_label.chars().count() > 14 {
+            let truncated: String = tx_hash_label.chars().take(13).collect();
+            format!("{truncated}…")
+        } else {
+            tx_hash_label
+        };
+        let tx_hash_style = if app.is_known_tx(&tx.hash) {
+            theme::LABEL_STYLE
+        } else {
+            theme::TX_HASH_STYLE
+        };
+
         let main_line = Line::from(vec![
             Span::styled(format!(" {:<8}", tx.nonce), theme::NORMAL_STYLE),
             Span::styled(format!("{:<15}", tx.tx_type), type_style),
-            Span::styled(
-                format!("{:<14}", short_hash(&tx.hash)),
-                theme::TX_HASH_STYLE,
-            ),
+            Span::styled(format!("{:<14}", tx_hash_display), tx_hash_style),
             Span::styled(format!("{:<30}", contracts_display), theme::LABEL_STYLE),
             Span::styled(format!("{:<31}", endpoint), theme::LABEL_STYLE),
             Span::styled(format!("{:<17}", fee_str), theme::TX_FEE_STYLE),
@@ -752,13 +762,23 @@ fn draw_calls_tab(f: &mut Frame, app: &mut App, area: Rect) {
                 _ => theme::SUGGESTION_STYLE,
             };
 
+            let tx_hash_label = app.format_tx_hash(&call.tx_hash);
+            let tx_hash_display = if tx_hash_label.chars().count() > 14 {
+                let truncated: String = tx_hash_label.chars().take(13).collect();
+                format!("{truncated}…")
+            } else {
+                tx_hash_label
+            };
+            let tx_hash_style = if app.is_known_tx(&call.tx_hash) {
+                theme::LABEL_STYLE
+            } else {
+                theme::TX_HASH_STYLE
+            };
+
             let line = Line::from(vec![
                 Span::styled(format!(" {:<25} ", sender_display), theme::LABEL_STYLE),
                 Span::styled(format!("{:<31}", func), theme::LABEL_STYLE),
-                Span::styled(
-                    format!("{:<14}", short_hash(&call.tx_hash)),
-                    theme::TX_HASH_STYLE,
-                ),
+                Span::styled(format!("{:<14}", tx_hash_display), tx_hash_style),
                 Span::styled(format!("{:<10}", nonce_str), theme::NORMAL_STYLE),
                 Span::styled(format!("{:<17}", fee_str), theme::TX_FEE_STYLE),
                 Span::styled(format!("{:<17}", tip_str), theme::SUGGESTION_STYLE),
@@ -893,9 +913,22 @@ fn draw_meta_txs_tab(f: &mut Frame, app: &mut App, area: Rect) {
                 _ => theme::SUGGESTION_STYLE,
             };
 
+            let tx_hash_label = app.format_tx_hash(&m.hash);
+            let tx_hash_display = if tx_hash_label.chars().count() > 14 {
+                let truncated: String = tx_hash_label.chars().take(13).collect();
+                format!("{truncated}…")
+            } else {
+                tx_hash_label
+            };
+            let tx_hash_style = if app.is_known_tx(&m.hash) {
+                theme::LABEL_STYLE
+            } else {
+                theme::TX_HASH_STYLE
+            };
+
             let line = Line::from(vec![
                 Span::styled(format!(" {:<5}", age), theme::BLOCK_AGE_STYLE),
-                Span::styled(format!("{:<14}", short_hash(&m.hash)), theme::TX_HASH_STYLE),
+                Span::styled(format!("{:<14}", tx_hash_display), tx_hash_style),
                 Span::styled(
                     format!("#{:<10}", m.block_number),
                     theme::BLOCK_NUMBER_STYLE,
@@ -1045,12 +1078,24 @@ fn draw_events_tab(f: &mut Frame, app: &mut App, area: Rect) {
         .map(|event| {
             let contract = app.format_address(&event.contract_address);
             let name = event.event_name.as_deref().unwrap_or("?");
-            let tx_short = short_hash(&event.raw.transaction_hash);
+            let tx_hash = event.raw.transaction_hash;
+            let tx_label = app.format_tx_hash(&tx_hash);
+            let tx_display = if tx_label.chars().count() > 14 {
+                let truncated: String = tx_label.chars().take(13).collect();
+                format!("{truncated}…")
+            } else {
+                tx_label
+            };
+            let tx_style = if app.is_known_tx(&tx_hash) {
+                theme::LABEL_STYLE
+            } else {
+                theme::TX_HASH_STYLE
+            };
 
             let line = Line::from(vec![
                 Span::styled(format!(" {:<20}", name), theme::LABEL_STYLE),
                 Span::styled(format!("{:<17}", contract), theme::BLOCK_HASH_STYLE),
-                Span::styled(tx_short, theme::TX_HASH_STYLE),
+                Span::styled(tx_display, tx_style),
             ]);
             ListItem::new(line)
         })

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -10,7 +10,7 @@ use crate::app::state::TxNavItem;
 use crate::app::{AddressTab, App};
 use crate::data::types::TokenBalance;
 use crate::ui::theme;
-use crate::ui::widgets::hex_display::{format_fri, format_strk_u128};
+use crate::ui::widgets::hex_display::{format_fri, format_strk_u128, tx_hash_cell};
 use crate::ui::widgets::price;
 use crate::ui::widgets::{search_bar, status_bar};
 use crate::utils::{felt_to_u64, felt_to_u128};
@@ -547,14 +547,9 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
             _ => theme::NORMAL_STYLE,
         };
 
-        let tx_hash_label = app.format_tx_hash(&tx.hash);
-        let tx_hash_display = if tx_hash_label.chars().count() > 14 {
-            let truncated: String = tx_hash_label.chars().take(13).collect();
-            format!("{truncated}…")
-        } else {
-            tx_hash_label
-        };
-        let tx_hash_style = if app.is_known_tx(&tx.hash) {
+        let tx_label = app.resolve_tx(&tx.hash);
+        let tx_hash_display = tx_hash_cell(tx_label, &tx.hash);
+        let tx_hash_style = if tx_label.is_some() {
             theme::LABEL_STYLE
         } else {
             theme::TX_HASH_STYLE
@@ -762,14 +757,9 @@ fn draw_calls_tab(f: &mut Frame, app: &mut App, area: Rect) {
                 _ => theme::SUGGESTION_STYLE,
             };
 
-            let tx_hash_label = app.format_tx_hash(&call.tx_hash);
-            let tx_hash_display = if tx_hash_label.chars().count() > 14 {
-                let truncated: String = tx_hash_label.chars().take(13).collect();
-                format!("{truncated}…")
-            } else {
-                tx_hash_label
-            };
-            let tx_hash_style = if app.is_known_tx(&call.tx_hash) {
+            let tx_label = app.resolve_tx(&call.tx_hash);
+            let tx_hash_display = tx_hash_cell(tx_label, &call.tx_hash);
+            let tx_hash_style = if tx_label.is_some() {
                 theme::LABEL_STYLE
             } else {
                 theme::TX_HASH_STYLE
@@ -913,14 +903,9 @@ fn draw_meta_txs_tab(f: &mut Frame, app: &mut App, area: Rect) {
                 _ => theme::SUGGESTION_STYLE,
             };
 
-            let tx_hash_label = app.format_tx_hash(&m.hash);
-            let tx_hash_display = if tx_hash_label.chars().count() > 14 {
-                let truncated: String = tx_hash_label.chars().take(13).collect();
-                format!("{truncated}…")
-            } else {
-                tx_hash_label
-            };
-            let tx_hash_style = if app.is_known_tx(&m.hash) {
+            let tx_label = app.resolve_tx(&m.hash);
+            let tx_hash_display = tx_hash_cell(tx_label, &m.hash);
+            let tx_hash_style = if tx_label.is_some() {
                 theme::LABEL_STYLE
             } else {
                 theme::TX_HASH_STYLE
@@ -1079,14 +1064,9 @@ fn draw_events_tab(f: &mut Frame, app: &mut App, area: Rect) {
             let contract = app.format_address(&event.contract_address);
             let name = event.event_name.as_deref().unwrap_or("?");
             let tx_hash = event.raw.transaction_hash;
-            let tx_label = app.format_tx_hash(&tx_hash);
-            let tx_display = if tx_label.chars().count() > 14 {
-                let truncated: String = tx_label.chars().take(13).collect();
-                format!("{truncated}…")
-            } else {
-                tx_label
-            };
-            let tx_style = if app.is_known_tx(&tx_hash) {
+            let tx_label = app.resolve_tx(&tx_hash);
+            let tx_display = tx_hash_cell(tx_label, &tx_hash);
+            let tx_style = if tx_label.is_some() {
                 theme::LABEL_STYLE
             } else {
                 theme::TX_HASH_STYLE

--- a/src/ui/views/block_detail.rs
+++ b/src/ui/views/block_detail.rs
@@ -7,7 +7,7 @@ use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 use crate::app::App;
 use crate::ui::theme;
 use crate::ui::widgets::address_color::AddressColorMap;
-use crate::ui::widgets::hex_display::{format_fee, format_fri, short_hash};
+use crate::ui::widgets::hex_display::{format_fee, format_fri, short_hash, tx_hash_cell};
 use crate::ui::widgets::{search_bar, status_bar};
 use crate::utils::felt_to_u64;
 
@@ -294,14 +294,9 @@ fn draw_tx_list(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
             };
 
             let tx_hash = tx.hash();
-            let tx_hash_label = app.format_tx_hash(&tx_hash);
-            let tx_hash_display = if tx_hash_label.chars().count() > 14 {
-                let truncated: String = tx_hash_label.chars().take(13).collect();
-                format!("{truncated}…")
-            } else {
-                tx_hash_label
-            };
-            let tx_hash_style = if app.is_known_tx(&tx_hash) {
+            let tx_label = app.resolve_tx(&tx_hash);
+            let tx_hash_display = tx_hash_cell(tx_label, &tx_hash);
+            let tx_hash_style = if tx_label.is_some() {
                 theme::LABEL_STYLE
             } else {
                 theme::TX_HASH_STYLE

--- a/src/ui/views/block_detail.rs
+++ b/src/ui/views/block_detail.rs
@@ -293,16 +293,27 @@ fn draw_tx_list(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
                 theme::NORMAL_STYLE
             };
 
+            let tx_hash = tx.hash();
+            let tx_hash_label = app.format_tx_hash(&tx_hash);
+            let tx_hash_display = if tx_hash_label.chars().count() > 14 {
+                let truncated: String = tx_hash_label.chars().take(13).collect();
+                format!("{truncated}…")
+            } else {
+                tx_hash_label
+            };
+            let tx_hash_style = if app.is_known_tx(&tx_hash) {
+                theme::LABEL_STYLE
+            } else {
+                theme::TX_HASH_STYLE
+            };
+
             let line = Line::from(vec![
                 Span::styled(format!(" {marker}"), theme::NORMAL_STYLE),
                 Span::styled(format!("{:<4} ", tx.index()), theme::BLOCK_NUMBER_STYLE),
                 Span::styled(format!("{:<4}", status), status_style),
                 Span::styled(format!("{:<15}", tx.type_name()), type_style),
                 Span::styled(format!("{:<10}", meta_str), theme::META_TX_STYLE),
-                Span::styled(
-                    format!("{:<14}", short_hash(&tx.hash())),
-                    theme::TX_HASH_STYLE,
-                ),
+                Span::styled(format!("{:<14}", tx_hash_display), tx_hash_style),
                 Span::styled(format!("{:<21}", sender_display), sender_style),
                 Span::styled(format!("{:<21}", intender_display), intender_style),
                 Span::styled(format!("{:<38} ", endpoint_display), theme::LABEL_STYLE),

--- a/src/ui/views/tx_detail.rs
+++ b/src/ui/views/tx_detail.rs
@@ -341,10 +341,19 @@ fn build_header_lines(
     };
 
     // === TX HEADER ===
-    lines.push(Line::from(vec![
+    let tx_label = app
+        .search_engine
+        .as_ref()
+        .and_then(|e| e.registry().resolve_tx(&tx.hash()).map(|s| s.to_string()));
+    let mut hash_spans = vec![
         Span::styled(" Hash:   ", theme::NORMAL_STYLE),
         Span::styled(format!("{:#x}", tx.hash()), theme::TX_HASH_STYLE),
-    ]));
+    ];
+    if let Some(name) = &tx_label {
+        hash_spans.push(Span::raw("  "));
+        hash_spans.push(Span::styled(format!("[{}]", name), theme::LABEL_STYLE));
+    }
+    lines.push(Line::from(hash_spans));
 
     // Block + index from receipt
     let (blk_num, blk_hash_str, finality_str) = if let Some(receipt) = &app.tx_detail.receipt {

--- a/src/ui/widgets/hex_display.rs
+++ b/src/ui/widgets/hex_display.rs
@@ -65,6 +65,21 @@ pub fn short_hash(felt: &Felt) -> String {
     truncate_felt(felt, 4, 4)
 }
 
+/// Render a tx-hash table cell: `[label]` (truncated to 14 chars with `…` on overflow)
+/// when a user label is supplied, short hex otherwise.
+pub fn tx_hash_cell(label: Option<&str>, hash: &Felt) -> String {
+    let raw = match label {
+        Some(name) => format!("[{name}]"),
+        None => short_hash(hash),
+    };
+    if raw.chars().count() > 14 {
+        let truncated: String = raw.chars().take(13).collect();
+        format!("{truncated}…")
+    } else {
+        raw
+    }
+}
+
 /// Format a u128 fri value as STRK amount (5 decimal places).
 pub fn format_strk_u128(fri: u128) -> String {
     if fri == 0 {

--- a/tests/populate_selectors.rs
+++ b/tests/populate_selectors.rs
@@ -74,7 +74,7 @@ fn collect_all_addresses() -> Vec<(Felt, String)> {
     // Load from labels.toml
     let labels_path = Path::new("labels.toml");
     if labels_path.exists()
-        && let Ok((labels, _)) = snbeat::registry::user_labels::load_user_labels(labels_path)
+        && let Ok((labels, _, _)) = snbeat::registry::user_labels::load_user_labels(labels_path)
     {
         for label in labels {
             if seen.insert(label.address) {

--- a/tests/registry_test.rs
+++ b/tests/registry_test.rs
@@ -134,6 +134,66 @@ fn test_format_address() {
 }
 
 #[test]
+fn test_resolve_tx_label() {
+    let labels = make_user_labels(
+        r#"
+[transactions]
+"0x05c8845db9ac7775e736853b456a8dddaf22367a81d35ae6951825c36e1a27c3" = "60M STRK deposit"
+"#,
+    );
+
+    let registry = snbeat::registry::AddressRegistry::load(labels.path())
+        .unwrap()
+        .0;
+
+    let tx_hash =
+        Felt::from_hex("0x05c8845db9ac7775e736853b456a8dddaf22367a81d35ae6951825c36e1a27c3")
+            .unwrap();
+    assert_eq!(registry.resolve_tx(&tx_hash), Some("60M STRK deposit"));
+
+    let other = Felt::from_hex("0xdeadbeef").unwrap();
+    assert_eq!(registry.resolve_tx(&other), None);
+}
+
+#[test]
+fn test_tx_label_appears_in_search() {
+    let labels = make_user_labels(
+        r#"
+[transactions]
+"0x05c8845db9ac7775e736853b456a8dddaf22367a81d35ae6951825c36e1a27c3" = "60M STRK deposit"
+"#,
+    );
+
+    let registry = snbeat::registry::AddressRegistry::load(labels.path())
+        .unwrap()
+        .0;
+
+    let results = registry.search("60M", 10);
+    assert!(!results.is_empty(), "tx label should be searchable by name");
+    assert!(results[0].is_user);
+    assert!(results[0].display.contains("60M STRK deposit"));
+    assert!(
+        matches!(results[0].kind, snbeat::registry::EntryKind::Transaction),
+        "result kind should be Transaction"
+    );
+
+    // resolve_by_name returns the tx hash so the network resolver can navigate
+    let felt = registry.resolve_by_name("60M STRK deposit").unwrap();
+    assert_eq!(
+        felt,
+        Felt::from_hex("0x05c8845db9ac7775e736853b456a8dddaf22367a81d35ae6951825c36e1a27c3")
+            .unwrap()
+    );
+}
+
+#[test]
+fn test_corrupted_labels_returns_warning() {
+    let labels = make_user_labels("[transactions]\nthis is not toml = broken");
+    let (_reg, warning) = snbeat::registry::AddressRegistry::load(labels.path()).unwrap();
+    assert!(warning.is_some());
+}
+
+#[test]
 fn test_get_decimals() {
     let registry = snbeat::registry::AddressRegistry::load(std::path::Path::new("/dev/null"))
         .unwrap()

--- a/tests/registry_test.rs
+++ b/tests/registry_test.rs
@@ -194,6 +194,28 @@ fn test_corrupted_labels_returns_warning() {
 }
 
 #[test]
+fn test_invalid_tx_hash_entry_is_skipped() {
+    let labels = make_user_labels(
+        r#"
+[transactions]
+"not-a-hex-string" = "garbage"
+"0x05c8845db9ac7775e736853b456a8dddaf22367a81d35ae6951825c36e1a27c3" = "valid tx"
+"#,
+    );
+
+    let (registry, warning) = snbeat::registry::AddressRegistry::load(labels.path()).unwrap();
+    assert!(
+        warning.is_none(),
+        "per-entry skip must not surface a global warning"
+    );
+
+    let valid =
+        Felt::from_hex("0x05c8845db9ac7775e736853b456a8dddaf22367a81d35ae6951825c36e1a27c3")
+            .unwrap();
+    assert_eq!(registry.resolve_tx(&valid), Some("valid tx"));
+}
+
+#[test]
 fn test_get_decimals() {
     let registry = snbeat::registry::AddressRegistry::load(std::path::Path::new("/dev/null"))
         .unwrap()


### PR DESCRIPTION
## Summary
- New `[transactions]` section in `labels.toml` maps tx hash → name; loaded alongside address labels and indexed for search.
- Search bar resolves tx labels by name and routes Enter to the tx detail view; `SearchResult` now carries a `kind` discriminator.
- Labeled tx hashes render as `[name]` in `LABEL_STYLE` in block detail and the address info Txs/Calls/Meta/Events tabs; column width stays at 14, with overflow truncated to `name…` so headers stay aligned.
- Tx detail header surfaces the label next to the full hash.

## Test plan
- [ ] Add a `[transactions]` entry to `labels.toml`, restart, and confirm the label shows in:
  - [ ] block detail tx list (truncated to fit)
  - [ ] address info Txs / Calls / Meta / Events tabs
  - [ ] tx detail header
- [ ] Type the label in the search bar and confirm Enter opens the tx detail view
- [ ] Confirm a malformed tx hash in `labels.toml` is skipped with a warning, not a hard failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)