### PR TITLE
Privacy: shield OE inner pool calls, palette refresh, scope Pool changes

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1610,6 +1610,7 @@ impl App {
                             status: m.status,
                             nonce: None,
                             tip: 0,
+                            inner_targets: m.inner_targets,
                         })
                         .collect();
                     if !promoted.is_empty() {
@@ -1906,6 +1907,7 @@ impl App {
                         status: "OK".to_string(), // events only fire for successful txs
                         nonce: None,              // filled in by EnrichAddressCalls
                         tip: 0,
+                        inner_targets: Vec::new(), // filled in by EnrichAddressCalls
                     };
                     let _ = self.action_tx.send(Action::EnrichAddressCalls {
                         address,

--- a/src/app/views/address_info.rs
+++ b/src/app/views/address_info.rs
@@ -1106,6 +1106,7 @@ mod tests {
             status: "OK".into(),
             nonce: None,
             tip: 0,
+            inner_targets: Vec::new(),
         }
     }
 

--- a/src/app/views/address_info.rs
+++ b/src/app/views/address_info.rs
@@ -323,6 +323,16 @@ impl AddressInfoState {
         self.call_color_processed_len = 0;
     }
 
+    /// Drop the cached tx-color map. `merge_tx_summaries` calls this when
+    /// an in-place upgrade fills `called_contracts` on an existing row —
+    /// the length-keyed fast path wouldn't otherwise notice, so the
+    /// Contracts column would stay in NORMAL_STYLE until the list grows.
+    pub fn invalidate_tx_color_cache(&mut self) {
+        self.tx_contract_counts.clear();
+        self.tx_color_map = AddressColorMap::new();
+        self.tx_color_processed_len = 0;
+    }
+
     /// Refresh the per-sender count map and color slots for the Calls tab.
     ///
     /// Cheap fast path: when `calls.items.len()` matches the cached length,
@@ -484,15 +494,22 @@ impl AddressInfoState {
         let mut seen_hashes: HashSet<Felt> = self.txs.items.iter().map(|t| t.hash).collect();
         let had_selection = self.txs.state.selected();
 
+        let mut called_contracts_upgraded = false;
         for item in incoming {
             if seen_hashes.contains(&item.hash) {
                 if let Some(existing) = self.txs.items.iter_mut().find(|t| t.hash == item.hash) {
-                    upgrade_tx_summary(existing, &item);
+                    called_contracts_upgraded |= upgrade_tx_summary(existing, &item);
                 }
             } else {
                 seen_hashes.insert(item.hash);
                 self.txs.items.push(item);
             }
+        }
+        // In-place called_contracts fill doesn't move items.len(), so the
+        // tx-color cache's length-keyed fast path would miss it. Force a
+        // rebuild now so the Contracts column reflects the enriched rows.
+        if called_contracts_upgraded {
+            self.invalidate_tx_color_cache();
         }
 
         self.txs.items.sort_by(|a, b| b.nonce.cmp(&a.nonce));
@@ -769,7 +786,10 @@ impl AddressInfoState {
 }
 
 /// Upgrade an existing tx summary with better data from an incoming one.
-pub fn upgrade_tx_summary(existing: &mut AddressTxSummary, incoming: &AddressTxSummary) {
+/// Returns `true` if `called_contracts` was filled in (was empty, is now
+/// populated). Callers use this to invalidate the Txs-tab color cache,
+/// whose length-keyed fast path would otherwise miss the in-place change.
+pub fn upgrade_tx_summary(existing: &mut AddressTxSummary, incoming: &AddressTxSummary) -> bool {
     if existing.block_number == 0 && incoming.block_number > 0 {
         existing.block_number = incoming.block_number;
     }
@@ -785,7 +805,9 @@ pub fn upgrade_tx_summary(existing: &mut AddressTxSummary, incoming: &AddressTxS
     if existing.endpoint_names.is_empty() && !incoming.endpoint_names.is_empty() {
         existing.endpoint_names.clone_from(&incoming.endpoint_names);
     }
-    if existing.called_contracts.is_empty() && !incoming.called_contracts.is_empty() {
+    let called_contracts_filled =
+        existing.called_contracts.is_empty() && !incoming.called_contracts.is_empty();
+    if called_contracts_filled {
         existing
             .called_contracts
             .clone_from(&incoming.called_contracts);
@@ -796,6 +818,7 @@ pub fn upgrade_tx_summary(existing: &mut AddressTxSummary, incoming: &AddressTxS
     if existing.tip == 0 && incoming.tip > 0 {
         existing.tip = incoming.tip;
     }
+    called_contracts_filled
 }
 
 #[cfg(test)]

--- a/src/app/views/address_info.rs
+++ b/src/app/views/address_info.rs
@@ -189,6 +189,17 @@ pub struct AddressInfoState {
     /// matches the current length, the cache is up-to-date and renders skip
     /// the rescan entirely.
     pub call_color_processed_len: usize,
+    /// Per-contract occurrence counts across `txs.items`'s `called_contracts`.
+    /// Drives palette assignment in the Txs tab's Contracts column so repeated
+    /// targets pop out, unlabeled one-offs stay neutral, and labeled or
+    /// privacy contracts keep their tagged style.
+    pub tx_contract_counts: HashMap<Felt, usize>,
+    /// Slot assignments for repeated, non-tagged contracts called by this
+    /// address's outbound txs. Same idempotent-slot guarantee as
+    /// `call_color_map`.
+    pub tx_color_map: AddressColorMap,
+    /// Cached `txs.items.len()` from the last contract color-map rebuild.
+    pub tx_color_processed_len: usize,
 }
 
 /// Auto-fill row target for the event-backed tabs (currently MetaTxs;
@@ -249,6 +260,9 @@ impl Default for AddressInfoState {
             call_sender_counts: HashMap::new(),
             call_color_map: AddressColorMap::new(),
             call_color_processed_len: 0,
+            tx_contract_counts: HashMap::new(),
+            tx_color_map: AddressColorMap::new(),
+            tx_color_processed_len: 0,
         }
     }
 }
@@ -291,6 +305,9 @@ impl AddressInfoState {
         self.call_sender_counts.clear();
         self.call_color_map = AddressColorMap::new();
         self.call_color_processed_len = 0;
+        self.tx_contract_counts.clear();
+        self.tx_color_map = AddressColorMap::new();
+        self.tx_color_processed_len = 0;
     }
 
     /// Drop the cached color map so the next render rebuilds it from scratch.
@@ -330,6 +347,28 @@ impl AddressInfoState {
             }
         }
         self.call_color_processed_len = self.calls.items.len();
+    }
+
+    /// Refresh the per-contract count map and color slots for the Txs tab's
+    /// Contracts column. Mirrors `update_call_color_map`: counts occurrences
+    /// across every tx's `called_contracts`, and assigns palette slots only
+    /// to repeats that aren't already registry-known (labeled contracts keep
+    /// their `LABEL_STYLE`; privacy contracts keep `PRIVACY_STYLE`).
+    pub fn update_tx_color_map(&mut self, is_known: impl Fn(&Felt) -> bool) {
+        if self.tx_color_processed_len == self.txs.items.len() {
+            return;
+        }
+        self.tx_contract_counts.clear();
+        for tx in &self.txs.items {
+            for contract in &tx.called_contracts {
+                let count = self.tx_contract_counts.entry(*contract).or_insert(0);
+                *count += 1;
+                if *count == 2 && !is_known(contract) {
+                    self.tx_color_map.register(*contract);
+                }
+            }
+        }
+        self.tx_color_processed_len = self.txs.items.len();
     }
 
     /// Whether any source thinks there is more data to fetch.

--- a/src/data/types.rs
+++ b/src/data/types.rs
@@ -275,9 +275,17 @@ pub struct AddressTxSummary {
     /// The actual sender of this transaction (may differ from the viewed address for deployment txs).
     #[serde(default)]
     pub sender: Option<Felt>,
-    /// Top-level contracts directly invoked by this tx's multicall, in order
-    /// (deduplicated). Populated by the same path that fills `endpoint_names`;
-    /// remains empty for non-INVOKE txs and pre-enrichment stubs.
+    /// Contracts reached by this tx, in first-seen order with duplicates
+    /// removed. Includes each top-level multicall target plus the inner
+    /// target of any outside-execution call so privacy-pool reaches via
+    /// `execute_from_outside*` / `execute_private_sponsored` wrappers are
+    /// surfaced alongside the wrapper itself.
+    ///
+    /// Populated by the same path that fills `endpoint_names`; remains
+    /// empty for non-INVOKE txs and pre-enrichment stubs. Consumers (Txs
+    /// tab Contracts column, privacy-tx predicate, palette color map)
+    /// treat the union as a single set — they don't need to distinguish
+    /// top-level from OE-inner.
     #[serde(default)]
     pub called_contracts: Vec<Felt>,
 }

--- a/src/data/types.rs
+++ b/src/data/types.rs
@@ -342,6 +342,12 @@ pub struct ContractCallSummary {
     /// Sender tip (FRI). `0` from Dune-sourced rows and stubs; filled by RPC/pf path.
     #[serde(default)]
     pub tip: u64,
+    /// Target addresses of any outside-execution inner calls in this tx's
+    /// multicall (deduped, first-seen order). Empty for Dune-only stubs (no
+    /// calldata) and non-INVOKE rows. Used by the Calls-tab Prv column to
+    /// flag txs that reach a privacy address only via an OE wrapper.
+    #[serde(default)]
+    pub inner_targets: Vec<Felt>,
 }
 
 /// Label information fetched from Voyager for a contract/account address.
@@ -406,6 +412,9 @@ pub fn deduplicate_contract_calls(calls: Vec<ContractCallSummary>) -> Vec<Contra
             }
             if existing.tip == 0 && call.tip > 0 {
                 existing.tip = call.tip;
+            }
+            if existing.inner_targets.is_empty() && !call.inner_targets.is_empty() {
+                existing.inner_targets = call.inner_targets;
             }
         } else {
             seen.insert(call.tx_hash, result.len());

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -641,6 +641,13 @@ pub(super) async fn build_contract_calls_from_hashes(
                     .to_string();
                 let function_name = helpers::format_endpoint_names(&fetched_tx, abi_reg);
                 let (nonce, tip) = helpers::extract_nonce_tip(&fetched_tx);
+                let inner_targets = match &fetched_tx {
+                    crate::data::types::SnTransaction::Invoke(i) => {
+                        let calls = parse_multicall(&i.calldata);
+                        helpers::oe_inner_targets(&calls, abi_reg)
+                    }
+                    _ => Vec::new(),
+                };
                 calls_list.push(crate::data::types::ContractCallSummary {
                     tx_hash: hash,
                     sender: fetched_tx.sender(),
@@ -651,6 +658,7 @@ pub(super) async fn build_contract_calls_from_hashes(
                     status,
                     nonce: Some(nonce),
                     tip,
+                    inner_targets,
                 });
             }
         }
@@ -705,18 +713,20 @@ pub(super) async fn build_contract_calls_from_pf_rows(
         let fee_fri =
             u128::from_str_radix(row.actual_fee.trim_start_matches("0x"), 16).unwrap_or(0);
 
-        let function_name = if helpers::normalize_pf_tx_type(&row.tx_type) == "INVOKE" {
+        let (function_name, inner_targets) = if helpers::normalize_pf_tx_type(&row.tx_type)
+            == "INVOKE"
+        {
             let calldata: Vec<Felt> = row
                 .calldata
                 .iter()
                 .filter_map(|h| Felt::from_hex(h).ok())
                 .collect();
-            helpers::format_selector_names(
-                parse_multicall(&calldata).iter().map(|c| c.selector),
-                abi_reg,
-            )
+            let calls = parse_multicall(&calldata);
+            let name = helpers::format_selector_names(calls.iter().map(|c| c.selector), abi_reg);
+            let inner = helpers::oe_inner_targets(&calls, abi_reg);
+            (name, inner)
         } else {
-            String::new()
+            (String::new(), Vec::new())
         };
 
         calls_list.push(crate::data::types::ContractCallSummary {
@@ -729,6 +739,7 @@ pub(super) async fn build_contract_calls_from_pf_rows(
             status: row.status.clone(),
             nonce: row.nonce,
             tip: row.tip,
+            inner_targets,
         });
     }
 
@@ -3106,6 +3117,12 @@ pub(super) async fn enrich_dune_calls(
                     let (nonce, tip) = helpers::extract_nonce_tip(fetched_tx);
                     call.nonce = Some(nonce);
                     call.tip = tip;
+                    if call.inner_targets.is_empty()
+                        && let crate::data::types::SnTransaction::Invoke(i) = fetched_tx
+                    {
+                        let calls = parse_multicall(&i.calldata);
+                        call.inner_targets = helpers::oe_inner_targets(&calls, abi_reg);
+                    }
                 }
                 if let Ok(receipt) = rx_result {
                     call.total_fee_fri = felt_to_u128(&receipt.actual_fee);

--- a/src/network/dune.rs
+++ b/src/network/dune.rs
@@ -242,6 +242,7 @@ impl DuneClient {
                     status,
                     nonce: None, // Not in calls table — merged in from RPC/pf path
                     tip: 0,
+                    inner_targets: Vec::new(), // Dune lacks calldata — filled by RPC enrich path
                 })
             })
             .collect())
@@ -363,6 +364,7 @@ impl DuneClient {
                     status,
                     nonce: None,
                     tip: 0,
+                    inner_targets: Vec::new(),
                 })
             })
             .collect())

--- a/src/network/helpers.rs
+++ b/src/network/helpers.rs
@@ -14,7 +14,8 @@ use crate::data::types::{
     AddressTxSummary, ContractCallSummary, ExecutionStatus, SnReceipt, SnTransaction,
 };
 use crate::decode::AbiRegistry;
-use crate::decode::functions::parse_multicall;
+use crate::decode::functions::{RawCall, parse_multicall};
+use crate::decode::outside_execution::detect_outside_execution;
 use crate::utils::{felt_to_u64, felt_to_u128};
 
 /// Format endpoint/function names from a transaction's multicall calldata.
@@ -49,6 +50,29 @@ fn dedupe_preserve_order(items: impl IntoIterator<Item = Felt>) -> Vec<Felt> {
     for item in items {
         if !out.contains(&item) {
             out.push(item);
+        }
+    }
+    out
+}
+
+/// Walk a multicall's raw calls and collect target addresses of any OE inner
+/// calls (deduplicated, first-seen order). Surfaces privacy-pool / anonymizer
+/// interactions that only appear inside `execute_from_outside*` or
+/// `execute_private_sponsored` wrappers — the top-level call list alone would
+/// miss them.
+pub fn oe_inner_targets(calls: &[RawCall], abi_reg: &AbiRegistry) -> Vec<Felt> {
+    let mut out: Vec<Felt> = Vec::new();
+    for call in calls {
+        let resolved_name = call
+            .function_name
+            .clone()
+            .or_else(|| abi_reg.get_selector_name(&call.selector));
+        if let Some((oe, _method)) = detect_outside_execution(call, resolved_name.as_deref()) {
+            for ic in &oe.inner_calls {
+                if !out.contains(&ic.contract_address) {
+                    out.push(ic.contract_address);
+                }
+            }
         }
     }
     out
@@ -272,7 +296,14 @@ pub fn build_tx_summary(
         _ => Vec::new(),
     };
     let endpoint_names = format_selector_names(calls.iter().map(|c| c.selector), abi_reg);
-    let called_contracts = dedupe_preserve_order(calls.iter().map(|c| c.contract_address));
+    let mut called_contracts = dedupe_preserve_order(calls.iter().map(|c| c.contract_address));
+    // Append OE inner targets so the privacy predicate (and the Calls column)
+    // can see the pool when it's reached only via an outside-execution wrapper.
+    for addr in oe_inner_targets(&calls, abi_reg) {
+        if !called_contracts.contains(&addr) {
+            called_contracts.push(addr);
+        }
+    }
 
     AddressTxSummary {
         hash,
@@ -328,7 +359,12 @@ pub fn build_tx_summary_from_pf_data(
             .collect();
         let calls = parse_multicall(&calldata);
         let names = format_selector_names(calls.iter().map(|c| c.selector), abi_reg);
-        let contracts = dedupe_preserve_order(calls.into_iter().map(|c| c.contract_address));
+        let mut contracts = dedupe_preserve_order(calls.iter().map(|c| c.contract_address));
+        for addr in oe_inner_targets(&calls, abi_reg) {
+            if !contracts.contains(&addr) {
+                contracts.push(addr);
+            }
+        }
         (names, contracts)
     } else {
         (String::new(), Vec::new())

--- a/src/network/helpers.rs
+++ b/src/network/helpers.rs
@@ -33,8 +33,13 @@ pub fn format_endpoint_names(tx: &SnTransaction, abi_reg: &AbiRegistry) -> Strin
     format_selector_names(calls.iter().map(|c| c.selector), abi_reg)
 }
 
-/// Top-level contracts directly invoked by `tx`'s multicall, in first-seen
-/// order with duplicates removed. Empty for non-Invoke txs.
+/// Top-level multicall targets only, in first-seen order with duplicates
+/// removed. Empty for non-Invoke txs.
+///
+/// Unlike the broader `AddressTxSummary::called_contracts` field (which
+/// `build_tx_summary` extends with OE inner targets), this helper stops
+/// at the top level — callers that need OE-inner addresses should walk
+/// `oe_inner_targets` themselves.
 pub fn tx_called_contracts(tx: &SnTransaction) -> Vec<Felt> {
     let calls = match tx {
         SnTransaction::Invoke(i) => parse_multicall(&i.calldata),

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -59,10 +59,13 @@ pub const TITLE_STYLE: Style = Style::new().fg(Color::Cyan).add_modifier(Modifie
 pub const BORDER_STYLE: Style = Style::new().fg(Color::DarkGray);
 pub const BORDER_FOCUSED_STYLE: Style = Style::new().fg(Color::Cyan);
 
-// Per-address color palette for tx detail view.
-// Slot 0 is reserved for the tx sender.
+// Per-address color palette. Used for "spot the repeat" highlighting across
+// list views (block tx list, address-info Txs/Calls tabs, tx detail). All
+// slots are plain (non-bold) so unlabeled, non-special addresses don't draw
+// the eye — bold is reserved for inherently special roles like the tx
+// sender (see `TX_SENDER_STYLE`) or privacy contracts (`PRIVACY_STYLE`).
 pub const ADDRESS_PALETTE: [Style; 8] = [
-    Style::new().fg(Color::White).add_modifier(Modifier::BOLD),
+    Style::new().fg(Color::LightCyan),
     Style::new().fg(Color::LightMagenta),
     Style::new().fg(Color::LightGreen),
     Style::new().fg(Color::LightYellow),
@@ -71,3 +74,9 @@ pub const ADDRESS_PALETTE: [Style; 8] = [
     Style::new().fg(Color::Magenta),
     Style::new().fg(Color::Blue),
 ];
+
+/// Highlight style for the tx sender in the tx detail view. Bold white so
+/// "this is the signer" pops on the header line. Deliberately NOT in
+/// `ADDRESS_PALETTE` — bold should mean "special role", not "this was
+/// just the first repeat we registered".
+pub const TX_SENDER_STYLE: Style = Style::new().fg(Color::White).add_modifier(Modifier::BOLD);

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -733,6 +733,7 @@ fn draw_calls_tab(f: &mut Frame, app: &mut App, area: Rect) {
         Span::styled("Tip              ", theme::SUGGESTION_STYLE),
         Span::styled("Block     ", theme::SUGGESTION_STYLE),
         Span::styled("St  ", theme::SUGGESTION_STYLE),
+        Span::styled("Prv ", theme::SUGGESTION_STYLE),
         Span::styled("Age  ", theme::SUGGESTION_STYLE),
     ]));
     f.render_widget(header, header_area);
@@ -807,6 +808,15 @@ fn draw_calls_tab(f: &mut Frame, app: &mut App, area: Rect) {
                 theme::TX_HASH_STYLE
             };
 
+            // A call is "privacy" iff any OE inner target is in the curated
+            // privacy bundle. The viewed contract is the top-level callee for
+            // every row in this tab, so checking the top level isn't useful —
+            // the pool only shows up through an OE wrapper here.
+            let is_privacy_call = registry
+                .map(|reg| call.inner_targets.iter().any(|t| reg.is_privacy_address(t)))
+                .unwrap_or(false);
+            let prv_marker_text = if is_privacy_call { "🛡   " } else { "    " };
+
             let line = Line::from(vec![
                 Span::styled(format!(" {:<25} ", sender_display), sender_style),
                 Span::styled(format!("{:<31}", func), theme::LABEL_STYLE),
@@ -819,6 +829,7 @@ fn draw_calls_tab(f: &mut Frame, app: &mut App, area: Rect) {
                     theme::BLOCK_NUMBER_STYLE,
                 ),
                 Span::styled(format!("{:<4}", &call.status), status_style),
+                Span::styled(prv_marker_text, theme::PRIVACY_STYLE),
                 Span::styled(format_age(call.timestamp), theme::BLOCK_AGE_STYLE),
             ]);
             ListItem::new(line)

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -495,6 +495,13 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
         return;
     }
 
+    // Refresh the per-contract count + color slot cache for the Contracts
+    // column. No-op when the tx list hasn't grown since the last render.
+    // Done before the gap closure below borrows `app.address` immutably.
+    let registry = app.search_engine.as_ref().map(|e| e.registry());
+    app.address
+        .update_tx_color_map(|addr| registry.is_some_and(|r| r.is_known(addr)));
+
     // (tx_idx, lo_nonce) for each gap, sorted by tx_idx ascending. Each gap
     // renders as its own ListItem above the lo_nonce tx.
     let gap_positions = app.address.gap_render_positions();
@@ -542,7 +549,7 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
         } else {
             tx.endpoint_names.clone()
         };
-        let contracts_display = format_called_contracts(app, &tx.called_contracts);
+        let contract_spans = format_called_contracts_spans(app, &tx.called_contracts);
         // A tx is "privacy" iff any of its top-level called contracts is in the
         // curated privacy bundle. Catches the common case (top-level pool call
         // or pool-via-known-helper). OE-wrapped sponsored txs that only reach
@@ -559,11 +566,6 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
                     .any(|c| reg.is_privacy_address(c))
             })
             .unwrap_or(false);
-        let contracts_style = if is_privacy_tx {
-            theme::PRIVACY_STYLE
-        } else {
-            theme::LABEL_STYLE
-        };
 
         let status_style = match tx.status.as_str() {
             "OK" => theme::STATUS_OK,
@@ -588,11 +590,13 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
         };
 
         let prv_marker_text = if is_privacy_tx { "🛡   " } else { "    " };
-        let main_line = Line::from(vec![
+        let mut row_spans: Vec<Span<'static>> = vec![
             Span::styled(format!(" {:<8}", tx.nonce), theme::NORMAL_STYLE),
             Span::styled(format!("{:<15}", tx.tx_type), type_style),
             Span::styled(format!("{:<14}", tx_hash_display), tx_hash_style),
-            Span::styled(format!("{:<30}", contracts_display), contracts_style),
+        ];
+        row_spans.extend(contract_spans);
+        row_spans.extend([
             Span::styled(format!("{:<31}", endpoint), theme::LABEL_STYLE),
             Span::styled(format!("{:<17}", fee_str), theme::TX_FEE_STYLE),
             Span::styled(format!("{:<17}", tip_str), theme::SUGGESTION_STYLE),
@@ -604,7 +608,7 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
             Span::styled(prv_marker_text, theme::PRIVACY_STYLE),
             Span::styled(age, theme::BLOCK_AGE_STYLE),
         ]);
-        items.push(ListItem::new(main_line));
+        items.push(ListItem::new(Line::from(row_spans)));
     }
 
     let gap_suffix = if app.address.unfilled_gaps.is_empty() {
@@ -658,28 +662,61 @@ fn draw_transactions_tab(f: &mut Frame, app: &mut App, area: Rect) {
 /// (registry/Voyager-resolved or short hex), followed by ` +N` for any
 /// remaining. Each label is truncated to share the 29-char content budget;
 /// any slack left by a short first label spills over to the second.
-fn format_called_contracts(app: &App, contracts: &[Felt]) -> String {
-    const BUDGET: usize = 29;
+///
+/// Returns a sequence of styled spans so each contract gets its own theme:
+/// privacy contracts render in `PRIVACY_STYLE`, registry-labeled contracts
+/// in `LABEL_STYLE`, repeats in their palette slot, one-offs in `NORMAL_STYLE`.
+/// Separator and `+N` overflow stay in `SUGGESTION_STYLE`. The returned
+/// vector always totals exactly 30 visible chars (one trailing pad column).
+fn format_called_contracts_spans(app: &App, contracts: &[Felt]) -> Vec<Span<'static>> {
+    const CONTENT_BUDGET: usize = 29;
+    const COLUMN_WIDTH: usize = 30;
     if contracts.is_empty() {
-        return String::new();
+        return vec![Span::raw(" ".repeat(COLUMN_WIDTH))];
     }
+    let registry = app.search_engine.as_ref().map(|e| e.registry());
+    let color_map = &app.address.tx_color_map;
     let labels: Vec<String> = contracts.iter().map(|c| app.format_address(c)).collect();
+
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let used_chars;
+
     if labels.len() == 1 {
-        return truncate_to(&labels[0], BUDGET);
-    }
-    let extra = labels.len().saturating_sub(2);
-    let suffix = if extra > 0 {
-        format!(" +{extra}")
+        let label = truncate_to(&labels[0], CONTENT_BUDGET);
+        let style = known_or_palette_style(&contracts[0], registry, color_map);
+        used_chars = label.chars().count();
+        spans.push(Span::styled(label, style));
     } else {
-        String::new()
-    };
-    const SEP: &str = ", ";
-    let usable = BUDGET.saturating_sub(suffix.chars().count() + SEP.len());
-    let a_budget = usable / 2;
-    let a = truncate_to(&labels[0], a_budget);
-    let b_budget = usable.saturating_sub(a.chars().count());
-    let b = truncate_to(&labels[1], b_budget);
-    format!("{a}{SEP}{b}{suffix}")
+        let extra = labels.len().saturating_sub(2);
+        let suffix = if extra > 0 {
+            format!(" +{extra}")
+        } else {
+            String::new()
+        };
+        const SEP: &str = ", ";
+        let inner_budget = CONTENT_BUDGET.saturating_sub(suffix.chars().count() + SEP.len());
+        let a_budget = inner_budget / 2;
+        let a = truncate_to(&labels[0], a_budget);
+        let b_budget = inner_budget.saturating_sub(a.chars().count());
+        let b = truncate_to(&labels[1], b_budget);
+
+        let style_a = known_or_palette_style(&contracts[0], registry, color_map);
+        let style_b = known_or_palette_style(&contracts[1], registry, color_map);
+
+        used_chars = a.chars().count() + SEP.len() + b.chars().count() + suffix.chars().count();
+        spans.push(Span::styled(a, style_a));
+        spans.push(Span::styled(SEP, theme::SUGGESTION_STYLE));
+        spans.push(Span::styled(b, style_b));
+        if !suffix.is_empty() {
+            spans.push(Span::styled(suffix, theme::SUGGESTION_STYLE));
+        }
+    }
+
+    let pad = COLUMN_WIDTH.saturating_sub(used_chars);
+    if pad > 0 {
+        spans.push(Span::raw(" ".repeat(pad)));
+    }
+    spans
 }
 
 /// Truncate a label to fit `max` chars, appending `…` when shortened. Returns

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -761,6 +761,15 @@ fn draw_calls_tab(f: &mut Frame, app: &mut App, area: Rect) {
     app.address
         .update_call_color_map(|addr| registry.is_some_and(|r| r.is_known(addr)));
 
+    // If the viewed contract is itself a privacy address, every incoming
+    // call in this tab is by definition a privacy interaction — no need to
+    // look at `inner_targets` (which would only fire for OE-wrapped flows
+    // when viewing a non-privacy contract).
+    let viewed_is_privacy = registry
+        .zip(app.address.info.as_ref())
+        .map(|(reg, info)| reg.is_privacy_address(&info.address))
+        .unwrap_or(false);
+
     let items: Vec<ListItem> = app
         .address
         .calls
@@ -808,13 +817,15 @@ fn draw_calls_tab(f: &mut Frame, app: &mut App, area: Rect) {
                 theme::TX_HASH_STYLE
             };
 
-            // A call is "privacy" iff any OE inner target is in the curated
-            // privacy bundle. The viewed contract is the top-level callee for
-            // every row in this tab, so checking the top level isn't useful —
-            // the pool only shows up through an OE wrapper here.
-            let is_privacy_call = registry
-                .map(|reg| call.inner_targets.iter().any(|t| reg.is_privacy_address(t)))
-                .unwrap_or(false);
+            // Privacy iff the viewed contract is itself a privacy address
+            // (every incoming call is then a privacy interaction) OR any OE
+            // inner target is in the curated bundle (for non-privacy contract
+            // pages like AVNU Forwarder where the pool only appears as an
+            // inner call).
+            let is_privacy_call = viewed_is_privacy
+                || registry
+                    .map(|reg| call.inner_targets.iter().any(|t| reg.is_privacy_address(t)))
+                    .unwrap_or(false);
             let prv_marker_text = if is_privacy_call { "🛡   " } else { "    " };
 
             let line = Line::from(vec![

--- a/src/ui/views/tx_detail.rs
+++ b/src/ui/views/tx_detail.rs
@@ -614,7 +614,8 @@ fn build_header_lines(
         }
     }
 
-    // Sender + Nonce — colored with slot 0
+    // Sender + Nonce — sender renders in `TX_SENDER_STYLE` via the
+    // color map's sender override.
     let sender = tx.sender();
     let nonce_str = tx
         .nonce()
@@ -2908,8 +2909,11 @@ fn block_marker(n: u64, selected: Option<&TxNavItem>) -> Span<'static> {
 }
 
 /// Build the address color map for the current tx view.
-/// Sender is registered first (slot 0), then call contracts, then event contracts,
-/// then ContractAddress-typed params — so the same address always gets the same color.
+/// The tx sender is pinned to `TX_SENDER_STYLE` via `set_sender` so it
+/// always reads as "the signer" regardless of how many other addresses
+/// the view registers. Other contracts (call targets, deployed addrs,
+/// event params) get plain palette slots in registration order, so a
+/// repeated address keeps a consistent color across tabs.
 fn build_color_map(app: &App, privacy: Option<&PrivacySummary>) -> AddressColorMap {
     let mut cm = AddressColorMap::new();
     if let Some(engine) = &app.search_engine {
@@ -2917,7 +2921,7 @@ fn build_color_map(app: &App, privacy: Option<&PrivacySummary>) -> AddressColorM
     }
 
     if let Some(tx) = &app.tx_detail.transaction {
-        cm.register(tx.sender());
+        cm.set_sender(tx.sender());
     }
 
     // Deployed addresses (via UDC) get their own color slots

--- a/src/ui/views/tx_detail.rs
+++ b/src/ui/views/tx_detail.rs
@@ -1919,10 +1919,12 @@ struct PrivacyTokenFlow {
     public_withdraw_to: Option<Felt>,
 }
 
-/// Synthesize one Net-flow line per token from the decrypted/spent
-/// note sets and public pool events for this tx. Returns empty when
-/// neither viewing-key-decoded activity nor public pool flows exist
-/// for any token.
+/// Synthesize one Pool-changes line per token whose pool TVL moved in
+/// this tx (public Deposit / Withdrawal / OpenNoteDeposited). The
+/// viewing-key flows (decrypted / spent notes) are folded in as detail
+/// for those tokens but never trigger a row on their own — pure
+/// internal transfers have no pool-TVL effect, and their per-note
+/// breakdown is already shown in the Decrypted / Spent sections.
 fn build_privacy_net_flow_lines(
     app: &App,
     summary: &PrivacySummary,
@@ -1977,16 +1979,15 @@ fn build_privacy_net_flow_lines(
         entry.public_open_deposited = entry.public_open_deposited.saturating_add(ond.amount);
         entry.public_depositor.get_or_insert(ond.depositor);
     }
+    // Only surface tokens whose pool TVL actually moved (a public
+    // Deposit / Withdrawal / OpenNoteDeposited). Purely viewing-key
+    // flows are an internal transfer between two pool users — the
+    // pool's balance didn't change, and the per-note breakdown is
+    // already shown in the Decrypted / Spent notes sections below.
     let mut ordered: Vec<(&Felt, &PrivacyTokenFlow)> = flows
         .iter()
         .filter(|(_, f)| {
-            f.sent_to_external != 0
-                || f.received_from_external != 0
-                || f.self_change != 0
-                || f.spent_self != 0
-                || f.public_deposited != 0
-                || f.public_withdrawn != 0
-                || f.public_open_deposited != 0
+            f.public_deposited != 0 || f.public_withdrawn != 0 || f.public_open_deposited != 0
         })
         .collect();
     ordered.sort_by(|(a, _), (b, _)| a.to_bytes_be().cmp(&b.to_bytes_be()));

--- a/src/ui/widgets/address_color.rs
+++ b/src/ui/widgets/address_color.rs
@@ -35,18 +35,23 @@ pub fn known_or_palette_style(
 
 /// Assigns a stable palette color to each unique address seen in a tx view.
 ///
-/// Registration order determines the slot (and thus the color). The caller
-/// should register addresses in a consistent order so the sender always gets
-/// slot 0 (LightCyan).
+/// Registration order determines the slot (and thus the color). Palette
+/// slots are all plain colors so the spot-the-repeat scan stays even —
+/// no one slot draws extra attention.
 ///
-/// Addresses added to `privacy_overrides` skip the palette entirely and
-/// always render in `theme::PRIVACY_STYLE`, so privacy-pool contracts pop
-/// out wherever they appear regardless of which slot they'd otherwise land
-/// in.
+/// Two override sets escape the palette entirely:
+///
+/// - `privacy_overrides` — addresses pinned to `theme::PRIVACY_STYLE` so
+///   curated privacy contracts pop out wherever they appear.
+/// - `sender_override` — at most one address per map, pinned to
+///   `theme::TX_SENDER_STYLE` (bold white). The tx detail view sets this
+///   on the tx initiator so "this is the signer" is visually distinct
+///   from every other address on the page.
 pub struct AddressColorMap {
     slots: HashMap<Felt, usize>,
     next_slot: usize,
     privacy_overrides: HashSet<Felt>,
+    sender_override: Option<Felt>,
 }
 
 impl Default for AddressColorMap {
@@ -61,6 +66,7 @@ impl AddressColorMap {
             slots: HashMap::new(),
             next_slot: 0,
             privacy_overrides: HashSet::new(),
+            sender_override: None,
         }
     }
 
@@ -70,9 +76,21 @@ impl AddressColorMap {
         self.privacy_overrides.extend(addrs);
     }
 
+    /// Mark this address as the "tx sender" anchor. It will always render
+    /// in `TX_SENDER_STYLE` (bold white), shortcutting both palette and
+    /// privacy assignments. Calling this twice replaces the previous
+    /// sender. Intended for tx detail; views that show many senders side
+    /// by side (block detail, calls tab) should leave this unset.
+    pub fn set_sender(&mut self, addr: Felt) {
+        self.sender_override = Some(addr);
+    }
+
     /// Register an address and return its assigned Style.
     /// Idempotent: the same address always gets the same slot.
     pub fn register(&mut self, addr: Felt) -> Style {
+        if self.sender_override == Some(addr) {
+            return theme::TX_SENDER_STYLE;
+        }
         if self.privacy_overrides.contains(&addr) {
             return theme::PRIVACY_STYLE;
         }
@@ -87,6 +105,9 @@ impl AddressColorMap {
     /// Look up an already-registered address.
     /// Returns `NORMAL_STYLE` for addresses not in the map.
     pub fn style_for(&self, addr: &Felt) -> Style {
+        if self.sender_override.as_ref() == Some(addr) {
+            return theme::TX_SENDER_STYLE;
+        }
         if self.privacy_overrides.contains(addr) {
             return theme::PRIVACY_STYLE;
         }

--- a/tests/cache_pool_bench_test.rs
+++ b/tests/cache_pool_bench_test.rs
@@ -158,6 +158,7 @@ fn mk_call_summary(idx: u64) -> ContractCallSummary {
         status: "OK".to_string(),
         nonce: Some(idx),
         tip: 0,
+        inner_targets: Vec::new(),
     }
 }
 

--- a/tests/dedup_test.rs
+++ b/tests/dedup_test.rs
@@ -13,6 +13,7 @@ fn make_call(tx_hash: u64, sender: u64, function_name: &str, block: u64) -> Cont
         status: "OK".into(),
         nonce: None,
         tip: 0,
+        inner_targets: Vec::new(),
     }
 }
 


### PR DESCRIPTION
## Summary

- **Privacy shield on Transactions + Calls tabs (`83464ec`)** — the shield only fired when a top-level multicall target was in the privacy bundle, so `execute_private_sponsored` / OE-wrapped txs that reach the pool only through an inner call were missed. Extends `called_contracts` with OE inner targets and adds a Prv column to the per-contract Calls tab.
- **Shield every row on a privacy contract's own Calls tab (`012c73b`)** — when the viewed address itself is in the bundle, every incoming call is a privacy interaction; the previous predicate only checked inner_targets and missed direct top-level calls.
- **Dedicated tx-sender style + palette repeats in Txs tab Contracts column (`0a5f294`)** — splits bold-white out of the address palette into `TX_SENDER_STYLE`. Palette slot 0 is now plain LightCyan, so "first registered repeat" no longer accidentally inherits the sender's bold style. Mirrors the Calls tab's per-contract coloring on the Txs tab Contracts column (known→LABEL, privacy→PRIVACY, repeats→palette, one-offs→NORMAL).
- **Scope Pool changes to public pool-TVL events (`acd7014`)** — internal pool transfers (decrypted+spent on the same user with no public Deposit/Withdrawal/OpenNoteDeposited) no longer render as "Pool changes". The pool's TVL is unchanged for those, and the per-note breakdown is already shown in Decrypted / Spent notes. Viewing-key flows still appear as inline detail on rows that *do* have a public event.

## Test plan

- [ ] Tx detail → Privacy tab on an internal-only transfer tx: `Pool changes` section is hidden; `Decrypted` / `Spent notes` still show the per-note rows.
- [ ] Tx detail → Privacy tab on a deposit / withdrawal tx: `Pool changes` still shows with the `(deposited X from …)` / `(withdrew X → …)` detail.
- [ ] Address page → Txs tab: repeated unlabeled contracts in the Contracts column get a consistent palette color across rows; labeled contracts stay in LABEL_STYLE; privacy contracts stay in PRIVACY_STYLE.
- [ ] Tx detail header: sender renders in bold white regardless of how many other addresses appear; other repeated addresses use plain palette slots.
- [ ] Address page → Calls / Transactions tabs on a sponsored privacy tx (OE inner call to pool): Prv shield appears on the row.
- [ ] Address page for a privacy contract itself: every Calls row has the Prv shield.

🤖 Generated with [Claude Code](https://claude.com/claude-code)