### PR TITLE
Add DUNE_PRIVATE_QUERIES toggle + Drop-based archive cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,11 @@ APP_RPC_URL=https://api.zan.top/public/starknet-mainnet/rpc/v0_10
 # Dune Analytics API key — enables reverted-tx detection and contract call history
 # DUNE_API_KEY=
 
+# Mark dynamic Dune queries as private (default: true). Set to false to dodge
+# the per-account private-query quota when it's exhausted; archive-on-finish
+# cleanup still runs either way, so the queries stay temporary.
+# DUNE_PRIVATE_QUERIES=true
+
 # ── Labels & registry ─────────────────────────────────────────────────────────
 
 # Path to user-defined labels file (default: labels.toml in the working directory)

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ All variables are optional except `APP_RPC_URL`.
 | `APP_PATHFINDER_SERVICE_URL` | -                       | URL of a running `pf-query` instance           |
 | `VOYAGER_API_KEY`            | -                       | Voyager API key for address metadata           |
 | `DUNE_API_KEY`               | -                       | Dune Analytics API key                         |
+| `DUNE_PRIVATE_QUERIES`       | `true`                  | Mark dynamic Dune queries private; set `false` to dodge private-query quota |
 | `APP_USER_LABELS`            | `labels.toml`           | Path to your custom labels file                |
 | `APP_LOG_LEVEL`              | `info`                  | `trace` / `debug` / `info` / `warn` / `error`  |
 | `APP_LOG_DIR`                | `~/.config/snbeat/logs` | Log file directory                             |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -28,6 +28,14 @@ pub struct AppConfig {
     #[arg(long, env = "DUNE_API_KEY")]
     pub dune_api_key: Option<String>,
 
+    /// Mark dynamic Dune queries as private. Default true preserves the
+    /// pre-existing behavior; set `DUNE_PRIVATE_QUERIES=false` to create
+    /// non-private queries, which can dodge the per-account private-query
+    /// quota when it's exhausted (the same archive-on-finish cleanup still
+    /// applies, so they stay temporary).
+    #[arg(long, env = "DUNE_PRIVATE_QUERIES", default_value_t = true)]
+    pub dune_private_queries: bool,
+
     /// Pathfinder query service URL (e.g. http://steak:8234)
     #[arg(long, env = "APP_PATHFINDER_SERVICE_URL")]
     pub pathfinder_service_url: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,8 +145,11 @@ async fn main() -> anyhow::Result<()> {
         .as_ref()
         .filter(|k| !k.is_empty())
         .map(|key| {
-            info!("Dune API enabled");
-            Arc::new(network::dune::DuneClient::new(key.clone()))
+            info!(is_private = config.dune_private_queries, "Dune API enabled");
+            Arc::new(network::dune::DuneClient::new(
+                key.clone(),
+                config.dune_private_queries,
+            ))
         });
 
     // DefiLlama needs no API key, so the client is always created when the cache opens.

--- a/src/network/dune.rs
+++ b/src/network/dune.rs
@@ -12,6 +12,11 @@ const DUNE_API_BASE: &str = "https://api.dune.com/api/v1";
 pub struct DuneClient {
     client: reqwest::Client,
     api_key: String,
+    /// Whether dynamic queries created via `execute_sql` are flagged
+    /// `is_private`. Toggleable so callers can sidestep a per-account
+    /// private-query quota when it's exhausted; archive-on-finish still
+    /// runs either way, so the queries stay temporary.
+    is_private: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -33,6 +38,46 @@ struct ExecutionStatusResponse {
 #[derive(Debug, Deserialize)]
 struct ExecutionResult {
     rows: Vec<serde_json::Value>,
+}
+
+/// RAII archive trigger for ephemeral queries created by `execute_sql`.
+/// Dropping this fires a detached archive POST so the query doesn't leak on
+/// the Dune account when the awaiting future is cancelled mid-poll. Cleanup
+/// is best-effort: if the runtime is shutting down the spawned task may not
+/// run, but on regular cancellation it does.
+struct ArchiveGuard {
+    client: reqwest::Client,
+    api_key: String,
+    query_id: u64,
+}
+
+impl Drop for ArchiveGuard {
+    fn drop(&mut self) {
+        let client = self.client.clone();
+        let api_key = std::mem::take(&mut self.api_key);
+        let query_id = self.query_id;
+        tokio::spawn(async move {
+            match client
+                .post(format!("{}/query/{}/archive", DUNE_API_BASE, query_id))
+                .header("X-Dune-API-Key", &api_key)
+                .send()
+                .await
+            {
+                Ok(resp) => {
+                    let status = resp.status();
+                    if status.is_success() {
+                        debug!(query_id, "Dune archive succeeded");
+                    } else {
+                        let body = resp.text().await.unwrap_or_default();
+                        tracing::warn!(query_id, %status, body = %body, "Dune archive returned non-success");
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(query_id, error = %e, "Dune archive request failed");
+                }
+            }
+        });
+    }
 }
 
 /// Result of a lightweight probe: block range + count of address activity.
@@ -86,10 +131,11 @@ impl AddressActivityProbe {
 }
 
 impl DuneClient {
-    pub fn new(api_key: String) -> Self {
+    pub fn new(api_key: String, is_private: bool) -> Self {
         Self {
             client: reqwest::Client::new(),
             api_key,
+            is_private,
         }
     }
 
@@ -505,7 +551,7 @@ impl DuneClient {
         let create_body = serde_json::json!({
             "name": format!("snbeat_{}", chrono::Utc::now().timestamp()),
             "query_sql": sql,
-            "is_private": true
+            "is_private": self.is_private
         });
 
         let resp: CreateQueryResponse = self
@@ -523,6 +569,16 @@ impl DuneClient {
             .map_err(|e| format!("Dune create parse failed: {e}"))?;
 
         let query_id = resp.query_id;
+        // Arm the archive guard immediately after create. If the calling task
+        // is cancelled (or any later step short-circuits with `?`), the guard
+        // spawns a fire-and-forget archive request from Drop so we don't leak
+        // the query on the Dune account. Non-private queries make this matter
+        // more — they're visible org-wide until archived.
+        let _archive_guard = ArchiveGuard {
+            client: self.client.clone(),
+            api_key: self.api_key.clone(),
+            query_id,
+        };
 
         let exec_resp: ExecuteResponse = self
             .client
@@ -540,7 +596,10 @@ impl DuneClient {
 
         let execution_id = &exec_resp.execution_id;
         let mut attempts = 0;
-        let result = loop {
+        // Archive runs from `_archive_guard`'s Drop impl so the query is
+        // cleaned up on every exit path (success, polling failure, future
+        // cancellation, error early-return).
+        loop {
             tokio::time::sleep(Duration::from_secs(2)).await;
             attempts += 1;
 
@@ -573,17 +632,7 @@ impl DuneClient {
                     }
                 }
             }
-        };
-
-        // Archive the ephemeral query to avoid accumulating queries on the account.
-        let _ = self
-            .client
-            .post(format!("{}/query/{}/archive", DUNE_API_BASE, query_id))
-            .header("X-Dune-API-Key", &self.api_key)
-            .send()
-            .await;
-
-        result
+        }
     }
 }
 
@@ -697,7 +746,7 @@ mod tests {
         let dune_key = std::env::var("DUNE_API_KEY").expect("DUNE_API_KEY");
         let rpc_url = std::env::var("APP_RPC_URL").expect("APP_RPC_URL");
 
-        let dune = DuneClient::new(dune_key);
+        let dune = DuneClient::new(dune_key, true);
         let ds = RpcDataSource::new(&rpc_url);
         let address = Felt::from_hex(HYBRID_TEST_ADDR).unwrap();
 


### PR DESCRIPTION
## Summary

- Add `DUNE_PRIVATE_QUERIES` env var (default `true`, set `false` to dodge a per-account *private*-query quota when it's been hit).
- Replace the inline post-success archive call with a `Drop`-based `ArchiveGuard`, so ephemeral queries are cleaned up on **every** exit path (success, polling error, future cancellation, `?` early-return).
- Log archive outcomes (`debug!` on success, `warn!` on non-success/network error) so future failures don't get silently swallowed.

## Why

The current Dune API key was returning HTTP 402 Payment Required on every `POST /api/v1/query` create — quota was on private queries specifically. That made the address view's fast paths (account txs windowed, activity probes, contract-call discovery) all fail silently; the only reason gaps eventually filled was the slow RPC events fallback (~7 min on busy accounts). Switching to non-private creates resolved the 402 immediately on the same key.

## Verification (against the live API)

Restart with `DUNE_PRIVATE_QUERIES=false`:

| Query | Outcome | Archive |
|---|---|---|
| acct txs windowed | errored ~1s into execute | archived ✓ (Drop fired on `?` early-return) |
| acct txs windowed | rows=100 | archived ✓ |
| events probe | event_count=286 | archived ✓ |
| acct txs windowed | rows=57 | archived ✓ |

4/4 archive requests returned success in the log; zero 402s after the toggle.

## Test plan

- [ ] Default (no env var change) — confirm queries still log `is_private=true` and behavior is unchanged.
- [ ] `DUNE_PRIVATE_QUERIES=false` in `.env` — confirm Dune queries succeed where they previously 402'd, and `Dune archive succeeded query_id=...` lines appear after each.
- [ ] Kill the app mid-Dune-poll (Ctrl+C) — known limitation: spawned archive task may not complete before runtime tears down; not tested here, called out in the Drop comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)