### PR TITLE
Show DEPLOY_ACCOUNT tx in account tx list

### DIFF
--- a/src/app/views/address_info.rs
+++ b/src/app/views/address_info.rs
@@ -97,7 +97,9 @@ pub struct AddressInfoState {
     pub events: StatefulList<DecodedEvent>,
     /// Enriched tx summaries for the Transactions tab.
     pub txs: StatefulList<AddressTxSummary>,
-    /// The DEPLOY_ACCOUNT tx that created this address (filtered out of txs).
+    /// The deploy tx that created this address. For self-deploys
+    /// (DEPLOY_ACCOUNT, sender == address) the same tx also stays in `txs`
+    /// since it consumed nonce 0; for UDC-style deploys it's only here.
     pub deployment: Option<AddressTxSummary>,
     /// Incoming calls to this contract (for the Calls tab).
     pub calls: StatefulList<ContractCallSummary>,
@@ -393,6 +395,12 @@ impl AddressInfoState {
     }
 
     /// Split `txs` into regular txs and deployment tx.
+    ///
+    /// DEPLOY_ACCOUNT txs (where the new account paid for its own deploy,
+    /// `sender == address`) consume nonce 0 and are part of the account's
+    /// history, so they populate `self.deployment` *and* stay in the regular
+    /// list. UDC-style deploys (`sender != address`) are the deployer's tx,
+    /// not the deployed contract's, so they're pulled out entirely.
     pub fn filter_deployment_txs(
         &mut self,
         address: Felt,
@@ -400,17 +408,21 @@ impl AddressInfoState {
     ) -> Vec<AddressTxSummary> {
         let mut regular = Vec::with_capacity(txs.len());
         for tx in txs {
-            let is_deploy = tx.tx_type == "DEPLOY_ACCOUNT"
-                || tx.tx_type.starts_with("DEPLOY")
-                || tx.sender.is_some_and(|s| s != address);
-            if is_deploy {
+            let self_deploy =
+                tx.tx_type == "DEPLOY_ACCOUNT" && tx.sender.is_none_or(|s| s == address);
+            let foreign_deploy =
+                tx.tx_type.starts_with("DEPLOY") || tx.sender.is_some_and(|s| s != address);
+            if self_deploy || foreign_deploy {
                 let should_set = self.deployment.is_none()
                     || self
                         .deployment
                         .as_ref()
                         .is_some_and(|d| d.hash == Felt::ZERO);
                 if should_set {
-                    self.deployment = Some(tx);
+                    self.deployment = Some(tx.clone());
+                }
+                if self_deploy {
+                    regular.push(tx);
                 }
             } else {
                 regular.push(tx);

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -68,34 +68,15 @@ fn count_fragment(shown: u64, bound: CountBound) -> String {
 /// so once nonce is known the bound is [`CountBound::Exact`]. Dune's event
 /// count over-counts on hybrid accounts (it counts emitted events, not
 /// sender txs) — not suitable here.
+///
+/// The on-chain `nonce` is the *next* nonce to use, so the total tx count
+/// equals `nonce`. DEPLOY_ACCOUNT (self-deploy) consumes nonce 0 and stays
+/// in `txs.items`; UDC-deployed contracts have `nonce 0` start as their
+/// first invoke. Either way, `nonce` is the count.
 fn tx_count_fragment(app: &App) -> String {
     let count = app.address.txs.items.len() as u64;
-    // The on-chain `nonce` is the *next* nonce to use. For a self-deployed
-    // account (DEPLOY_ACCOUNT), the deploy itself consumed nonce 0 and is
-    // pulled out of `txs.items` by `filter_deployment_txs`, so the Txs tab
-    // ends up holding `nonce - 1` rows. For a UDC-deployed account the
-    // "deployment" entry is the *deployer's* tx (sender != address), the
-    // account's own nonce 0 is its first invoke and stays in `txs.items`,
-    // so the tab holds the full `nonce` rows.
-    //
-    // Distinguish on `deployment.sender`: when it equals the account
-    // address, the deploy was self-sent; otherwise it was UDC-style.
     let bound = match app.address.info.as_ref().map(|i| felt_to_u64(&i.nonce)) {
-        Some(nonce) => {
-            let self_deployed = matches!(
-                (
-                    app.address.context,
-                    app.address.deployment.as_ref().and_then(|d| d.sender),
-                ),
-                (Some(addr), Some(sender)) if sender == addr
-            );
-            let total = if self_deployed {
-                nonce.saturating_sub(1)
-            } else {
-                nonce
-            };
-            CountBound::Exact(total)
-        }
+        Some(nonce) => CountBound::Exact(nonce),
         None => CountBound::LowerBound { hint: None },
     };
     count_fragment(count, bound)

--- a/tests/merge_test.rs
+++ b/tests/merge_test.rs
@@ -136,13 +136,17 @@ fn merge_preserves_selection() {
 }
 
 #[test]
-fn filter_deployment_txs_separates_deploy() {
+fn filter_deployment_txs_self_deploy_stays_in_list() {
+    // DEPLOY_ACCOUNT where the new account paid for its own deploy:
+    // it consumed nonce 0 and is part of the account's tx history,
+    // so it must populate `self.deployment` AND remain in the regular list.
     let mut state = AddressInfoState::default();
     let addr = Felt::from(0x1u64);
 
+    let deploy_hash = Felt::from(0xdu64);
     let txs = vec![
         AddressTxSummary {
-            hash: Felt::from(0xdu64),
+            hash: deploy_hash,
             nonce: 0,
             block_number: 100,
             timestamp: 0,
@@ -158,8 +162,43 @@ fn filter_deployment_txs_separates_deploy() {
     ];
 
     let regular = state.filter_deployment_txs(addr, txs);
-    assert_eq!(regular.len(), 1);
-    assert_eq!(regular[0].nonce, 1);
+    assert_eq!(regular.len(), 2);
+    assert!(
+        regular
+            .iter()
+            .any(|t| t.hash == deploy_hash && t.nonce == 0)
+    );
+    assert!(regular.iter().any(|t| t.nonce == 1));
     assert!(state.deployment.is_some());
     assert_eq!(state.deployment.as_ref().unwrap().tx_type, "DEPLOY_ACCOUNT");
+    assert_eq!(state.deployment.as_ref().unwrap().hash, deploy_hash);
+}
+
+#[test]
+fn filter_deployment_txs_udc_deploy_pulled_out() {
+    // UDC-style deploy: sender != address, so the tx belongs to the
+    // deployer's history, not the deployed contract's. It populates
+    // `self.deployment` and is removed from the regular list.
+    let mut state = AddressInfoState::default();
+    let addr = Felt::from(0x1u64);
+    let deployer = Felt::from(0x2u64);
+
+    let txs = vec![AddressTxSummary {
+        hash: Felt::from(0xdu64),
+        nonce: 0,
+        block_number: 100,
+        timestamp: 0,
+        endpoint_names: String::new(),
+        total_fee_fri: 0,
+        tip: 0,
+        tx_type: "DEPLOY (UDC)".to_string(),
+        status: "OK".to_string(),
+        sender: Some(deployer),
+        called_contracts: Vec::new(),
+    }];
+
+    let regular = state.filter_deployment_txs(addr, txs);
+    assert!(regular.is_empty());
+    assert!(state.deployment.is_some());
+    assert_eq!(state.deployment.as_ref().unwrap().sender, Some(deployer));
 }


### PR DESCRIPTION
## Summary
- For self-deployed accounts (DEPLOY_ACCOUNT where `sender == address`), the deploy tx consumed nonce 0 and is part of the account's history — keep it in the Txs tab while still populating the deployment header.
- UDC-style deploys (`sender != address`) keep their existing behavior: pulled out of the list entirely since they belong to the deployer's history.
- Drop the `nonce - 1` saturation in `tx_count_fragment`; the count is now exactly `nonce` for both deploy styles.

## Test plan
- [x] `cargo build --release`
- [x] `cargo clippy --all-targets`
- [x] `cargo test` (197 passed, including two new cases in `tests/merge_test.rs`)
- [ ] Visit `0x51258c78dba24ee15c3aed60fb6fbbfb91a7cb2f739c82e39871847823aa410` in the TUI — confirm the Txs tab now shows nonce 0 (DEPLOY_ACCOUNT) as the first row and the count reads `N / N` matching the on-chain nonce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)