### PR TITLE
Add Privacy tab to tx detail view + decode sponsored privacy txs

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -132,7 +132,8 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) -> Option<Action> {
                 return maybe_dispatch_meta_txs_on_entry(app);
             }
             if app.current_view() == View::TxDetail {
-                app.tx_detail.active_tab = app.tx_detail.active_tab.next();
+                let has_privacy = tx_detail_has_privacy(app);
+                app.tx_detail.active_tab = app.tx_detail.active_tab.next_visible(has_privacy);
             }
             None
         }
@@ -149,7 +150,8 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) -> Option<Action> {
                 return maybe_dispatch_meta_txs_on_entry(app);
             }
             if app.current_view() == View::TxDetail {
-                app.tx_detail.active_tab = app.tx_detail.active_tab.prev();
+                let has_privacy = tx_detail_has_privacy(app);
+                app.tx_detail.active_tab = app.tx_detail.active_tab.prev_visible(has_privacy);
             }
             None
         }
@@ -782,4 +784,25 @@ fn handle_enter(app: &mut App) -> Option<Action> {
         View::TxDetail => None,
         View::ClassInfo => None,
     }
+}
+
+/// Whether the current tx in `TxDetail` is a privacy-pool tx, controlling
+/// whether `Tab`/`Shift+Tab` includes the Privacy tab in the cycle.
+fn tx_detail_has_privacy(app: &App) -> bool {
+    let Some(tx) = &app.tx_detail.transaction else {
+        return false;
+    };
+    let oe: Vec<_> = app
+        .tx_detail
+        .outside_executions
+        .iter()
+        .map(|(_, info)| info.clone())
+        .collect();
+    crate::decode::privacy::summarize(
+        tx,
+        &app.tx_detail.decoded_calls,
+        &app.tx_detail.decoded_events,
+        &oe,
+    )
+    .is_some()
 }

--- a/src/app/views/tx_detail.rs
+++ b/src/app/views/tx_detail.rs
@@ -10,6 +10,11 @@ use crate::decode::outside_execution::OutsideExecutionInfo;
 use crate::decode::trace::DecodedTrace;
 
 /// Which body tab is active in the tx detail view.
+///
+/// `Privacy` is the only tab that's conditionally rendered: it appears when
+/// the tx interacts with the Starknet Privacy Pool (see
+/// [`crate::decode::privacy::summarize`]). For non-privacy txs the cycle
+/// skips it via [`TxTab::next_visible`]/[`TxTab::prev_visible`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TxTab {
     #[default]
@@ -17,6 +22,7 @@ pub enum TxTab {
     Calls,
     Transfers,
     Trace,
+    Privacy,
 }
 
 impl TxTab {
@@ -25,15 +31,37 @@ impl TxTab {
             Self::Events => Self::Calls,
             Self::Calls => Self::Transfers,
             Self::Transfers => Self::Trace,
-            Self::Trace => Self::Events,
+            Self::Trace => Self::Privacy,
+            Self::Privacy => Self::Events,
         }
     }
     pub fn prev(self) -> Self {
         match self {
-            Self::Events => Self::Trace,
+            Self::Events => Self::Privacy,
             Self::Calls => Self::Events,
             Self::Transfers => Self::Calls,
             Self::Trace => Self::Transfers,
+            Self::Privacy => Self::Trace,
+        }
+    }
+
+    /// Tab cycling that skips the Privacy tab when the current tx isn't a
+    /// privacy tx. `has_privacy` is the caller's view of whether
+    /// `decode::privacy::summarize` produced a summary for this tx.
+    pub fn next_visible(self, has_privacy: bool) -> Self {
+        let n = self.next();
+        if matches!(n, Self::Privacy) && !has_privacy {
+            n.next()
+        } else {
+            n
+        }
+    }
+    pub fn prev_visible(self, has_privacy: bool) -> Self {
+        let n = self.prev();
+        if matches!(n, Self::Privacy) && !has_privacy {
+            n.prev()
+        } else {
+            n
         }
     }
 }
@@ -47,6 +75,7 @@ pub enum NavSection {
     Calls,
     Transfers,
     Trace,
+    Privacy,
 }
 
 /// All state related to the transaction detail view.
@@ -63,6 +92,7 @@ pub struct TxDetailState {
     pub calls_scroll: u16,
     pub transfers_scroll: u16,
     pub trace_scroll: u16,
+    pub privacy_scroll: u16,
     /// Decoded recursive call tree (populated lazily after the main fetch).
     pub trace: Option<DecodedTrace>,
     /// True from the moment we trigger the trace fetch until it lands.
@@ -110,6 +140,7 @@ impl TxDetailState {
         self.calls_scroll = 0;
         self.transfers_scroll = 0;
         self.trace_scroll = 0;
+        self.privacy_scroll = 0;
         self.trace = None;
         self.trace_loading = false;
         self.visual_mode = false;
@@ -297,6 +328,64 @@ impl TxDetailState {
             }
         }
 
+        // === Privacy tab ===
+        // Compute the privacy summary once and walk it for nav-able addresses
+        // (deposit user_addr / withdrawal to_addr / open-note depositor /
+        // viewing-key user_addr / invoke-external target / OE intender). The
+        // pool address itself is already covered by the Calls section.
+        let oe_clone: Vec<crate::decode::outside_execution::OutsideExecutionInfo> = self
+            .outside_executions
+            .iter()
+            .map(|(_, oe)| oe.clone())
+            .collect();
+        if let Some(tx) = &self.transaction
+            && let Some(summary) = crate::decode::privacy::summarize(
+                tx,
+                &self.decoded_calls,
+                &self.decoded_events,
+                &oe_clone,
+            )
+        {
+            let push_priv =
+                |felt: starknet::core::types::Felt,
+                 items: &mut Vec<TxNavItem>,
+                 sections: &mut Vec<NavSection>,
+                 seen: &mut HashSet<starknet::core::types::Felt>| {
+                    if felt != starknet::core::types::Felt::ZERO && seen.insert(felt) {
+                        push(
+                            TxNavItem::Address(felt),
+                            NavSection::Privacy,
+                            items,
+                            sections,
+                        );
+                    }
+                };
+            for d in &summary.deposits {
+                push_priv(d.user_addr, &mut items, &mut sections, &mut seen);
+                push_priv(d.token, &mut items, &mut sections, &mut seen);
+            }
+            for w in &summary.withdrawals {
+                push_priv(w.to_addr, &mut items, &mut sections, &mut seen);
+                push_priv(w.token, &mut items, &mut sections, &mut seen);
+            }
+            for n in &summary.open_notes_created {
+                push_priv(n.token, &mut items, &mut sections, &mut seen);
+            }
+            for d in &summary.open_notes_deposited {
+                push_priv(d.depositor, &mut items, &mut sections, &mut seen);
+                push_priv(d.token, &mut items, &mut sections, &mut seen);
+            }
+            for v in &summary.viewing_keys_set {
+                push_priv(v.user_addr, &mut items, &mut sections, &mut seen);
+            }
+            if let Some(ie) = &summary.invoke_external {
+                push_priv(ie.target, &mut items, &mut sections, &mut seen);
+            }
+            if let Some(intender) = summary.intender {
+                push_priv(intender, &mut items, &mut sections, &mut seen);
+            }
+        }
+
         // === Trace tab ===
         if let Some(trace) = &self.trace {
             trace.for_each_call(|call| {
@@ -344,6 +433,7 @@ impl TxDetailState {
             TxTab::Calls => self.calls_scroll,
             TxTab::Transfers => self.transfers_scroll,
             TxTab::Trace => self.trace_scroll,
+            TxTab::Privacy => self.privacy_scroll,
         }
     }
 
@@ -355,6 +445,7 @@ impl TxDetailState {
             TxTab::Calls => &mut self.calls_scroll,
             TxTab::Transfers => &mut self.transfers_scroll,
             TxTab::Trace => &mut self.trace_scroll,
+            TxTab::Privacy => &mut self.privacy_scroll,
         }
     }
 
@@ -376,6 +467,7 @@ impl TxDetailState {
                 NavSection::Calls => self.active_tab = TxTab::Calls,
                 NavSection::Transfers => self.active_tab = TxTab::Transfers,
                 NavSection::Trace => self.active_tab = TxTab::Trace,
+                NavSection::Privacy => self.active_tab = TxTab::Privacy,
                 NavSection::Header => {} // header is always visible — no tab switch
             }
         }
@@ -389,6 +481,7 @@ impl TxDetailState {
                 Some(NavSection::Calls) => self.calls_scroll = target,
                 Some(NavSection::Transfers) => self.transfers_scroll = target,
                 Some(NavSection::Trace) => self.trace_scroll = target,
+                Some(NavSection::Privacy) => self.privacy_scroll = target,
                 Some(NavSection::Header) | None => {}
             }
         }

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -4,6 +4,7 @@ pub mod class_cache;
 pub mod events;
 pub mod functions;
 pub mod outside_execution;
+pub mod privacy;
 pub mod trace;
 
 use std::sync::Arc;

--- a/src/decode/outside_execution.rs
+++ b/src/decode/outside_execution.rs
@@ -28,15 +28,54 @@ pub enum OutsideExecutionVersion {
     V1,
     V2,
     V3,
+    /// AVNU `execute_private_sponsored` (selector
+    /// `0x3bd4b5033e788e9cc450fefa99ea20e3bed0fa358c8b280c0488f0c4647472e`).
+    /// A privacy-aware sponsorship entrypoint where the user's identity is
+    /// proven inside the wrapped call (typically a Privacy Pool
+    /// `apply_actions`), so the wrapper carries no caller / nonce /
+    /// timestamps — just a call array followed by auth metadata.
+    PrivateSponsored,
 }
 
+impl OutsideExecutionVersion {
+    /// Short, fixed-width tag used in tight UI contexts (block-list "Meta(...)"
+    /// column, address-info meta-tx column). Stays ≤ 2 chars so it always
+    /// fits within the existing `{:<10}` and `{:<6}` budgets without
+    /// shifting downstream columns.
+    ///
+    /// Versioning convention:
+    /// * `v1` / `v2` / `v3` — SNIP-9 outside-execution variants.
+    /// * `p1` — first AVNU privacy-aware sponsorship variant
+    ///   (`execute_private_sponsored`). A future `p2` slot is reserved if
+    ///   AVNU ships a follow-on entrypoint.
+    pub fn short(&self) -> &'static str {
+        match self {
+            Self::V1 => "v1",
+            Self::V2 => "v2",
+            Self::V3 => "v3",
+            Self::PrivateSponsored => "p1",
+        }
+    }
+
+    /// Long, descriptive name. Used in the tx-detail header / Calls-tab
+    /// intent expansion where there's room for clarity.
+    pub fn verbose(&self) -> &'static str {
+        match self {
+            Self::V1 => "v1",
+            Self::V2 => "v2",
+            Self::V3 => "v3",
+            Self::PrivateSponsored => "private-sponsored",
+        }
+    }
+}
+
+/// `Display` defaults to the short tag — it's what the block-list and
+/// address-info columns format with `format!("{}", version)` and they
+/// can't tolerate variable widths. Use [`OutsideExecutionVersion::verbose`]
+/// in places that have room for the long form.
 impl std::fmt::Display for OutsideExecutionVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::V1 => write!(f, "v1"),
-            Self::V2 => write!(f, "v2"),
-            Self::V3 => write!(f, "v3"),
-        }
+        f.write_str(self.short())
     }
 }
 
@@ -68,9 +107,16 @@ pub fn is_outside_execution(function_name: &str) -> Option<OutsideExecutionVersi
         "execute_from_outside" => Some(OutsideExecutionVersion::V1),
         "execute_from_outside_v2" => Some(OutsideExecutionVersion::V2),
         "execute_from_outside_v3" => Some(OutsideExecutionVersion::V3),
+        "execute_private_sponsored" => Some(OutsideExecutionVersion::PrivateSponsored),
         _ => None,
     }
 }
+
+/// `execute_private_sponsored` selector — the AVNU privacy-aware
+/// sponsorship entrypoint. Recognized by raw selector too, since
+/// `populate_selectors` may not have indexed AVNU's ABI on every install.
+pub const EXECUTE_PRIVATE_SPONSORED_SELECTOR: Felt =
+    Felt::from_hex_unchecked("0x3bd4b5033e788e9cc450fefa99ea20e3bed0fa358c8b280c0488f0c4647472e");
 
 /// Heuristic: detect outside execution by calldata pattern when function name is
 /// unresolved (e.g. Argent/Dojo contracts with component-based selectors where
@@ -88,6 +134,51 @@ pub fn looks_like_outside_execution(call: &RawCall) -> bool {
     // Try both nonce formats and see if either produces a valid parse
     try_parse_with_nonce_size(&call.data, 1).is_some()
         || try_parse_with_nonce_size(&call.data, 2).is_some()
+}
+
+/// Detect `execute_private_sponsored` by exact selector match. Cheap and
+/// reliable — the ABI may not have been indexed yet when this runs.
+pub fn looks_like_private_sponsored(call: &RawCall) -> bool {
+    call.selector == EXECUTE_PRIVATE_SPONSORED_SELECTOR
+}
+
+/// Parse `execute_private_sponsored` calldata.
+///
+/// Layout (no caller/nonce/timestamps — those don't apply because the user's
+/// authority is proven cryptographically inside the inner call's payload,
+/// typically a Privacy Pool `apply_actions` proof):
+///
+///   [0]     num_calls
+///   [1..]   call array — each call is `(target, selector, data_len, data...)`
+///   [..end] trailing auth metadata (relayer-side; not decoded)
+///
+/// `call.contract_address` is the AVNU forwarder. Surface it as `intender`
+/// so existing nav-item / color-map / privacy-summary paths keep working;
+/// the UI relabels the line "Forwarder" when `version == PrivateSponsored`.
+pub fn parse_private_sponsored(call: &RawCall) -> Option<OutsideExecutionInfo> {
+    let data = &call.data;
+    if data.len() < 4 {
+        return None;
+    }
+    let num_inner_calls = felt_to_u64(&data[0]) as usize;
+    // Same sanity cap as the standard SNIP-9 parser.
+    if num_inner_calls > 100 {
+        return None;
+    }
+    let (inner_calls, _offset_after) = parse_call_array(data, 1, num_inner_calls);
+    if inner_calls.len() != num_inner_calls {
+        return None;
+    }
+    Some(OutsideExecutionInfo {
+        intender: call.contract_address,
+        caller: Felt::ZERO,
+        nonce: Felt::ZERO,
+        execute_after: 0,
+        execute_before: u64::MAX,
+        inner_calls,
+        signature: Vec::new(),
+        version: OutsideExecutionVersion::PrivateSponsored,
+    })
 }
 
 /// Parse an outside execution call's raw calldata into structured info.
@@ -288,7 +379,34 @@ pub fn detect_outside_execution(
     call: &RawCall,
     function_name: Option<&str>,
 ) -> Option<(OutsideExecutionInfo, DetectionMethod)> {
-    // Method 1: AVNU forwarder (address-based).
+    // Method 1a: function name match (covers `execute_from_outside_v*` and
+    // `execute_private_sponsored`). Run before the AVNU-forwarder address
+    // check because `execute_private_sponsored` *is* a call directly to the
+    // forwarder, but with a different calldata layout than the classic
+    // `execute_sponsored(account, entrypoint, calldata, …)` shape.
+    if let Some(name) = function_name
+        && let Some(version) = is_outside_execution(name)
+    {
+        let parsed = if matches!(version, OutsideExecutionVersion::PrivateSponsored) {
+            parse_private_sponsored(call)
+        } else {
+            parse_outside_execution(call, version)
+        };
+        if let Some(oe) = parsed {
+            return Some((oe, DetectionMethod::Name));
+        }
+    }
+
+    // Method 1b: selector match for `execute_private_sponsored` when name
+    // didn't resolve (cold ABI cache).
+    if looks_like_private_sponsored(call)
+        && let Some(oe) = parse_private_sponsored(call)
+    {
+        return Some((oe, DetectionMethod::Name));
+    }
+
+    // Method 2: AVNU forwarder address. The classic forwarder layout
+    // `execute_sponsored(account, entrypoint, calldata, …)`.
     if is_avnu_forwarder(&call.contract_address) {
         if let Some(oe) = parse_forwarder_call(call) {
             return Some((oe, DetectionMethod::AvnuForwarder));
@@ -297,14 +415,6 @@ pub fn detect_outside_execution(
         // won't match the other methods either (different data layout), so
         // short-circuit with `None`.
         return None;
-    }
-
-    // Method 2: function name match.
-    if let Some(name) = function_name
-        && let Some(version) = is_outside_execution(name)
-        && let Some(oe) = parse_outside_execution(call, version)
-    {
-        return Some((oe, DetectionMethod::Name));
     }
 
     // Method 3: calldata heuristic fallback. Runs when the name doesn't
@@ -353,6 +463,10 @@ mod tests {
         assert_eq!(
             is_outside_execution("execute_from_outside_v3"),
             Some(OutsideExecutionVersion::V3)
+        );
+        assert_eq!(
+            is_outside_execution("execute_private_sponsored"),
+            Some(OutsideExecutionVersion::PrivateSponsored)
         );
         assert_eq!(is_outside_execution("transfer"), None);
         assert_eq!(is_outside_execution("execute"), None);
@@ -680,5 +794,70 @@ mod tests {
         );
         assert_eq!(oe.inner_calls[0].data.len(), 3);
         assert_eq!(oe.signature.len(), 2);
+    }
+
+    /// Mirrors the calldata shape of mainnet tx
+    /// `0x3e47f71dfab420be6e157bc704f25c606ca0b6017885655e16a8858d07449fa`
+    /// (a single-call `execute_private_sponsored` wrapping a Privacy Pool
+    /// `apply_actions`). The wrapper has no caller/nonce/timestamps — just
+    /// `[num_calls, …call_array…, …auth_blob…]`.
+    #[test]
+    fn test_parse_private_sponsored_basic() {
+        let forwarder = felt("0x127021a1b5a52d3174c2ab077c2b043c80369250d29428cee956d76ee51584f");
+        let pool = felt("0x40337b1af3c663e86e333bab5a4b28da8d4652a15a69beee2b677776ffe812a");
+        let apply_actions =
+            felt("0x246333a752c1ac637ff1591c5c885e27d56060d241a29aad8475072da0777db");
+
+        // 1 inner call: pool.apply_actions([0xAA, 0xBB, 0xCC])
+        let inner_data = vec![
+            Felt::from(0xAAu64),
+            Felt::from(0xBBu64),
+            Felt::from(0xCCu64),
+        ];
+        let mut data = vec![
+            Felt::from(1u64), // num_inner_calls
+            pool,
+            apply_actions,
+            Felt::from(inner_data.len() as u64),
+        ];
+        data.extend_from_slice(&inner_data);
+        // Trailing relayer-side auth blob (not decoded; just here so the
+        // parser must tolerate trailing data).
+        data.extend_from_slice(&[Felt::from(0x1u64), felt("0xdeadbeef")]);
+
+        let call = RawCall {
+            contract_address: forwarder,
+            selector: EXECUTE_PRIVATE_SPONSORED_SELECTOR,
+            data,
+            function_name: Some("execute_private_sponsored".into()),
+            function_def: None,
+            contract_abi: None,
+        };
+
+        assert!(looks_like_private_sponsored(&call));
+        let oe = parse_private_sponsored(&call).expect("should parse");
+        assert_eq!(oe.intender, forwarder);
+        assert_eq!(oe.version, OutsideExecutionVersion::PrivateSponsored);
+        assert_eq!(oe.inner_calls.len(), 1);
+        assert_eq!(oe.inner_calls[0].contract_address, pool);
+        assert_eq!(oe.inner_calls[0].selector, apply_actions);
+        assert_eq!(oe.inner_calls[0].data, inner_data);
+        // Caller/nonce/timestamps are not part of this wrapper.
+        assert_eq!(oe.caller, Felt::ZERO);
+        assert_eq!(oe.nonce, Felt::ZERO);
+        assert_eq!(oe.signature.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_private_sponsored_too_short() {
+        let call = RawCall {
+            contract_address: felt("0xabc"),
+            selector: EXECUTE_PRIVATE_SPONSORED_SELECTOR,
+            data: vec![Felt::from(1u64)], // missing inner-call body
+            function_name: None,
+            function_def: None,
+            contract_abi: None,
+        };
+        assert!(parse_private_sponsored(&call).is_none());
     }
 }

--- a/src/decode/privacy.rs
+++ b/src/decode/privacy.rs
@@ -1,0 +1,763 @@
+//! Starknet Privacy Pool tx summarization.
+//!
+//! Aggregates the publicly-observable parts of an `apply_actions` transaction:
+//! action-type counts, public boundary flows (Deposit/Withdrawal/OpenNote*),
+//! viewing-key registrations, the InvokeExternal target, and the pool fee.
+//!
+//! What we deliberately do NOT do here:
+//!   * Decode encrypted blobs (`enc_user_addr`, `EncPrivateKey`,
+//!     `packed_value`). They're auditor-only — surfacing the raw bytes would
+//!     just be noise.
+//!   * Correlate intra-tx Deposit ↔ EncNoteCreated ↔ NoteUsed ↔ Withdrawal.
+//!     That is exactly what the protocol prevents; doing so in a public
+//!     explorer would be misleading.
+//!
+//! Proof age is currently not extracted: `apply_actions` deserializes
+//! `ProofFacts` from `tx_info` (paymaster_data / account_deployment_data /
+//! signature tail), and the exact slot needs to be confirmed against
+//! `packages/privacy/src/privacy.cairo`. v1 ships without proof age.
+//!
+//! Reference contract / class hashes (mainnet):
+//!   * Pool address:        0x040337b1af3c663e86e333bab5a4b28da8d4652a15a69beee2b677776ffe812a
+//!   * Ekubo helper class:  0x061047c201f235d66cab8a0c4768ea0ca9f900c64b478a90531fb2fb30e061dc
+//!   * Vesu helper class:   0x02fec72887f6431e4a66090bec49ecf8bde30cf39a7045e4ed6ce57447704b24
+
+use std::sync::LazyLock;
+
+use starknet::core::types::Felt;
+use starknet::core::utils::get_selector_from_name;
+
+use super::events::DecodedEvent;
+use super::functions::RawCall;
+use super::outside_execution::OutsideExecutionInfo;
+use crate::data::types::SnTransaction;
+use crate::utils::felt_to_u128;
+
+/// Mainnet Privacy Pool address.
+pub static POOL_ADDRESS: LazyLock<Felt> = LazyLock::new(|| {
+    Felt::from_hex("0x040337b1af3c663e86e333bab5a4b28da8d4652a15a69beee2b677776ffe812a").unwrap()
+});
+
+/// Pool event selectors. Computed lazily so we never pay the cost on
+/// non-privacy txs.
+struct EventSelectors {
+    note_used: Felt,
+    enc_note_created: Felt,
+    open_note_created: Felt,
+    open_note_deposited: Felt,
+    deposit: Felt,
+    withdrawal: Felt,
+    viewing_key_set: Felt,
+}
+
+static EVENT_SELECTORS: LazyLock<EventSelectors> = LazyLock::new(|| EventSelectors {
+    // Selectors observed on mainnet tx 0x90304ef5b180c520ce866161c0a14618a72af5aa841fe38a243220aa05bfa2.
+    note_used: Felt::from_hex("0x0247fc60d782e0094e7f98c47f277d92a3345d07a436f1f56b27a9b62be2322e")
+        .unwrap(),
+    enc_note_created: Felt::from_hex(
+        "0x023c20207be8b1ef4430c25eef8ce779c9745ebe04139555ae81bd4f8fdd6ec5",
+    )
+    .unwrap(),
+    open_note_created: Felt::from_hex(
+        "0x022330482fd296a27cf9096807b4a3622cd619d31cce42c1e55655914e8459ee",
+    )
+    .unwrap(),
+    open_note_deposited: Felt::from_hex(
+        "0x025b6da03c4858d11cb0708d5cb6be79b190fb32eb7a7ce83804e07cbbb9bead",
+    )
+    .unwrap(),
+    withdrawal: Felt::from_hex(
+        "0x002eed7e29b3502a726faf503ac4316b7101f3da813654e8df02c13449e03da8",
+    )
+    .unwrap(),
+    // Computed from `Deposit` / `ViewingKeySet` event names (Cairo Poseidon-based).
+    deposit: get_selector_from_name("Deposit").unwrap(),
+    viewing_key_set: get_selector_from_name("ViewingKeySet").unwrap(),
+});
+
+/// Categorizes a Privacy Pool event by selector.
+fn classify_event(event: &DecodedEvent) -> Option<PrivacyEventKind> {
+    if event.contract_address != *POOL_ADDRESS {
+        return None;
+    }
+    let selector = event.raw.keys.first()?;
+    let s = &*EVENT_SELECTORS;
+    if *selector == s.note_used {
+        Some(PrivacyEventKind::NoteUsed)
+    } else if *selector == s.enc_note_created {
+        Some(PrivacyEventKind::EncNoteCreated)
+    } else if *selector == s.open_note_created {
+        Some(PrivacyEventKind::OpenNoteCreated)
+    } else if *selector == s.open_note_deposited {
+        Some(PrivacyEventKind::OpenNoteDeposited)
+    } else if *selector == s.deposit {
+        Some(PrivacyEventKind::Deposit)
+    } else if *selector == s.withdrawal {
+        Some(PrivacyEventKind::Withdrawal)
+    } else if *selector == s.viewing_key_set {
+        Some(PrivacyEventKind::ViewingKeySet)
+    } else {
+        None
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrivacyEventKind {
+    NoteUsed,
+    EncNoteCreated,
+    OpenNoteCreated,
+    OpenNoteDeposited,
+    Deposit,
+    Withdrawal,
+    ViewingKeySet,
+}
+
+/// One-line action-mix summary.
+#[derive(Debug, Clone, Default)]
+pub struct ActionMix {
+    pub notes_used: usize,
+    pub enc_notes_created: usize,
+    pub open_notes_created: usize,
+    pub open_notes_deposited: usize,
+    pub deposits: usize,
+    pub withdrawals: usize,
+    pub viewing_keys_set: usize,
+    pub invoke_external: usize,
+}
+
+impl ActionMix {
+    pub fn total(&self) -> usize {
+        self.notes_used
+            + self.enc_notes_created
+            + self.open_notes_created
+            + self.open_notes_deposited
+            + self.deposits
+            + self.withdrawals
+            + self.viewing_keys_set
+            + self.invoke_external
+    }
+}
+
+/// A public-side deposit event (`user_addr` + token + amount, all clear).
+#[derive(Debug, Clone)]
+pub struct PublicDeposit {
+    pub user_addr: Felt,
+    pub token: Felt,
+    /// `u128` amount (low bits if the contract serializes a u128; we don't
+    /// upcast).
+    pub amount: u128,
+}
+
+/// A public-side withdrawal: recipient + token + amount are clear; the
+/// withdrawing user is encrypted (auditor-only) and intentionally not
+/// surfaced here.
+#[derive(Debug, Clone)]
+pub struct PublicWithdrawal {
+    pub to_addr: Felt,
+    pub token: Felt,
+    pub amount: u128,
+}
+
+/// `OpenNoteCreated` — token + note id are clear; recipient address is
+/// encrypted (auditor-only) and intentionally not surfaced.
+#[derive(Debug, Clone)]
+pub struct OpenNote {
+    pub token: Felt,
+    pub note_id: Felt,
+}
+
+/// `OpenNoteDeposited` — depositor + token + note id + amount, all clear.
+#[derive(Debug, Clone)]
+pub struct OpenNoteDeposit {
+    pub depositor: Felt,
+    pub token: Felt,
+    pub note_id: Felt,
+    pub amount: u128,
+}
+
+/// A user joined the pool (registered a viewing public key).
+#[derive(Debug, Clone)]
+pub struct ViewingKeyRegistration {
+    pub user_addr: Felt,
+    pub public_key: Felt,
+}
+
+/// Aggregated summary of a Privacy Pool transaction.
+#[derive(Debug, Clone)]
+pub struct PrivacySummary {
+    pub actions: ActionMix,
+    pub deposits: Vec<PublicDeposit>,
+    pub withdrawals: Vec<PublicWithdrawal>,
+    pub open_notes_created: Vec<OpenNote>,
+    pub open_notes_deposited: Vec<OpenNoteDeposit>,
+    /// IDs of encrypted notes created in this tx. We don't surface their
+    /// `packed_value` (encodes salt+amount) — that's auditor-only.
+    pub enc_notes_created: Vec<Felt>,
+    /// Nullifiers of notes spent in this tx.
+    pub nullifiers: Vec<Felt>,
+    pub viewing_keys_set: Vec<ViewingKeyRegistration>,
+    /// Best-effort detection of an external helper call. Identified by walking
+    /// `decoded_calls` for any non-pool top-level call (the `apply_actions`
+    /// pipeline routes `InvokeExternal` through standard syscall, so it shows
+    /// up as a sibling call rather than nested) and by checking if any
+    /// known-helper class is referenced.
+    pub invoke_external: Option<InvokeExternalRef>,
+    /// Pool-fee paid in FRI. Detected as the residual STRK transfer from the
+    /// pool *not* matched against any `Withdrawal` event recipient — i.e. the
+    /// transfer that goes to the configured fee_collector rather than to a
+    /// withdrawing user. Returns `None` when the pool emits no STRK transfers.
+    pub pool_fee_fri: Option<u128>,
+    /// Sponsorship signal. See [`PaymasterMode`] for what each variant means.
+    pub paymaster: PaymasterMode,
+    /// When the pool call is wrapped in an outside-execution (the AVNU
+    /// gasless / SNIP-9 pattern), this is the user's account address (the
+    /// signer of the OE intent). The on-chain `tx.sender` in that case is
+    /// the relayer, *not* the user. Surface this so the privacy tab can
+    /// label "Intender" instead of misleading "Sender".
+    pub intender: Option<Felt>,
+}
+
+/// How (or whether) the chain-level fee for this tx is sponsored. None of
+/// these variants is a strict guarantee — the InvokeTx struct doesn't carry
+/// `paymaster_data` today, so we infer from on-chain shape only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaymasterMode {
+    /// No sponsorship signal detected (sender is not a known relayer, no
+    /// outside-execution wraps the pool call, no top-level call to a known
+    /// paymaster forwarder). Most likely the user paid directly.
+    None,
+    /// `tx.sender` is one of the known relayer / paymaster forwarder
+    /// addresses we have bundled.
+    KnownRelayer,
+    /// The privacy pool call is wrapped in an outside-execution intent (the
+    /// canonical SNIP-9 / AVNU gasless pattern). The intender (user) is
+    /// distinct from `tx.sender` (relayer).
+    OutsideExecution,
+    /// A top-level multicall entry routes through a known paymaster
+    /// forwarder (e.g. AVNU Forwarder) before/around the pool call. This
+    /// catches the gasless-token-fee pattern where the user pays the relayer
+    /// in STRK rather than ETH.
+    PaymasterForwarder,
+}
+
+impl PaymasterMode {
+    pub fn is_sponsored(&self) -> bool {
+        !matches!(self, Self::None)
+    }
+}
+
+/// Reference to the contract called by an `InvokeExternal` server action.
+#[derive(Debug, Clone)]
+pub struct InvokeExternalRef {
+    pub target: Felt,
+    pub selector: Felt,
+    pub function_name: Option<String>,
+}
+
+/// Summarize a transaction. Returns `None` for non-privacy txs.
+///
+/// Detects a privacy tx via *any* of: a top-level call targeting the pool,
+/// an outside-execution inner call targeting the pool, or a pool-emitted
+/// event in the receipt. The third signal catches OE-wrapped sponsored
+/// txs where neither the top-level multicall nor the OE inner-call list is
+/// where we'd naturally look (e.g. AVNU's paymaster v2 routes through an
+/// intermediate forwarder contract before reaching the pool).
+pub fn summarize(
+    tx: &SnTransaction,
+    decoded_calls: &[RawCall],
+    decoded_events: &[DecodedEvent],
+    outside_executions: &[OutsideExecutionInfo],
+) -> Option<PrivacySummary> {
+    let has_pool_call = decoded_calls
+        .iter()
+        .any(|c| c.contract_address == *POOL_ADDRESS);
+    let has_pool_oe_inner = outside_executions.iter().any(|oe| {
+        oe.inner_calls
+            .iter()
+            .any(|c| c.contract_address == *POOL_ADDRESS)
+    });
+    let has_pool_event = decoded_events
+        .iter()
+        .any(|e| e.contract_address == *POOL_ADDRESS);
+    if !(has_pool_call || has_pool_oe_inner || has_pool_event) {
+        return None;
+    }
+
+    let mut actions = ActionMix::default();
+    let mut deposits = Vec::new();
+    let mut withdrawals = Vec::new();
+    let mut open_notes_created = Vec::new();
+    let mut open_notes_deposited = Vec::new();
+    let mut enc_notes_created = Vec::new();
+    let mut nullifiers = Vec::new();
+    let mut viewing_keys_set = Vec::new();
+
+    for ev in decoded_events {
+        let Some(kind) = classify_event(ev) else {
+            continue;
+        };
+        match kind {
+            PrivacyEventKind::NoteUsed => {
+                actions.notes_used += 1;
+                // keys[0]=selector, keys[1]=nullifier
+                if let Some(nullifier) = ev.raw.keys.get(1).copied() {
+                    nullifiers.push(nullifier);
+                }
+            }
+            PrivacyEventKind::EncNoteCreated => {
+                actions.enc_notes_created += 1;
+                // keys[0]=selector, keys[1]=note_id
+                if let Some(note_id) = ev.raw.keys.get(1).copied() {
+                    enc_notes_created.push(note_id);
+                }
+            }
+            PrivacyEventKind::OpenNoteCreated => {
+                actions.open_notes_created += 1;
+                // keys: selector, token, note_id; data: enc_recipient_addr (auditor-only)
+                if let (Some(token), Some(note_id)) =
+                    (ev.raw.keys.get(1).copied(), ev.raw.keys.get(2).copied())
+                {
+                    open_notes_created.push(OpenNote { token, note_id });
+                }
+            }
+            PrivacyEventKind::OpenNoteDeposited => {
+                actions.open_notes_deposited += 1;
+                // keys: selector, depositor, token, note_id; data: amount (u128)
+                if let (Some(depositor), Some(token), Some(note_id)) = (
+                    ev.raw.keys.get(1).copied(),
+                    ev.raw.keys.get(2).copied(),
+                    ev.raw.keys.get(3).copied(),
+                ) {
+                    let amount = ev.raw.data.first().map(felt_to_u128).unwrap_or(0);
+                    open_notes_deposited.push(OpenNoteDeposit {
+                        depositor,
+                        token,
+                        note_id,
+                        amount,
+                    });
+                }
+            }
+            PrivacyEventKind::Deposit => {
+                actions.deposits += 1;
+                // keys: selector, user_addr, token; data: amount (u128)
+                if let (Some(user_addr), Some(token)) =
+                    (ev.raw.keys.get(1).copied(), ev.raw.keys.get(2).copied())
+                {
+                    let amount = ev.raw.data.first().map(felt_to_u128).unwrap_or(0);
+                    deposits.push(PublicDeposit {
+                        user_addr,
+                        token,
+                        amount,
+                    });
+                }
+            }
+            PrivacyEventKind::Withdrawal => {
+                actions.withdrawals += 1;
+                // keys: selector, to_addr, token; data: enc_user_addr blobs + amount (u128)
+                // The encrypted user-addr layout (`EncUserAddr` struct) makes the
+                // amount land at the tail of `data`; index by length rather
+                // than by a fixed offset so a struct-shape change in a future
+                // pool revision doesn't silently zero out the amount.
+                if let (Some(to_addr), Some(token)) =
+                    (ev.raw.keys.get(1).copied(), ev.raw.keys.get(2).copied())
+                {
+                    let amount = ev.raw.data.last().map(felt_to_u128).unwrap_or(0);
+                    withdrawals.push(PublicWithdrawal {
+                        to_addr,
+                        token,
+                        amount,
+                    });
+                }
+            }
+            PrivacyEventKind::ViewingKeySet => {
+                actions.viewing_keys_set += 1;
+                // keys: selector, user_addr, public_key; data: enc_private_key
+                if let (Some(user_addr), Some(public_key)) =
+                    (ev.raw.keys.get(1).copied(), ev.raw.keys.get(2).copied())
+                {
+                    viewing_keys_set.push(ViewingKeyRegistration {
+                        user_addr,
+                        public_key,
+                    });
+                }
+            }
+        }
+    }
+
+    // Pool fee detection: each STRK transfer from the pool either
+    //   (a) matches a `Withdrawal` event recipient/amount → it's the
+    //       withdrawal payout (potentially to a paymaster, see
+    //       `0x4b9cde1...` for the AVNU gasless privacy pattern), or
+    //   (b) doesn't match → it's the pool fee transfer to fee_collector.
+    // Sum the (b) bucket. If every pool→X transfer is matched against a
+    // withdrawal, fee is `None` rather than `Some(0)` — we don't want to
+    // imply a fee column when the chain shape can't tell us.
+    let strk_token =
+        Felt::from_hex("0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d")
+            .unwrap();
+    let erc20_transfer_selector =
+        Felt::from_hex("0x0099cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9")
+            .unwrap();
+    let mut withdrawal_match: Vec<bool> = vec![false; withdrawals.len()];
+    let mut fee_total: u128 = 0;
+    let mut saw_pool_strk_transfer = false;
+    for ev in decoded_events {
+        if ev.contract_address != strk_token
+            || ev.raw.keys.first() != Some(&erc20_transfer_selector)
+            || ev.raw.keys.get(1) != Some(&*POOL_ADDRESS)
+        {
+            continue;
+        }
+        saw_pool_strk_transfer = true;
+        let to = ev.raw.keys.get(2).copied().unwrap_or(Felt::ZERO);
+        let amt = ev.raw.data.first().map(felt_to_u128).unwrap_or(0);
+        // Try to match this transfer against an unmatched withdrawal of the
+        // same token going to the same recipient with the same amount.
+        let matched = withdrawals.iter().enumerate().position(|(i, w)| {
+            !withdrawal_match[i] && w.token == strk_token && w.to_addr == to && w.amount == amt
+        });
+        if let Some(idx) = matched {
+            withdrawal_match[idx] = true;
+        } else {
+            fee_total = fee_total.saturating_add(amt);
+        }
+    }
+    let pool_fee_fri = if saw_pool_strk_transfer && fee_total > 0 {
+        Some(fee_total)
+    } else {
+        None
+    };
+
+    // Best-effort InvokeExternal detection: prefer a non-pool inner call in
+    // an outside-execution intent over a top-level non-pool call (the
+    // multicall often contains plumbing — approve, AVNU forwarder — that's
+    // *not* the helper). When neither is available, fall back to the first
+    // non-pool top-level call.
+    let invoke_external = outside_executions
+        .iter()
+        .flat_map(|oe| oe.inner_calls.iter())
+        .find(|c| c.contract_address != *POOL_ADDRESS)
+        .or_else(|| {
+            decoded_calls
+                .iter()
+                .find(|c| c.contract_address != *POOL_ADDRESS)
+        })
+        .map(|c| InvokeExternalRef {
+            target: c.contract_address,
+            selector: c.selector,
+            function_name: c.function_name.clone(),
+        });
+
+    // Paymaster mode (highest-fidelity signal first):
+    //   1. OE wrapping the pool call — true SNIP-9 sponsorship.
+    //   2. Top-level call to a known paymaster forwarder — AVNU gasless
+    //      pattern where the user signs a multicall that routes through
+    //      `0x12702...` to pay STRK fees.
+    //   3. Sender is itself a known relayer.
+    //   4. Otherwise: None.
+    let paymaster = if !outside_executions.is_empty() {
+        PaymasterMode::OutsideExecution
+    } else if decoded_calls
+        .iter()
+        .any(|c| is_known_paymaster_forwarder(&c.contract_address))
+    {
+        PaymasterMode::PaymasterForwarder
+    } else if is_known_paymaster_sender(&tx.sender()) {
+        PaymasterMode::KnownRelayer
+    } else {
+        PaymasterMode::None
+    };
+    let intender = outside_executions.first().map(|oe| oe.intender);
+
+    Some(PrivacySummary {
+        actions,
+        deposits,
+        withdrawals,
+        open_notes_created,
+        open_notes_deposited,
+        enc_notes_created,
+        nullifiers,
+        viewing_keys_set,
+        invoke_external,
+        pool_fee_fri,
+        paymaster,
+        intender,
+    })
+}
+
+/// AVNU Forwarder + a few well-known paymaster relayers. Tx whose sender
+/// matches one of these is overwhelmingly likely to be paymaster-sponsored.
+fn is_known_paymaster_sender(sender: &Felt) -> bool {
+    PAYMASTER_FORWARDERS.iter().any(|p| p == sender)
+}
+
+/// Known paymaster *forwarders* (contracts the user calls to delegate
+/// fee-paying / relaying). Distinct from a paymaster *relayer account*
+/// (which is what shows up as `tx.sender` and usually isn't easily
+/// enumerable). For now both lists collapse into one — extend if a
+/// distinction matters later.
+fn is_known_paymaster_forwarder(addr: &Felt) -> bool {
+    PAYMASTER_FORWARDERS.iter().any(|p| p == addr)
+}
+
+static PAYMASTER_FORWARDERS: LazyLock<Vec<Felt>> = LazyLock::new(|| {
+    [
+        // AVNU Forwarder (gasless v2 entry point)
+        "0x0127021a1b5a52d3174c2ab077c2b043c80369250d29428cee956d76ee51584f",
+        // AVNU Paymaster v2
+        "0x02314f5a43e28fdffd953b2482749f9ed21ced41bfcda186dcbcd91cc61b4054",
+    ]
+    .iter()
+    .filter_map(|h| Felt::from_hex(h).ok())
+    .collect()
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::types::SnEvent;
+
+    fn make_event(from: Felt, keys: Vec<Felt>, data: Vec<Felt>) -> DecodedEvent {
+        DecodedEvent {
+            contract_address: from,
+            event_name: None,
+            decoded_keys: Vec::new(),
+            decoded_data: Vec::new(),
+            raw: SnEvent {
+                from_address: from,
+                keys,
+                data,
+                transaction_hash: Felt::ZERO,
+                block_number: 0,
+                event_index: 0,
+            },
+        }
+    }
+
+    fn pool() -> Felt {
+        *POOL_ADDRESS
+    }
+
+    fn pool_call() -> RawCall {
+        RawCall {
+            contract_address: pool(),
+            selector: Felt::ZERO,
+            data: Vec::new(),
+            function_name: Some("apply_actions".to_string()),
+            function_def: None,
+            contract_abi: None,
+        }
+    }
+
+    fn invoke_tx_with_sender(sender: Felt) -> SnTransaction {
+        SnTransaction::Invoke(crate::data::types::InvokeTx {
+            hash: Felt::ZERO,
+            sender_address: sender,
+            calldata: Vec::new(),
+            nonce: None,
+            version: Felt::from(3u64),
+            actual_fee: None,
+            execution_status: crate::data::types::ExecutionStatus::Succeeded,
+            block_number: 0,
+            index: 0,
+            tip: 0,
+            resource_bounds: None,
+        })
+    }
+
+    #[test]
+    fn returns_none_for_non_privacy_tx() {
+        let tx = invoke_tx_with_sender(Felt::from(1u64));
+        let other_call = RawCall {
+            contract_address: Felt::from_hex(
+                "0x04270219d365d6b017231b52e92b3fb5d7c8378b05e9abc97724537a80e93b0f",
+            )
+            .unwrap(), // AVNU
+            selector: Felt::ZERO,
+            data: Vec::new(),
+            function_name: None,
+            function_def: None,
+            contract_abi: None,
+        };
+        assert!(summarize(&tx, &[other_call], &[], &[]).is_none());
+    }
+
+    /// Mirrors the structure of mainnet tx
+    /// 0x90304ef5b180c520ce866161c0a14618a72af5aa841fe38a243220aa05bfa2:
+    /// 2 NoteUsed, 1 OpenNoteCreated, 1 Withdrawal, 1 OpenNoteDeposited.
+    #[test]
+    fn counts_action_mix_from_events() {
+        let s = &*EVENT_SELECTORS;
+        let tx = invoke_tx_with_sender(Felt::from(1u64));
+        let p = pool();
+        let null_a = Felt::from(0xAAu64);
+        let null_b = Felt::from(0xBBu64);
+        let token =
+            Felt::from_hex("0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d")
+                .unwrap();
+        let note_id = Felt::from(0x100u64);
+        let to_addr = Felt::from(0xCAFEu64);
+        let depositor = Felt::from(0xBEEFu64);
+
+        let events = vec![
+            make_event(p, vec![s.note_used, null_a], vec![]),
+            make_event(p, vec![s.note_used, null_b], vec![]),
+            make_event(
+                p,
+                vec![s.open_note_created, token, note_id],
+                vec![Felt::ZERO; 3], // enc_recipient_addr (3 felts)
+            ),
+            make_event(
+                p,
+                vec![s.withdrawal, to_addr, token],
+                vec![
+                    Felt::ZERO,
+                    Felt::ZERO,
+                    Felt::ZERO,
+                    Felt::from(0xde0b6b3a7640000u128),
+                ],
+            ),
+            make_event(
+                p,
+                vec![s.open_note_deposited, depositor, token, note_id],
+                vec![Felt::from(0xde0b6b3a7640000u128), Felt::ZERO],
+            ),
+        ];
+
+        let summary = summarize(&tx, &[pool_call()], &events, &[]).expect("privacy tx");
+        assert_eq!(summary.actions.notes_used, 2);
+        assert_eq!(summary.actions.open_notes_created, 1);
+        assert_eq!(summary.actions.withdrawals, 1);
+        assert_eq!(summary.actions.open_notes_deposited, 1);
+        assert_eq!(summary.actions.total(), 5);
+        assert_eq!(summary.nullifiers, vec![null_a, null_b]);
+        assert_eq!(summary.withdrawals.len(), 1);
+        assert_eq!(summary.withdrawals[0].to_addr, to_addr);
+        assert_eq!(summary.withdrawals[0].token, token);
+        assert_eq!(summary.withdrawals[0].amount, 0xde0b6b3a7640000u128);
+        assert_eq!(summary.open_notes_deposited[0].depositor, depositor);
+        assert_eq!(
+            summary.open_notes_deposited[0].amount,
+            0xde0b6b3a7640000u128
+        );
+    }
+
+    #[test]
+    fn detects_paymaster_sender() {
+        let avnu =
+            Felt::from_hex("0x0127021a1b5a52d3174c2ab077c2b043c80369250d29428cee956d76ee51584f")
+                .unwrap();
+        let tx = invoke_tx_with_sender(avnu);
+        let summary = summarize(&tx, &[pool_call()], &[], &[]).unwrap();
+        assert_eq!(summary.paymaster, PaymasterMode::KnownRelayer);
+        assert!(summary.paymaster.is_sponsored());
+    }
+
+    /// Reproduces the shape of mainnet tx
+    /// `0x4b9cde1b731130096209a2af5f947e3a57c290dcfa99c358bc958521ff3c35f`:
+    /// the privacy pool call lives only inside an outside-execution intent;
+    /// no top-level multicall entry targets the pool. The summarizer must
+    /// still recognize it as a privacy tx (via the pool-emitted Withdrawal
+    /// event) and report `OutsideExecution` sponsorship.
+    #[test]
+    fn detects_oe_wrapped_pool_call() {
+        let s = &*EVENT_SELECTORS;
+        let strk =
+            Felt::from_hex("0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d")
+                .unwrap();
+        let avnu_forwarder =
+            Felt::from_hex("0x0127021a1b5a52d3174c2ab077c2b043c80369250d29428cee956d76ee51584f")
+                .unwrap();
+        // Synthetic relayer account address (NOT in our known list, like
+        // the real-world `0x22d28...` sender of this tx pattern).
+        let relayer = Felt::from_hex("0x22d28").unwrap();
+        let tx = invoke_tx_with_sender(relayer);
+
+        // Top-level multicall: just a transfer + a forwarder call. No direct
+        // pool reference — the pool only appears inside the OE inner_calls.
+        let approve = RawCall {
+            contract_address: strk,
+            selector: Felt::ZERO,
+            data: Vec::new(),
+            function_name: Some("transfer".into()),
+            function_def: None,
+            contract_abi: None,
+        };
+        let forwarder_call = RawCall {
+            contract_address: avnu_forwarder,
+            selector: Felt::ZERO,
+            data: Vec::new(),
+            function_name: Some("execute_from_outside_v2".into()),
+            function_def: None,
+            contract_abi: None,
+        };
+
+        let user_addr = Felt::from(0xCAFEu64);
+        let oe = OutsideExecutionInfo {
+            intender: user_addr,
+            caller: avnu_forwarder,
+            nonce: Felt::ZERO,
+            execute_after: 0,
+            execute_before: u64::MAX,
+            inner_calls: vec![RawCall {
+                contract_address: pool(),
+                selector: Felt::ZERO,
+                data: Vec::new(),
+                function_name: Some("apply_actions".into()),
+                function_def: None,
+                contract_abi: None,
+            }],
+            signature: Vec::new(),
+            version: super::super::outside_execution::OutsideExecutionVersion::V2,
+        };
+
+        // Receipt: pool emits a Withdrawal sending 4 STRK to the AVNU
+        // forwarder (paying the gasless service in private STRK).
+        let pool_to_forwarder_amount: u128 = 0x3782dace9d900000;
+        let events = vec![
+            // ERC-20 Transfer pool→forwarder for the withdrawal payout.
+            DecodedEvent {
+                contract_address: strk,
+                event_name: None,
+                decoded_keys: Vec::new(),
+                decoded_data: Vec::new(),
+                raw: SnEvent {
+                    from_address: strk,
+                    keys: vec![
+                        Felt::from_hex(
+                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9",
+                        )
+                        .unwrap(),
+                        pool(),
+                        avnu_forwarder,
+                    ],
+                    data: vec![Felt::from(pool_to_forwarder_amount), Felt::ZERO],
+                    transaction_hash: Felt::ZERO,
+                    block_number: 0,
+                    event_index: 0,
+                },
+            },
+            // Pool's matching Withdrawal event.
+            make_event(
+                pool(),
+                vec![s.withdrawal, avnu_forwarder, strk],
+                vec![
+                    Felt::ZERO,
+                    Felt::ZERO,
+                    Felt::ZERO,
+                    Felt::from(pool_to_forwarder_amount),
+                ],
+            ),
+        ];
+
+        let summary = summarize(&tx, &[approve, forwarder_call], &events, &[oe])
+            .expect("OE-wrapped pool call should still be recognized as a privacy tx");
+        assert_eq!(summary.actions.withdrawals, 1);
+        assert!(
+            summary.pool_fee_fri.is_none(),
+            "withdrawal payout must not be counted as the pool fee"
+        );
+        assert_eq!(summary.paymaster, PaymasterMode::OutsideExecution);
+        assert_eq!(summary.intender, Some(user_addr));
+    }
+}

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -3932,13 +3932,13 @@ pub(super) async fn classify_meta_tx_candidate(
         if oe.intender != address {
             continue;
         }
-        let label = match method {
+        // `OutsideExecutionVersion::short()` returns the canonical short tag
+        // (v1/v2/v3/p1, ≤ 2 chars). Centralizing the meta-tx label here lets
+        // a future version variant added to the enum auto-flow into this
+        // column without an extra match-site update here.
+        let label: &'static str = match method {
             DetectionMethod::AvnuForwarder => "avnu",
-            DetectionMethod::Name => match oe.version {
-                crate::decode::outside_execution::OutsideExecutionVersion::V1 => "v1",
-                crate::decode::outside_execution::OutsideExecutionVersion::V2 => "v2",
-                crate::decode::outside_execution::OutsideExecutionVersion::V3 => "v3",
-            },
+            DetectionMethod::Name => oe.version.short(),
             DetectionMethod::Heuristic => "v?",
         };
         found = Some((oe, label));

--- a/src/network/transaction.rs
+++ b/src/network/transaction.rs
@@ -17,7 +17,8 @@ use crate::decode::events::decode_event;
 use crate::decode::functions::parse_multicall;
 use crate::decode::outside_execution::{
     OutsideExecutionInfo, OutsideExecutionVersion, is_avnu_forwarder, is_outside_execution,
-    looks_like_outside_execution, parse_forwarder_call, parse_outside_execution,
+    looks_like_outside_execution, looks_like_private_sponsored, parse_forwarder_call,
+    parse_outside_execution, parse_private_sponsored,
 };
 
 /// Resolve the ABI for `addr` as of `block`. Prefers the prewarmed
@@ -202,9 +203,20 @@ async fn detect_and_resolve_outside_executions(
 
         let mut oe = None;
 
-        // Method 1: detect by resolved function name
+        // Method 1: detect by resolved function name. `is_outside_execution`
+        // covers both classic SNIP-9 (v1/v2/v3) and the privacy-aware
+        // `execute_private_sponsored` AVNU entrypoint.
         if let Some(version) = is_outside_execution(fname) {
-            oe = parse_outside_execution(call, version);
+            oe = if matches!(version, OutsideExecutionVersion::PrivateSponsored) {
+                parse_private_sponsored(call)
+            } else {
+                parse_outside_execution(call, version)
+            };
+        }
+        // Method 1b: detect `execute_private_sponsored` by selector when the
+        // ABI hasn't resolved a name yet (e.g. cold cache on first run).
+        if oe.is_none() && looks_like_private_sponsored(call) {
+            oe = parse_private_sponsored(call);
         }
         // Method 2: detect by calldata pattern (ANY_CALLER + valid struct)
         if oe.is_none() && fname.is_empty() && looks_like_outside_execution(call) {

--- a/src/registry/known_addresses.rs
+++ b/src/registry/known_addresses.rs
@@ -80,6 +80,8 @@ const BUNDLED_KNOWN_ADDRESSES: &str = r#"
 "0x04daa17763b286d1e59b97c283c0b8c949994c361e426a28f743c67bdfe9a32f" = { name = "tBTC", type = "ERC20", verified = true, source = "bundled", decimals = 18 }
 "0x028d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b0a" = { name = "xSTRK", type = "ERC20", verified = true, source = "bundled", decimals = 18 }
 "0x042b8f0484674ca266ac5d08e4ac6a3fe65bd3129795def2dca5c34ecc5f96d2" = { name = "nstSTRK", type = "ERC20", verified = true, source = "bundled", decimals = 18 }
+"0x02019e47a0bc54ea6b4853c6123ffc8158ea3ae2af4166928b0de6e89f06de6c" = { name = "Relend Network USDC", type = "ERC20", verified = true, source = "bundled", decimals = 6 }
+"0x036834a40984312f7f7de8d31e3f6305b325389eaeea5b1c0664b2fb936461a4" = { name = "LBTC", type = "ERC20", verified = true, source = "bundled", decimals = 8 }
 
 # DEXes
 "0x00000005dd3d2f4429af886cd1a3b08289dbcea99a294197e9eb43b0e0325b4b" = { name = "Ekubo Core", type = "DEX", verified = true, source = "bundled" }
@@ -100,6 +102,9 @@ const BUNDLED_KNOWN_ADDRESSES: &str = r#"
 
 # Lending
 "0x02545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148571e3" = { name = "Vesu Singleton", type = "Lending", verified = true, source = "bundled" }
+# Vesu V1 Singleton — alternate deployment, same V1 class hash
+# (`0x62c6e1d…25750ee`). Padded to 64 hex chars with leading zeros for canonical form.
+"0x000d8d6dfec4d33bfb6895de9f3852143a17c6f92fd2a21da3d6924d34870160" = { name = "Vesu V1 Singleton", type = "Lending", verified = true, source = "bundled" }
 "0x07e2a13b40fc1119ec55e0bcf9428eedaa581ab3c924561ad4e955f95da63138" = { name = "Zklend Market", type = "Lending", verified = true, source = "bundled" }
 
 # Staking
@@ -117,4 +122,14 @@ const BUNDLED_KNOWN_ADDRESSES: &str = r#"
 
 # Known exchanges/wallets
 "0x0620102ea610be8518125cf2de850d0c4f5d0c5d81f969cff666fb53b05042d2" = { name = "Kraken Hot Wallet", type = "Exchange", verified = true, source = "bundled" }
+
+# Privacy
+"0x040337b1af3c663e86e333bab5a4b28da8d4652a15a69beee2b677776ffe812a" = { name = "Privacy Pool", type = "Privacy", verified = true, source = "bundled" }
+# Privacy Pool's Ekubo swap helper (deployed instance of class
+# `0x61047c2...061dc`). Called by the pool's `InvokeExternal` action when
+# a user swaps private funds via Ekubo: pool withdraws to this helper,
+# helper executes the Ekubo swap, helper deposits the proceeds back into
+# the pool as an OpenNote. Identified via getClassHashAt against tx
+# 0x90304ef5b180c520ce866161c0a14618a72af5aa841fe38a243220aa05bfa2.
+"0x00389e0930f2bcf14221adefb71007ca71cec4cd4f64f321836392d2748a14c6" = { name = "Privacy Ekubo Helper", type = "Privacy", verified = true, source = "bundled" }
 "#;

--- a/src/ui/views/tx_detail.rs
+++ b/src/ui/views/tx_detail.rs
@@ -13,6 +13,7 @@ use crate::decode::calldata::{self, DecodedValue};
 use crate::decode::events::{DecodedEvent, DecodedParam};
 use crate::decode::functions::RawCall;
 use crate::decode::outside_execution;
+use crate::decode::privacy::PrivacySummary;
 use crate::decode::trace::{DecodedTraceCall, MulticallGroup, TransferRow};
 use crate::ui::theme;
 use crate::ui::widgets::address_color::AddressColorMap;
@@ -54,23 +55,58 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     let color_map = build_color_map(app);
     let mut line_map: Vec<Option<u16>> = vec![None; app.tx_detail.nav_items.len()];
 
+    // Compute the privacy summary once per frame (cheap: scans events + calls
+    // already in memory). Threaded into the header (for the PRIVACY badge),
+    // the tab bar (to conditionally show the Privacy tab), and the body.
+    // The summarizer needs the parsed outside-execution list too, since
+    // sponsored privacy txs (e.g. AVNU gasless) only reach the pool through
+    // an OE inner-call.
+    let oe_for_privacy: Vec<crate::decode::outside_execution::OutsideExecutionInfo> = app
+        .tx_detail
+        .outside_executions
+        .iter()
+        .map(|(_, info)| info.clone())
+        .collect();
+    let privacy_summary = app.tx_detail.transaction.as_ref().and_then(|tx| {
+        crate::decode::privacy::summarize(
+            tx,
+            &app.tx_detail.decoded_calls,
+            &app.tx_detail.decoded_events,
+            &oe_for_privacy,
+        )
+    });
+
     // Header always renders, so it's always rebuilt. Tab bodies are computed
-    // for all three tabs only in visual mode — that's when cross-tab cursor
+    // for all visible tabs only in visual mode — that's when cross-tab cursor
     // navigation needs up-to-date line offsets for every tab. Outside visual
     // mode only the active tab is visible, so we skip building the others to
     // avoid recomputing large traces on every frame.
-    let header_lines = build_header_lines(app, &color_map, selected.as_ref(), &mut line_map);
-    let (events_lines, calls_lines, transfers_lines, trace_lines) = if app.tx_detail.visual_mode {
+    let header_lines = build_header_lines(
+        app,
+        &color_map,
+        selected.as_ref(),
+        &mut line_map,
+        privacy_summary.as_ref(),
+    );
+    let (events_lines, calls_lines, transfers_lines, trace_lines, privacy_lines) = if app
+        .tx_detail
+        .visual_mode
+    {
         (
             build_events_lines(app, &color_map, selected.as_ref(), &mut line_map),
             build_calls_lines(app, &color_map, selected.as_ref(), &mut line_map),
             build_transfers_lines(app, &color_map, selected.as_ref(), &mut line_map),
             build_trace_lines(app, &color_map, selected.as_ref(), &mut line_map),
+            privacy_summary
+                .as_ref()
+                .map(|s| build_privacy_lines(app, s, &color_map, selected.as_ref(), &mut line_map))
+                .unwrap_or_default(),
         )
     } else {
         match app.tx_detail.active_tab {
             TxTab::Events => (
                 build_events_lines(app, &color_map, selected.as_ref(), &mut line_map),
+                Vec::new(),
                 Vec::new(),
                 Vec::new(),
                 Vec::new(),
@@ -80,11 +116,13 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                 build_calls_lines(app, &color_map, selected.as_ref(), &mut line_map),
                 Vec::new(),
                 Vec::new(),
+                Vec::new(),
             ),
             TxTab::Transfers => (
                 Vec::new(),
                 Vec::new(),
                 build_transfers_lines(app, &color_map, selected.as_ref(), &mut line_map),
+                Vec::new(),
                 Vec::new(),
             ),
             TxTab::Trace => (
@@ -92,6 +130,24 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                 Vec::new(),
                 Vec::new(),
                 build_trace_lines(app, &color_map, selected.as_ref(), &mut line_map),
+                Vec::new(),
+            ),
+            TxTab::Privacy => (
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                privacy_summary
+                    .as_ref()
+                    .map(|s| {
+                        build_privacy_lines(app, s, &color_map, selected.as_ref(), &mut line_map)
+                    })
+                    .unwrap_or_else(|| {
+                        vec![Line::from(Span::styled(
+                            "   (not a privacy-pool transaction)",
+                            theme::SUGGESTION_STYLE,
+                        ))]
+                    }),
             ),
         }
     };
@@ -114,7 +170,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
 
     search_bar::draw_input(f, app, chunks[0]);
     draw_header_panel(f, header_lines, chunks[1]);
-    draw_tabs_bar(f, app, chunks[2]);
+    draw_tabs_bar(f, app, chunks[2], privacy_summary.as_ref());
     draw_active_tab_body(
         f,
         app,
@@ -123,6 +179,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         calls_lines,
         transfers_lines,
         trace_lines,
+        privacy_lines,
     );
     status_bar::draw(f, app, chunks[4]);
 
@@ -142,7 +199,7 @@ fn draw_header_panel(f: &mut Frame, lines: Vec<Line<'static>>, area: Rect) {
     f.render_widget(widget, area);
 }
 
-fn draw_tabs_bar(f: &mut Frame, app: &App, area: Rect) {
+fn draw_tabs_bar(f: &mut Frame, app: &App, area: Rect, privacy: Option<&PrivacySummary>) {
     let events_count = app.tx_detail.decoded_events.len();
     let calls_count = app.tx_detail.decoded_calls.len();
     let trace_count = app
@@ -163,17 +220,26 @@ fn draw_tabs_bar(f: &mut Frame, app: &App, area: Rect) {
         None if app.tx_detail.trace_loading => "Transfers (loading…)".to_string(),
         None => "Transfers".to_string(),
     };
-    let titles = vec![
+    let mut titles = vec![
         Span::raw(format!(" Events ({events_count}) ")),
         Span::raw(format!(" Calls ({calls_count}) ")),
         Span::raw(format!(" {transfers_label} ")),
         Span::raw(format!(" {trace_label} ")),
     ];
+    // Privacy tab is conditional: only show when this tx interacts with the
+    // pool. Non-privacy txs keep the original 4-tab layout.
+    if let Some(s) = privacy {
+        titles.push(Span::styled(
+            format!(" Privacy ({}) ", s.actions.total()),
+            theme::META_TX_STYLE,
+        ));
+    }
     let selected = match app.tx_detail.active_tab {
         TxTab::Events => 0,
         TxTab::Calls => 1,
         TxTab::Transfers => 2,
         TxTab::Trace => 3,
+        TxTab::Privacy => 4,
     };
     // Active tab uses a filled background for high contrast — much more
     // visible than the default underline at-a-glance.
@@ -190,6 +256,7 @@ fn draw_tabs_bar(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(tabs, area);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn draw_active_tab_body(
     f: &mut Frame,
     app: &App,
@@ -198,6 +265,7 @@ fn draw_active_tab_body(
     calls_lines: Vec<Line<'static>>,
     transfers_lines: Vec<Line<'static>>,
     trace_lines: Vec<Line<'static>>,
+    privacy_lines: Vec<Line<'static>>,
 ) {
     let (lines, scroll, title) = match app.tx_detail.active_tab {
         TxTab::Events => (
@@ -219,6 +287,11 @@ fn draw_active_tab_body(
             trace_lines,
             app.tx_detail.trace_scroll,
             " Trace (j/k: scroll · Ctrl+U/D: page · v: visual · e: expand · Tab: switch · Ctrl+P/N: tx up/down) ",
+        ),
+        TxTab::Privacy => (
+            privacy_lines,
+            app.tx_detail.privacy_scroll,
+            " Privacy (j/k: scroll · Ctrl+U/D: page · v: visual · e: expand · Tab: switch · Ctrl+P/N: tx up/down) ",
         ),
     };
     let widget = Paragraph::new(lines)
@@ -333,6 +406,7 @@ fn build_header_lines(
     color_map: &AddressColorMap,
     selected: Option<&TxNavItem>,
     line_map: &mut [Option<u16>],
+    privacy: Option<&PrivacySummary>,
 ) -> Vec<Line<'static>> {
     let mut lines: Vec<Line<'static>> = Vec::new();
     let tx = match &app.tx_detail.transaction {
@@ -428,6 +502,42 @@ fn build_header_lines(
         Span::styled(tx.type_name(), type_style),
     ]));
 
+    // PRIVACY indicator: present only when this tx interacts with the
+    // Starknet Privacy Pool. One line: pool fee + paymaster signal + action
+    // count. The full breakdown lives in the Privacy tab.
+    if let Some(p) = privacy {
+        let mut spans: Vec<Span<'static>> = Vec::new();
+        spans.push(Span::styled(" Tag:    ", theme::NORMAL_STYLE));
+        spans.push(Span::styled("PRIVACY", theme::META_TX_STYLE));
+        spans.push(Span::styled(
+            format!("  ({} actions)", p.actions.total()),
+            theme::SUGGESTION_STYLE,
+        ));
+        if let Some(fee) = p.pool_fee_fri {
+            spans.push(Span::styled("  Pool fee: ", theme::NORMAL_STYLE));
+            spans.push(Span::styled(format_strk_u128(fee), theme::TX_FEE_STYLE));
+        }
+        match p.paymaster {
+            crate::decode::privacy::PaymasterMode::OutsideExecution => {
+                spans.push(Span::styled(
+                    "  paymaster: sponsored (outside-exec)",
+                    theme::STATUS_OK,
+                ));
+            }
+            crate::decode::privacy::PaymasterMode::PaymasterForwarder => {
+                spans.push(Span::styled(
+                    "  paymaster: forwarder route",
+                    theme::STATUS_OK,
+                ));
+            }
+            crate::decode::privacy::PaymasterMode::KnownRelayer => {
+                spans.push(Span::styled("  paymaster: known relayer", theme::STATUS_OK));
+            }
+            crate::decode::privacy::PaymasterMode::None => {}
+        }
+        lines.push(Line::from(spans));
+    }
+
     // META TX indicator for outside executions
     if !app.tx_detail.outside_executions.is_empty() {
         for (_, oe) in &app.tx_detail.outside_executions {
@@ -440,14 +550,36 @@ fn build_header_lines(
                 &app.tx_detail.nav_sections,
                 NavSection::Header,
             );
-            lines.push(Line::from(vec![
+            // For `execute_private_sponsored` the user identity is hidden
+            // inside the privacy proof — there's no "intender" in the
+            // SNIP-9 sense. Label the surfaced address as "Forwarder" and
+            // skip the meaningless `Nonce: 0x0`.
+            let is_private_sponsored = matches!(
+                oe.version,
+                crate::decode::outside_execution::OutsideExecutionVersion::PrivateSponsored
+            );
+            let role_label = if is_private_sponsored {
+                "  Forwarder: "
+            } else {
+                "  Intender: "
+            };
+            let mut spans = vec![
                 addr_marker(&oe.intender, selected),
                 Span::styled("Meta:   ", theme::NORMAL_STYLE),
-                Span::styled(format!("META TX ({})", oe.version), theme::META_TX_STYLE),
-                Span::styled("  Intender: ", theme::NORMAL_STYLE),
+                Span::styled(
+                    format!("META TX ({})", oe.version.verbose()),
+                    theme::META_TX_STYLE,
+                ),
+                Span::styled(role_label, theme::NORMAL_STYLE),
                 Span::styled(fmt_addr_full(app, &oe.intender), intender_style),
-                Span::styled(format!("  Nonce: {:#x}", oe.nonce), theme::SUGGESTION_STYLE),
-            ]));
+            ];
+            if !is_private_sponsored {
+                spans.push(Span::styled(
+                    format!("  Nonce: {:#x}", oe.nonce),
+                    theme::SUGGESTION_STYLE,
+                ));
+            }
+            lines.push(Line::from(spans));
             lines.push(Line::from(vec![
                 Span::raw("        "),
                 Span::styled(format!(" {:#x}", oe.intender), intender_style),
@@ -902,7 +1034,7 @@ fn build_calls_lines(
             lines.push(Line::from(vec![
                 Span::raw("        "),
                 Span::styled(
-                    format!("Outside Execution ({})", oe.version),
+                    format!("Outside Execution ({})", oe.version.verbose()),
                     theme::META_TX_STYLE,
                 ),
                 Span::styled(
@@ -937,30 +1069,57 @@ fn build_calls_lines(
         ]));
         for (_, oe) in &app.tx_detail.outside_executions {
             let intender_style = addr_style(&oe.intender, color_map, selected);
-            let caller_str = outside_execution::format_caller(&oe.caller);
-            lines.push(Line::from(vec![
-                Span::styled("   Intender: ", theme::NORMAL_STYLE),
-                Span::styled(fmt_addr_full(app, &oe.intender), intender_style),
-            ]));
-            lines.push(Line::from(vec![
-                Span::raw("             "),
-                Span::styled(format!("{:#x}", oe.intender), intender_style),
-            ]));
-            lines.push(Line::from(vec![
-                Span::styled("   Caller:   ", theme::NORMAL_STYLE),
-                Span::raw(caller_str),
-            ]));
-            lines.push(Line::from(vec![
-                Span::styled("   Nonce:    ", theme::NORMAL_STYLE),
-                Span::styled(format!("{:#x}", oe.nonce), theme::TX_HASH_STYLE),
-            ]));
-            lines.push(Line::from(vec![
-                Span::styled("   Window:   ", theme::NORMAL_STYLE),
-                Span::raw(format!(
-                    "after: {}  before: {}",
-                    oe.execute_after, oe.execute_before
-                )),
-            ]));
+            let is_private_sponsored = matches!(
+                oe.version,
+                crate::decode::outside_execution::OutsideExecutionVersion::PrivateSponsored
+            );
+            // For `execute_private_sponsored` the user is anonymous (proof
+            // is inside the inner call), and there's no caller/nonce/window
+            // to display — the wrapper carries only a call array + relayer
+            // auth blob. Show the forwarder address and jump straight to
+            // the inner calls.
+            if is_private_sponsored {
+                lines.push(Line::from(vec![
+                    Span::styled("   Forwarder: ", theme::NORMAL_STYLE),
+                    Span::styled(fmt_addr_full(app, &oe.intender), intender_style),
+                ]));
+                lines.push(Line::from(vec![
+                    Span::raw("              "),
+                    Span::styled(format!("{:#x}", oe.intender), intender_style),
+                ]));
+                lines.push(Line::from(vec![
+                    Span::styled("   User:      ", theme::NORMAL_STYLE),
+                    Span::styled(
+                        "anonymous (privacy-proven inside inner call)",
+                        theme::SUGGESTION_STYLE,
+                    ),
+                ]));
+            } else {
+                let caller_str = outside_execution::format_caller(&oe.caller);
+                lines.push(Line::from(vec![
+                    Span::styled("   Intender: ", theme::NORMAL_STYLE),
+                    Span::styled(fmt_addr_full(app, &oe.intender), intender_style),
+                ]));
+                lines.push(Line::from(vec![
+                    Span::raw("             "),
+                    Span::styled(format!("{:#x}", oe.intender), intender_style),
+                ]));
+                lines.push(Line::from(vec![
+                    Span::styled("   Caller:   ", theme::NORMAL_STYLE),
+                    Span::raw(caller_str),
+                ]));
+                lines.push(Line::from(vec![
+                    Span::styled("   Nonce:    ", theme::NORMAL_STYLE),
+                    Span::styled(format!("{:#x}", oe.nonce), theme::TX_HASH_STYLE),
+                ]));
+                lines.push(Line::from(vec![
+                    Span::styled("   Window:   ", theme::NORMAL_STYLE),
+                    Span::raw(format!(
+                        "after: {}  before: {}",
+                        oe.execute_after, oe.execute_before
+                    )),
+                ]));
+            }
             lines.push(Line::from(""));
             lines.push(Line::from(Span::styled(
                 format!("   Inner Calls ({})", oe.inner_calls.len()),
@@ -1011,6 +1170,364 @@ fn build_calls_lines(
     }
 
     lines
+}
+
+/// Build the Privacy tab body: action-mix line + per-action breakdown of
+/// publicly-observable fields. Encrypted fields (enc_user_addr,
+/// enc_recipient_addr, packed_value) are deliberately not surfaced — they're
+/// auditor-only and showing the bytes is just noise.
+fn build_privacy_lines(
+    app: &App,
+    summary: &PrivacySummary,
+    color_map: &AddressColorMap,
+    selected: Option<&TxNavItem>,
+    line_map: &mut [Option<u16>],
+) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let registry = app.search_engine.as_ref().map(|e| e.registry());
+
+    // === Action mix (one-line summary) ===
+    lines.push(Line::from(Span::styled(
+        format!(" Actions ({} total)", summary.actions.total()),
+        theme::TITLE_STYLE,
+    )));
+    let mix = &summary.actions;
+    let mut chips: Vec<String> = Vec::new();
+    if mix.notes_used > 0 {
+        chips.push(format!("{} NoteUsed", mix.notes_used));
+    }
+    if mix.enc_notes_created > 0 {
+        chips.push(format!("{} EncNoteCreated", mix.enc_notes_created));
+    }
+    if mix.open_notes_created > 0 {
+        chips.push(format!("{} OpenNoteCreated", mix.open_notes_created));
+    }
+    if mix.open_notes_deposited > 0 {
+        chips.push(format!("{} OpenNoteDeposited", mix.open_notes_deposited));
+    }
+    if mix.deposits > 0 {
+        chips.push(format!("{} Deposit", mix.deposits));
+    }
+    if mix.withdrawals > 0 {
+        chips.push(format!("{} Withdrawal", mix.withdrawals));
+    }
+    if mix.viewing_keys_set > 0 {
+        chips.push(format!("{} ViewingKeySet", mix.viewing_keys_set));
+    }
+    if mix.invoke_external > 0 {
+        chips.push(format!("{} InvokeExternal", mix.invoke_external));
+    }
+    let mix_line = if chips.is_empty() {
+        "(none)".to_string()
+    } else {
+        chips.join(" · ")
+    };
+    lines.push(Line::from(vec![
+        Span::raw("   "),
+        Span::styled(mix_line, theme::TX_HASH_STYLE),
+    ]));
+    lines.push(Line::from(""));
+
+    // === Public deposits ===
+    if !summary.deposits.is_empty() {
+        lines.push(Line::from(Span::styled(
+            format!(" Deposits ({})", summary.deposits.len()),
+            theme::TITLE_STYLE,
+        )));
+        for (i, d) in summary.deposits.iter().enumerate() {
+            let last = i == summary.deposits.len() - 1;
+            let branch = if last { "└─" } else { "├─" };
+            let token_label = fmt_addr(app, &d.token);
+            let token_style = addr_style(&d.token, color_map, selected);
+            let user_style = addr_style(&d.user_addr, color_map, selected);
+            let amount_str = format_amount_for_token(registry, &d.token, d.amount);
+            record(
+                &TxNavItem::Address(d.user_addr),
+                lines.len(),
+                line_map,
+                &app.tx_detail.nav_items,
+                &app.tx_detail.nav_sections,
+                NavSection::Privacy,
+            );
+            lines.push(Line::from(vec![
+                addr_marker_any(&[&d.user_addr, &d.token], selected),
+                Span::styled(format!("{branch} "), theme::BORDER_STYLE),
+                Span::styled(amount_str, theme::TX_FEE_STYLE),
+                Span::raw(" "),
+                Span::styled(token_label, token_style),
+                Span::styled("  from ", theme::SUGGESTION_STYLE),
+                Span::styled(fmt_addr(app, &d.user_addr), user_style),
+            ]));
+        }
+        lines.push(Line::from(""));
+    }
+
+    // === Public withdrawals (sender encrypted, recipient clear) ===
+    if !summary.withdrawals.is_empty() {
+        lines.push(Line::from(Span::styled(
+            format!(" Withdrawals ({})", summary.withdrawals.len()),
+            theme::TITLE_STYLE,
+        )));
+        for (i, w) in summary.withdrawals.iter().enumerate() {
+            let last = i == summary.withdrawals.len() - 1;
+            let branch = if last { "└─" } else { "├─" };
+            let token_label = fmt_addr(app, &w.token);
+            let token_style = addr_style(&w.token, color_map, selected);
+            let to_style = addr_style(&w.to_addr, color_map, selected);
+            let amount_str = format_amount_for_token(registry, &w.token, w.amount);
+            record(
+                &TxNavItem::Address(w.to_addr),
+                lines.len(),
+                line_map,
+                &app.tx_detail.nav_items,
+                &app.tx_detail.nav_sections,
+                NavSection::Privacy,
+            );
+            lines.push(Line::from(vec![
+                addr_marker_any(&[&w.to_addr, &w.token], selected),
+                Span::styled(format!("{branch} "), theme::BORDER_STYLE),
+                Span::styled(amount_str, theme::TX_FEE_STYLE),
+                Span::raw(" "),
+                Span::styled(token_label, token_style),
+                Span::styled("  → ", theme::SUGGESTION_STYLE),
+                Span::styled(fmt_addr(app, &w.to_addr), to_style),
+                Span::styled("    sender: encrypted", theme::SUGGESTION_STYLE),
+            ]));
+        }
+        lines.push(Line::from(""));
+    }
+
+    // === Open notes (created + deposited) ===
+    if !summary.open_notes_created.is_empty() || !summary.open_notes_deposited.is_empty() {
+        let total = summary.open_notes_created.len() + summary.open_notes_deposited.len();
+        lines.push(Line::from(Span::styled(
+            format!(" Open notes ({total})"),
+            theme::TITLE_STYLE,
+        )));
+        for (i, n) in summary.open_notes_created.iter().enumerate() {
+            let last_outer = i == summary.open_notes_created.len() - 1
+                && summary.open_notes_deposited.is_empty();
+            let branch = if last_outer { "└─" } else { "├─" };
+            let token_label = fmt_addr(app, &n.token);
+            let token_style = addr_style(&n.token, color_map, selected);
+            lines.push(Line::from(vec![
+                Span::raw(" "),
+                Span::styled(format!("{branch} "), theme::BORDER_STYLE),
+                Span::styled("created  ", theme::NORMAL_STYLE),
+                Span::styled(token_label, token_style),
+                Span::styled(format!("  note {:#x}", n.note_id), theme::SUGGESTION_STYLE),
+                Span::styled("    recipient: encrypted", theme::SUGGESTION_STYLE),
+            ]));
+        }
+        for (i, d) in summary.open_notes_deposited.iter().enumerate() {
+            let last = i == summary.open_notes_deposited.len() - 1;
+            let branch = if last { "└─" } else { "├─" };
+            let token_label = fmt_addr(app, &d.token);
+            let token_style = addr_style(&d.token, color_map, selected);
+            let depositor_style = addr_style(&d.depositor, color_map, selected);
+            let amount_str = format_amount_for_token(registry, &d.token, d.amount);
+            record(
+                &TxNavItem::Address(d.depositor),
+                lines.len(),
+                line_map,
+                &app.tx_detail.nav_items,
+                &app.tx_detail.nav_sections,
+                NavSection::Privacy,
+            );
+            lines.push(Line::from(vec![
+                addr_marker_any(&[&d.depositor, &d.token], selected),
+                Span::styled(format!("{branch} "), theme::BORDER_STYLE),
+                Span::styled("deposited ", theme::NORMAL_STYLE),
+                Span::styled(amount_str, theme::TX_FEE_STYLE),
+                Span::raw(" "),
+                Span::styled(token_label, token_style),
+                Span::styled(format!("  note {:#x}", d.note_id), theme::SUGGESTION_STYLE),
+                Span::styled("  by ", theme::SUGGESTION_STYLE),
+                Span::styled(fmt_addr(app, &d.depositor), depositor_style),
+            ]));
+        }
+        lines.push(Line::from(""));
+    }
+
+    // === Viewing-key registrations ===
+    if !summary.viewing_keys_set.is_empty() {
+        lines.push(Line::from(Span::styled(
+            format!(" Joined pool ({})", summary.viewing_keys_set.len()),
+            theme::TITLE_STYLE,
+        )));
+        for (i, v) in summary.viewing_keys_set.iter().enumerate() {
+            let last = i == summary.viewing_keys_set.len() - 1;
+            let branch = if last { "└─" } else { "├─" };
+            let user_style = addr_style(&v.user_addr, color_map, selected);
+            record(
+                &TxNavItem::Address(v.user_addr),
+                lines.len(),
+                line_map,
+                &app.tx_detail.nav_items,
+                &app.tx_detail.nav_sections,
+                NavSection::Privacy,
+            );
+            lines.push(Line::from(vec![
+                addr_marker(&v.user_addr, selected),
+                Span::styled(format!("{branch} "), theme::BORDER_STYLE),
+                Span::styled(fmt_addr_full(app, &v.user_addr), user_style),
+                Span::styled(
+                    format!("  pubkey {:#x}", v.public_key),
+                    theme::SUGGESTION_STYLE,
+                ),
+            ]));
+        }
+        lines.push(Line::from(""));
+    }
+
+    // === Internal counts (nullifiers + enc-notes) ===
+    // Surfaced as collapsed summaries by default; `e` (expand_all) lists IDs.
+    if !summary.nullifiers.is_empty() {
+        lines.push(Line::from(vec![
+            Span::styled(" Nullifiers consumed: ", theme::TITLE_STYLE),
+            Span::styled(
+                format!("{} note(s) spent", summary.nullifiers.len()),
+                theme::TX_HASH_STYLE,
+            ),
+        ]));
+        if app.tx_detail.expand_all {
+            for (i, n) in summary.nullifiers.iter().enumerate() {
+                let last = i == summary.nullifiers.len() - 1;
+                let branch = if last { "└─" } else { "├─" };
+                lines.push(Line::from(vec![
+                    Span::raw(" "),
+                    Span::styled(format!("{branch} "), theme::BORDER_STYLE),
+                    Span::styled(format!("{:#x}", n), theme::SUGGESTION_STYLE),
+                ]));
+            }
+        }
+    }
+    if !summary.enc_notes_created.is_empty() {
+        lines.push(Line::from(vec![
+            Span::styled(" Enc-notes created:   ", theme::TITLE_STYLE),
+            Span::styled(
+                format!("{} note(s)", summary.enc_notes_created.len()),
+                theme::TX_HASH_STYLE,
+            ),
+            Span::styled(
+                "    (values encrypted, auditor-only)",
+                theme::SUGGESTION_STYLE,
+            ),
+        ]));
+        if app.tx_detail.expand_all {
+            for (i, n) in summary.enc_notes_created.iter().enumerate() {
+                let last = i == summary.enc_notes_created.len() - 1;
+                let branch = if last { "└─" } else { "├─" };
+                lines.push(Line::from(vec![
+                    Span::raw(" "),
+                    Span::styled(format!("{branch} "), theme::BORDER_STYLE),
+                    Span::styled(format!("{:#x}", n), theme::SUGGESTION_STYLE),
+                ]));
+            }
+        }
+    }
+    if !summary.nullifiers.is_empty() || !summary.enc_notes_created.is_empty() {
+        lines.push(Line::from(""));
+    }
+
+    // === InvokeExternal target ===
+    if let Some(ie) = &summary.invoke_external {
+        lines.push(Line::from(Span::styled(
+            " Invoke external",
+            theme::TITLE_STYLE,
+        )));
+        let target_style = addr_style(&ie.target, color_map, selected);
+        let fn_label = ie
+            .function_name
+            .clone()
+            .unwrap_or_else(|| format!("{:#x}", ie.selector));
+        record(
+            &TxNavItem::Address(ie.target),
+            lines.len(),
+            line_map,
+            &app.tx_detail.nav_items,
+            &app.tx_detail.nav_sections,
+            NavSection::Privacy,
+        );
+        lines.push(Line::from(vec![
+            addr_marker(&ie.target, selected),
+            Span::styled("└─ ", theme::BORDER_STYLE),
+            Span::styled(fmt_addr_full(app, &ie.target), target_style),
+            Span::styled("  → ", theme::NORMAL_STYLE),
+            Span::styled(fn_label, theme::TX_HASH_STYLE),
+        ]));
+        lines.push(Line::from(""));
+    }
+
+    // === Pool fee + paymaster signal ===
+    if let Some(fee) = summary.pool_fee_fri {
+        lines.push(Line::from(vec![
+            Span::styled(" Pool fee: ", theme::NORMAL_STYLE),
+            Span::styled(format_strk_u128(fee), theme::TX_FEE_STYLE),
+            Span::styled(
+                "    (transferred from the pool to its fee collector)",
+                theme::SUGGESTION_STYLE,
+            ),
+        ]));
+    }
+    let (paymaster_label, paymaster_style) = match summary.paymaster {
+        crate::decode::privacy::PaymasterMode::OutsideExecution => (
+            "sponsored (outside-execution intent)".to_string(),
+            theme::STATUS_OK,
+        ),
+        crate::decode::privacy::PaymasterMode::PaymasterForwarder => (
+            "sponsored (multicall routes through a known paymaster forwarder)".to_string(),
+            theme::STATUS_OK,
+        ),
+        crate::decode::privacy::PaymasterMode::KnownRelayer => (
+            "sponsored (sender is a known relayer)".to_string(),
+            theme::STATUS_OK,
+        ),
+        crate::decode::privacy::PaymasterMode::None => (
+            "no sponsorship signal (sender likely paid directly)".to_string(),
+            theme::SUGGESTION_STYLE,
+        ),
+    };
+    lines.push(Line::from(vec![
+        Span::styled(" Paymaster: ", theme::NORMAL_STYLE),
+        Span::styled(paymaster_label, paymaster_style),
+    ]));
+    if let Some(intender) = summary.intender {
+        let intender_style = addr_style(&intender, color_map, selected);
+        record(
+            &TxNavItem::Address(intender),
+            lines.len(),
+            line_map,
+            &app.tx_detail.nav_items,
+            &app.tx_detail.nav_sections,
+            NavSection::Privacy,
+        );
+        lines.push(Line::from(vec![
+            addr_marker(&intender, selected),
+            Span::styled("Intender:  ", theme::NORMAL_STYLE),
+            Span::styled(fmt_addr_full(app, &intender), intender_style),
+            Span::styled(
+                "  (signer of the OE intent — the actual user)",
+                theme::SUGGESTION_STYLE,
+            ),
+        ]));
+    }
+
+    lines
+}
+
+/// Format a u128 amount using token decimals when known. Falls back to a
+/// raw decimal print for tokens we don't have decimals for.
+fn format_amount_for_token(
+    registry: Option<&crate::registry::AddressRegistry>,
+    token: &Felt,
+    amount: u128,
+) -> String {
+    let decimals = registry.and_then(|r| r.get_decimals(token));
+    match decimals {
+        Some(d) => crate::ui::widgets::param_display::format_token_amount(amount, 0, d),
+        None => format!("{}", amount),
+    }
 }
 
 /// Build the Trace tab body: recursive call tree with ABI-decoded function

--- a/tests/populate_selectors.rs
+++ b/tests/populate_selectors.rs
@@ -211,6 +211,27 @@ fn hardcoded_selectors() -> Vec<(Felt, &'static str)> {
             "0x00e316f0d9d2a3affa97de1d99bb2aac0538e2666d0d8545545ead241ef0ccab",
             "Swap",
         ),
+        // Starknet Privacy Pool events (selectors observed on mainnet)
+        (
+            "0x0247fc60d782e0094e7f98c47f277d92a3345d07a436f1f56b27a9b62be2322e",
+            "NoteUsed",
+        ),
+        (
+            "0x023c20207be8b1ef4430c25eef8ce779c9745ebe04139555ae81bd4f8fdd6ec5",
+            "EncNoteCreated",
+        ),
+        (
+            "0x022330482fd296a27cf9096807b4a3622cd619d31cce42c1e55655914e8459ee",
+            "OpenNoteCreated",
+        ),
+        (
+            "0x002eed7e29b3502a726faf503ac4316b7101f3da813654e8df02c13449e03da8",
+            "Withdrawal",
+        ),
+        (
+            "0x025b6da03c4858d11cb0708d5cb6be79b190fb32eb7a7ce83804e07cbbb9bead",
+            "OpenNoteDeposited",
+        ),
     ];
     for (hex, name) in known_hex {
         if let Ok(felt) = Felt::from_hex(hex) {
@@ -218,7 +239,48 @@ fn hardcoded_selectors() -> Vec<(Felt, &'static str)> {
         }
     }
 
+    // Privacy-pool action / event names that resolve via get_selector_from_name.
+    // We add them here so events emitted by future helper deployments still
+    // get a readable name even before the pool's full ABI lands in cache.
+    let privacy = [
+        "ViewingKeySet",
+        "Deposit",
+        "apply_actions",
+        "compile_actions",
+        "deposit_to_open_note",
+    ];
+    for name in privacy {
+        if let Ok(sel) = get_selector_from_name(name) {
+            selectors.push((sel, name));
+        }
+    }
+
     selectors
+}
+
+/// Class hashes we want to seed directly (no live deployed instance required).
+/// Used for protocol helper classes referenced by InvokeExternal but not in
+/// the address registry.
+fn hardcoded_class_hashes() -> Vec<(Felt, &'static str)> {
+    let mut out = Vec::new();
+    let entries = [
+        (
+            // Starknet Privacy: Ekubo swap helper
+            "0x061047c201f235d66cab8a0c4768ea0ca9f900c64b478a90531fb2fb30e061dc",
+            "Privacy Ekubo Helper",
+        ),
+        (
+            // Starknet Privacy: Vesu lending helper
+            "0x02fec72887f6431e4a66090bec49ecf8bde30cf39a7045e4ed6ce57447704b24",
+            "Privacy Vesu Helper",
+        ),
+    ];
+    for (hex, name) in entries {
+        if let Ok(felt) = Felt::from_hex(hex) {
+            out.push((felt, name));
+        }
+    }
+    out
 }
 
 #[tokio::test]
@@ -283,6 +345,21 @@ async fn populate_selectors() {
         class_hashes.len(),
         failed
     );
+
+    // Step 3.5: Merge hardcoded helper class hashes (no deployed instance required).
+    let mut hardcoded_added = 0usize;
+    for (ch, name) in hardcoded_class_hashes() {
+        if seen_classes.insert(ch) {
+            class_hashes.push((ch, name.to_string()));
+            hardcoded_added += 1;
+        }
+    }
+    if hardcoded_added > 0 {
+        println!(
+            "Added {} hardcoded class hashes (privacy helpers, etc.)",
+            hardcoded_added
+        );
+    }
 
     // Step 4: Fetch and parse ABIs for each unique class
     println!("\n=== Fetching ABIs for {} classes ===", class_hashes.len());

--- a/tests/privacy_summary_test.rs
+++ b/tests/privacy_summary_test.rs
@@ -1,0 +1,327 @@
+//! End-to-end probe of the Privacy Pool summarizer against real mainnet txs.
+//!
+//! Two fixtures, both offline (receipt JSON condensed into helper calls):
+//!
+//!   * `0x90304ef5...` (block 9216979) — direct (non-sponsored) privacy tx
+//!     with deposit/withdrawal/InvokeExternal mix.
+//!
+//!   * `0x4b9cde1b...` (block 9515174) — AVNU-sponsored privacy tx where
+//!     the pool call is wrapped in an outside-execution intent and the
+//!     pool's withdrawal recipient is the AVNU forwarder itself (gasless
+//!     fee-in-private-STRK pattern). Verifies the OE-aware detection plus
+//!     the fix that doesn't double-count a withdrawal payout as a pool fee.
+
+use snbeat::data::types::{ExecutionStatus, InvokeTx, SnEvent, SnTransaction};
+use snbeat::decode::events::DecodedEvent;
+use snbeat::decode::functions::RawCall;
+use snbeat::decode::outside_execution::{OutsideExecutionInfo, OutsideExecutionVersion};
+use snbeat::decode::privacy::{self, POOL_ADDRESS, PaymasterMode};
+use starknet::core::types::Felt;
+use starknet::core::utils::get_selector_from_name;
+
+fn felt(hex: &str) -> Felt {
+    Felt::from_hex(hex).unwrap()
+}
+
+fn pool_event(selector: Felt, keys_after_selector: Vec<Felt>, data: Vec<Felt>) -> DecodedEvent {
+    let mut keys = vec![selector];
+    keys.extend(keys_after_selector);
+    DecodedEvent {
+        contract_address: *POOL_ADDRESS,
+        event_name: None,
+        decoded_keys: Vec::new(),
+        decoded_data: Vec::new(),
+        raw: SnEvent {
+            from_address: *POOL_ADDRESS,
+            keys,
+            data,
+            transaction_hash: Felt::ZERO,
+            block_number: 9_216_979,
+            event_index: 0,
+        },
+    }
+}
+
+fn pool_call() -> RawCall {
+    RawCall {
+        contract_address: *POOL_ADDRESS,
+        selector: get_selector_from_name("apply_actions").unwrap(),
+        data: Vec::new(),
+        function_name: Some("apply_actions".to_string()),
+        function_def: None,
+        contract_abi: None,
+    }
+}
+
+fn invoke_tx(sender: Felt) -> SnTransaction {
+    SnTransaction::Invoke(InvokeTx {
+        hash: Felt::ZERO,
+        sender_address: sender,
+        calldata: Vec::new(),
+        nonce: None,
+        version: Felt::from(3u64),
+        actual_fee: None,
+        execution_status: ExecutionStatus::Succeeded,
+        block_number: 9_216_979,
+        index: 0,
+        tip: 0,
+        resource_bounds: None,
+    })
+}
+
+#[test]
+fn matches_mainnet_example_tx() {
+    let note_used = felt("0x0247fc60d782e0094e7f98c47f277d92a3345d07a436f1f56b27a9b62be2322e");
+    let enc_note_created =
+        felt("0x023c20207be8b1ef4430c25eef8ce779c9745ebe04139555ae81bd4f8fdd6ec5");
+    let open_note_created =
+        felt("0x022330482fd296a27cf9096807b4a3622cd619d31cce42c1e55655914e8459ee");
+    let withdrawal = felt("0x002eed7e29b3502a726faf503ac4316b7101f3da813654e8df02c13449e03da8");
+    let open_note_deposited =
+        felt("0x025b6da03c4858d11cb0708d5cb6be79b190fb32eb7a7ce83804e07cbbb9bead");
+
+    // Tokens (STRK, USDC) and addresses observed in the example tx.
+    let strk = felt("0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d");
+    let usdc = felt("0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb");
+    let to_addr = felt("0x389e0930f2bcf14221adefb71007ca71cec4cd4f64f321836392d2748a14c6");
+    let depositor = felt("0x389e0930f2bcf14221adefb71007ca71cec4cd4f64f321836392d2748a14c6");
+    let one_strk: u128 = 0xde0b6b3a7640000; // 1.0 STRK in fri.
+    let nullifier_a = felt("0x30cc93d82386c9f64ffdf15899f42169a07d38c043c2dfa4727e2a65034de6d");
+    let nullifier_b = felt("0x6a0c5a0e0ab2a02934da15f7d761cd484cdb8c704ef55bf8345ecb8160338cc");
+    let note_id_open = felt("0x7dd4dc2cee342d94cbf47505a4bd368bf07c41826ac248ce05830201d34c82");
+    let note_id_enc_a = felt("0x1eed60b8d483b3bede62d1cc0f32874aea30747e6943437c858359b41801bf7");
+
+    let events = vec![
+        pool_event(note_used, vec![nullifier_a], vec![]),
+        pool_event(note_used, vec![nullifier_b], vec![]),
+        pool_event(
+            open_note_created,
+            vec![usdc, note_id_open],
+            vec![Felt::ZERO; 3],
+        ),
+        pool_event(
+            enc_note_created,
+            vec![note_id_enc_a],
+            vec![felt(
+                "0x53f6f5e87c1aa2c7329d4e060260075db650f2a68d11b6e4316215b9333fe86",
+            )],
+        ),
+        pool_event(
+            withdrawal,
+            vec![to_addr, strk],
+            // 3 felts of EncUserAddr blob, then amount as u128 low.
+            vec![Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::from(one_strk)],
+        ),
+        pool_event(
+            open_note_deposited,
+            vec![depositor, strk, note_id_open],
+            // amount = 1 STRK (u128 low + high).
+            vec![Felt::from(one_strk), Felt::ZERO],
+        ),
+    ];
+
+    let sender = felt("0x51258c78dba24ee15c3aed60fb6fbbfb91a7cb2f739c82e39871847823aa410");
+    let tx = invoke_tx(sender);
+    let summary =
+        privacy::summarize(&tx, &[pool_call()], &events, &[]).expect("tx is a privacy-pool tx");
+
+    // Action-mix counts mirror the real tx's pool-side events.
+    assert_eq!(summary.actions.notes_used, 2);
+    assert_eq!(summary.actions.enc_notes_created, 1);
+    assert_eq!(summary.actions.open_notes_created, 1);
+    assert_eq!(summary.actions.withdrawals, 1);
+    assert_eq!(summary.actions.open_notes_deposited, 1);
+    assert_eq!(summary.actions.viewing_keys_set, 0);
+    assert_eq!(summary.actions.deposits, 0);
+
+    // Public-side fields.
+    assert_eq!(summary.nullifiers, vec![nullifier_a, nullifier_b]);
+    assert_eq!(summary.enc_notes_created, vec![note_id_enc_a]);
+
+    let w = &summary.withdrawals[0];
+    assert_eq!(w.to_addr, to_addr);
+    assert_eq!(w.token, strk);
+    assert_eq!(w.amount, one_strk);
+
+    let n = &summary.open_notes_created[0];
+    assert_eq!(n.token, usdc);
+    assert_eq!(n.note_id, note_id_open);
+
+    let d = &summary.open_notes_deposited[0];
+    assert_eq!(d.depositor, depositor);
+    assert_eq!(d.token, strk);
+    assert_eq!(d.note_id, note_id_open);
+    assert_eq!(d.amount, one_strk);
+
+    // Sender is the user's own account, not a known paymaster.
+    assert_eq!(summary.paymaster, PaymasterMode::None);
+    assert!(summary.intender.is_none());
+}
+
+#[test]
+fn non_privacy_tx_returns_none() {
+    let other_call = RawCall {
+        contract_address: felt(
+            "0x04270219d365d6b017231b52e92b3fb5d7c8378b05e9abc97724537a80e93b0f",
+        ),
+        selector: Felt::ZERO,
+        data: Vec::new(),
+        function_name: None,
+        function_def: None,
+        contract_abi: None,
+    };
+    let tx = invoke_tx(Felt::from(1u64));
+    assert!(privacy::summarize(&tx, &[other_call], &[], &[]).is_none());
+}
+
+/// Mirrors mainnet tx
+/// `0x4b9cde1b731130096209a2af5f947e3a57c290dcfa99c358bc958521ff3c35f` —
+/// an AVNU-sponsored privacy tx. Top-level multicall is `[STRK.transfer,
+/// AVNU_Forwarder.execute_from_outside_v2(intent)]`; the pool call lives
+/// only inside the OE intent's inner_calls. The pool's `Withdrawal` event
+/// pays 4 STRK to the AVNU forwarder (the gasless service fee in private
+/// STRK). The summarizer must:
+///   1. Recognize this as a privacy tx (via the pool-emitted Withdrawal).
+///   2. Surface `paymaster = OutsideExecution` and the OE intender.
+///   3. NOT report the 4 STRK pool→forwarder transfer as a pool fee
+///      (that would be double-counting the withdrawal payout).
+#[test]
+fn matches_mainnet_sponsored_tx() {
+    // AVNU-known relayer account (sender of the tx).
+    let relayer = felt("0x22d287c1251406e5e75e2777599ff0aed256fc838c354cb2fbf1f95775ecbdb");
+    // The actual user (intender) signed the OE intent.
+    let user = felt("0x383d01739484177556480d629b2dc75661dc3afa7d1a19c30d64be2999cb501");
+    let avnu_forwarder = felt("0x0127021a1b5a52d3174c2ab077c2b043c80369250d29428cee956d76ee51584f");
+    let strk = felt("0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d");
+    let four_strk: u128 = 0x3782dace9d900000;
+    let withdrawal_selector =
+        felt("0x002eed7e29b3502a726faf503ac4316b7101f3da813654e8df02c13449e03da8");
+    let enc_note_selector =
+        felt("0x023c20207be8b1ef4430c25eef8ce779c9745ebe04139555ae81bd4f8fdd6ec5");
+    let erc20_transfer = felt("0x0099cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9");
+
+    let tx = invoke_tx(relayer);
+
+    // Top-level multicall: STRK.transfer (the relayer's pre-fee top-up) +
+    // AVNU forwarder execute_from_outside_v2.
+    let top_calls = vec![
+        RawCall {
+            contract_address: strk,
+            selector: Felt::ZERO,
+            data: Vec::new(),
+            function_name: Some("transfer".to_string()),
+            function_def: None,
+            contract_abi: None,
+        },
+        RawCall {
+            contract_address: avnu_forwarder,
+            selector: Felt::ZERO,
+            data: Vec::new(),
+            function_name: Some("execute_from_outside_v2".to_string()),
+            function_def: None,
+            contract_abi: None,
+        },
+    ];
+
+    let oe = OutsideExecutionInfo {
+        intender: user,
+        caller: avnu_forwarder,
+        nonce: Felt::ZERO,
+        execute_after: 0,
+        execute_before: u64::MAX,
+        inner_calls: vec![
+            // approve(forwarder, fee) — pre-pool plumbing.
+            RawCall {
+                contract_address: strk,
+                selector: Felt::ZERO,
+                data: Vec::new(),
+                function_name: Some("approve".to_string()),
+                function_def: None,
+                contract_abi: None,
+            },
+            // The actual pool call.
+            RawCall {
+                contract_address: *POOL_ADDRESS,
+                selector: get_selector_from_name("apply_actions").unwrap(),
+                data: Vec::new(),
+                function_name: Some("apply_actions".to_string()),
+                function_def: None,
+                contract_abi: None,
+            },
+        ],
+        signature: Vec::new(),
+        version: OutsideExecutionVersion::V2,
+    };
+
+    let events = vec![
+        // Pool-emitted EncNoteCreated (a private receive-side note for the user).
+        DecodedEvent {
+            contract_address: *POOL_ADDRESS,
+            event_name: None,
+            decoded_keys: Vec::new(),
+            decoded_data: Vec::new(),
+            raw: SnEvent {
+                from_address: *POOL_ADDRESS,
+                keys: vec![enc_note_selector, Felt::from(0xAAu64)],
+                data: vec![Felt::from(0xBBu64)],
+                transaction_hash: Felt::ZERO,
+                block_number: 9_515_174,
+                event_index: 0,
+            },
+        },
+        // Pool-emitted Withdrawal: to_addr = AVNU forwarder, token = STRK,
+        // amount = 4 STRK (the AVNU service fee paid in private funds).
+        DecodedEvent {
+            contract_address: *POOL_ADDRESS,
+            event_name: None,
+            decoded_keys: Vec::new(),
+            decoded_data: Vec::new(),
+            raw: SnEvent {
+                from_address: *POOL_ADDRESS,
+                keys: vec![withdrawal_selector, avnu_forwarder, strk],
+                data: vec![Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::from(four_strk)],
+                transaction_hash: Felt::ZERO,
+                block_number: 9_515_174,
+                event_index: 0,
+            },
+        },
+        // Matching ERC-20 Transfer pool→forwarder for the withdrawal payout.
+        DecodedEvent {
+            contract_address: strk,
+            event_name: None,
+            decoded_keys: Vec::new(),
+            decoded_data: Vec::new(),
+            raw: SnEvent {
+                from_address: strk,
+                keys: vec![erc20_transfer, *POOL_ADDRESS, avnu_forwarder],
+                data: vec![Felt::from(four_strk), Felt::ZERO],
+                transaction_hash: Felt::ZERO,
+                block_number: 9_515_174,
+                event_index: 0,
+            },
+        },
+    ];
+
+    let summary = privacy::summarize(&tx, &top_calls, &events, &[oe])
+        .expect("OE-wrapped sponsored privacy tx must still be recognized");
+
+    // The pool only shows up in events (no top-level call, no top-level OE
+    // call landed at the contract address at the multicall layer).
+    assert_eq!(summary.actions.withdrawals, 1);
+    assert_eq!(summary.actions.enc_notes_created, 1);
+
+    // The 4 STRK pool→forwarder transfer matches the Withdrawal event, so
+    // it's classified as a withdrawal payout, not a pool fee.
+    assert!(
+        summary.pool_fee_fri.is_none(),
+        "withdrawal payout to AVNU forwarder must not surface as a pool fee"
+    );
+
+    // OE-based sponsorship + intender surfaced.
+    assert_eq!(summary.paymaster, PaymasterMode::OutsideExecution);
+    assert_eq!(summary.intender, Some(user));
+
+    // The withdrawal-recipient is correctly the forwarder, in the clear.
+    assert_eq!(summary.withdrawals[0].to_addr, avnu_forwarder);
+    assert_eq!(summary.withdrawals[0].amount, four_strk);
+}


### PR DESCRIPTION
## Summary

- New **Privacy tab** (5th tab in tx detail) for txs touching the Starknet Privacy Pool. Surfaces publicly-observable info: action mix, public deposits/withdrawals/open-notes, viewing-key registrations, internal nullifier counts, the `InvokeExternal` target, the pool fee, and a sponsorship signal.
- One-line **PRIVACY** badge in the tx-detail header. Compact `v1`/`v2`/`v3`/`p1` tags fit the block-list `Meta` column; the verbose form (`private-sponsored`) is used only in tx-detail header / Calls intent expansion.
- **OE-aware detection.** The pool call may be wrapped in an outside-execution intent (AVNU gasless / SNIP-9), and the new AVNU `execute_private_sponsored` entrypoint uses a different calldata layout (`[num_calls, ...calls..., ...auth...]` with no caller/nonce/timestamps). Both are decoded so the inner intent surfaces in the Calls tab and the privacy summarizer recognizes them.
- **Sponsorship modes.** New `PaymasterMode` enum: `OutsideExecution` / `PaymasterForwarder` / `KnownRelayer` / `None`. Pool-fee logic now subtracts withdrawal-payout transfers so it doesn't double-count e.g. a 4-STRK withdrawal to the AVNU forwarder.
- Bundled labels: Privacy Pool, Privacy Ekubo Helper instance, Vesu V1 Singleton (alt deployment), Relend Network USDC, LBTC. `populate_selectors` seeds the Ekubo + Vesu helper class hashes plus the pool's event selectors.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets`
- [x] `cargo test` (unit + integration)
- [x] Unit tests: OE wrapper, sponsored tx, fee subtraction, tag display
- [x] Integration probes mirror mainnet txs `0x90304ef5…`, `0x4b9cde1b…`, and the OE-wrapped `0x3e47f71d…`
- [x] `populate_selectors` against mainnet seeded all 3 helper classes + 10 privacy event names into `~/.config/snbeat/cache.db`

## Follow-up (separate PR)

Decoding the encrypted side of privacy txs using a user-supplied viewing key (via `discovery-core` from `starkware-libs/starknet-privacy`). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)