### PR TITLE
Stop refetching non-INVOKE address txs on every scroll

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -518,7 +518,7 @@ impl App {
             .iter()
             .skip(offset)
             .take(50)
-            .filter(|t| t.endpoint_names.is_empty() || t.timestamp == 0)
+            .filter(|t| t.needs_enrichment())
             .map(|t| t.hash)
             .collect();
         if !hashes.is_empty() {
@@ -1455,7 +1455,7 @@ impl App {
                         .iter()
                         .skip(offset)
                         .take(50)
-                        .filter(|t| t.endpoint_names.is_empty() || t.timestamp == 0)
+                        .filter(|t| t.needs_enrichment())
                         .map(|t| t.hash)
                         .collect();
                     if !hashes.is_empty() {
@@ -1790,7 +1790,7 @@ impl App {
                         .iter()
                         .skip(offset)
                         .take(50)
-                        .filter(|t| t.endpoint_names.is_empty() || t.timestamp == 0)
+                        .filter(|t| t.needs_enrichment())
                         .map(|t| t.hash)
                         .collect();
                     if !hashes.is_empty() {

--- a/src/data/types.rs
+++ b/src/data/types.rs
@@ -282,6 +282,18 @@ pub struct AddressTxSummary {
     pub called_contracts: Vec<Felt>,
 }
 
+impl AddressTxSummary {
+    /// Whether this row still needs an enrichment fetch.
+    ///
+    /// `endpoint_names` is only meaningful for INVOKE — DECLARE/DEPLOY_ACCOUNT/
+    /// L1_HANDLER have no multicall to decode, so an empty string there is a
+    /// terminal state, not "unfetched". Treating it as unfetched caused
+    /// pf-query refetches on every scroll keystroke.
+    pub fn needs_enrichment(&self) -> bool {
+        self.timestamp == 0 || (self.tx_type == "INVOKE" && self.endpoint_names.is_empty())
+    }
+}
+
 /// A meta-transaction (SNIP-9 outside execution) summary for the MetaTxs tab on
 /// an address view. Represents a tx where the viewed address is the intender
 /// (original signer), not the on-chain sender (paymaster/relayer).


### PR DESCRIPTION
## Summary
- Viewport enrichment predicate was `endpoint_names.is_empty() || timestamp == 0`. DECLARE/DEPLOY_ACCOUNT/L1_HANDLER txs have no multicall, so their `endpoint_names` stays `""` forever — they matched the predicate on every keystroke and triggered a `POST /txs-by-hash` that returned identical data and merged into a no-op.
- Centralize the check as `AddressTxSummary::needs_enrichment()` and make it type-aware: empty `endpoint_names` only counts for INVOKE.
- Three call sites in `src/app/mod.rs` updated to use the helper. The existing `src/network/address.rs:2616` was already gated on `tx_type == "INVOKE"` and is left as-is.

## Test plan
- [x] `cargo build --release`
- [x] `cargo fmt`
- [ ] Open an address that contains DECLARE or DEPLOY_ACCOUNT txs, scroll up/down through the Transactions tab, and confirm pf-query no longer logs a `POST /txs-by-hash` per keystroke.
- [ ] Open an account whose visible window is all INVOKE-with-decoded-endpoints — confirm no enrichment fetch fires (steady state idle).
- [ ] Open an account with un-enriched INVOKE rows — confirm a single enrichment fetch still fires, the rows fill in, and subsequent scrolls produce no further fetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)