### PR TITLE
Per-address Balance Changes summary in Transfers tab

### DIFF
--- a/src/decode/trace.rs
+++ b/src/decode/trace.rs
@@ -348,7 +348,11 @@ impl TransferGroups {
             for tk in token_order {
                 let accum = accum_map.remove(&tk).expect("token tracked in order");
                 let (net, overflow) = accum.finalize();
-                if matches!(net, Some(0)) && !overflow {
+                // Drop any (address, token) pair whose received and sent u256
+                // totals are exactly equal — that's a true zero net even when
+                // the sums saturated past i128/u128 and `net` had to fall
+                // back to `None`. Subsumes the common `net == Some(0)` case.
+                if accum.received_low == accum.sent_low && accum.received_high == accum.sent_high {
                     continue;
                 }
                 tokens.push(TokenDelta {
@@ -1126,5 +1130,67 @@ mod tests {
             assert!(ad.tokens[0].overflow, "expected overflow flag set");
             assert!(ad.tokens[0].net.is_none());
         }
+    }
+
+    /// A round-trip transfer where each leg's amount exceeds u128 (so the
+    /// per-address accumulators end up `overflow == true`) but received and
+    /// sent u256 totals match exactly. Net is still zero, so the row must
+    /// drop instead of rendering as a misleading overflow-fallback line.
+    #[test]
+    fn balance_changes_drops_overflow_round_trip() {
+        let token = felt(ETH);
+        let alice = felt(ALICE);
+        let avnu = felt(AVNU);
+
+        // value_high = 1 on both legs → each amount is > 2^128, but the
+        // received/sent totals on each side end up identical.
+        let make_ev = |from: Felt, to: Felt| DecodedEvent {
+            contract_address: token,
+            event_name: Some("Transfer".into()),
+            decoded_keys: vec![
+                DecodedParam {
+                    name: Some("from".into()),
+                    type_name: Some("ContractAddress".into()),
+                    value: from,
+                    value_high: None,
+                },
+                DecodedParam {
+                    name: Some("to".into()),
+                    type_name: Some("ContractAddress".into()),
+                    value: to,
+                    value_high: None,
+                },
+            ],
+            decoded_data: vec![DecodedParam {
+                name: Some("value".into()),
+                type_name: Some("u256".into()),
+                value: Felt::from(1u32),
+                value_high: Some(Felt::from(1u32)),
+            }],
+            raw: SnEvent {
+                from_address: token,
+                keys: Vec::new(),
+                data: Vec::new(),
+                transaction_hash: Felt::ZERO,
+                block_number: 0,
+                event_index: 0,
+            },
+        };
+
+        let execute = leaf_call(
+            alice,
+            "__execute__",
+            vec![make_ev(alice, avnu), make_ev(avnu, alice)],
+        );
+        let trace = DecodedTrace {
+            execute: Some(execute),
+            ..DecodedTrace::default()
+        };
+        let deltas = trace.collect_transfers().balance_changes();
+        assert!(
+            deltas.is_empty(),
+            "overflow round-trip should drop entirely; got {:?}",
+            deltas
+        );
     }
 }

--- a/src/decode/trace.rs
+++ b/src/decode/trace.rs
@@ -21,6 +21,7 @@ use super::AbiRegistry;
 use super::abi::{FunctionDef, ParsedAbi};
 use super::events::{DecodedEvent, decode_event};
 use crate::data::types::SnEvent;
+use crate::utils::felt_to_u128;
 
 /// One node in the decoded call tree. Mirrors `FunctionInvocation` with
 /// extra ABI-resolved fields. Field naming matches `RawCall` where possible
@@ -180,6 +181,180 @@ pub struct TransferRow {
     pub value_low: Felt,
     /// High 128 bits of the u256 amount.
     pub value_high: Felt,
+}
+
+/// Net delta of one (address, token) pair across every transfer in a tx.
+#[derive(Debug, Clone)]
+pub struct TokenDelta {
+    pub token: Felt,
+    /// Signed net amount (received − sent), low 128 bits. `None` when any
+    /// contributing transfer carried `value_high != 0` or a running total
+    /// exceeded the u128/i128 range — caller should fall back to raw display.
+    pub net: Option<i128>,
+    /// True when `net` could not be computed cleanly (u256 overflow or sum
+    /// saturation). Mutually exclusive with `net == Some(_)` in practice.
+    pub overflow: bool,
+    pub received_low: u128,
+    pub received_high: u128,
+    pub sent_low: u128,
+    pub sent_high: u128,
+}
+
+/// Per-address net balance changes across every token it touched.
+#[derive(Debug, Clone)]
+pub struct AddressDelta {
+    pub address: Felt,
+    /// First-appearance order. Caller sorts for display.
+    pub tokens: Vec<TokenDelta>,
+}
+
+/// Running totals for one (address, token) pair; collapsed into `TokenDelta` at finalize.
+#[derive(Debug, Default)]
+struct DeltaAccum {
+    received_low: u128,
+    received_high: u128,
+    sent_low: u128,
+    sent_high: u128,
+    /// Any contributing row had `value_high != 0`, or a u128 sum saturated.
+    overflow: bool,
+}
+
+impl DeltaAccum {
+    fn add_received(&mut self, low: u128, high: u128) {
+        if high != 0 {
+            self.overflow = true;
+        }
+        match self.received_low.checked_add(low) {
+            Some(v) => self.received_low = v,
+            None => self.overflow = true,
+        }
+        match self.received_high.checked_add(high) {
+            Some(v) => self.received_high = v,
+            None => self.overflow = true,
+        }
+    }
+    fn add_sent(&mut self, low: u128, high: u128) {
+        if high != 0 {
+            self.overflow = true;
+        }
+        match self.sent_low.checked_add(low) {
+            Some(v) => self.sent_low = v,
+            None => self.overflow = true,
+        }
+        match self.sent_high.checked_add(high) {
+            Some(v) => self.sent_high = v,
+            None => self.overflow = true,
+        }
+    }
+    fn finalize(&self) -> (Option<i128>, bool) {
+        if self.overflow {
+            return (None, true);
+        }
+        // received_low and sent_low fit in u128; convert to i128 individually.
+        // Both must be ≤ i128::MAX for the subtraction to stay in range.
+        let r = i128::try_from(self.received_low).ok();
+        let s = i128::try_from(self.sent_low).ok();
+        match (r, s) {
+            (Some(r), Some(s)) => match r.checked_sub(s) {
+                Some(net) => (Some(net), false),
+                None => (None, true),
+            },
+            _ => (None, true),
+        }
+    }
+}
+
+impl TransferGroups {
+    /// Iterate every TransferRow in display/execution order:
+    /// validate → constructor → execute_top → execute_calls[*] → l1_handler → fee.
+    fn all_transfers(&self) -> impl Iterator<Item = &TransferRow> {
+        self.validate
+            .iter()
+            .chain(self.constructor.iter())
+            .chain(self.execute_top.iter())
+            .chain(self.execute_calls.iter().flat_map(|g| g.transfers.iter()))
+            .chain(self.l1_handler.iter())
+            .chain(self.fee.iter())
+    }
+
+    /// Compute per-address per-token net balance changes across every transfer
+    /// in the tx, fees included. Self-transfers (`from == to`) and zero net
+    /// deltas are dropped. Addresses and their tokens are returned in
+    /// first-appearance order; the caller sorts for display.
+    pub fn balance_changes(&self) -> Vec<AddressDelta> {
+        use std::collections::HashMap;
+
+        let mut addr_order: Vec<Felt> = Vec::new();
+        // address -> (token first-appearance order, accumulators per token)
+        let mut per_addr: HashMap<Felt, (Vec<Felt>, HashMap<Felt, DeltaAccum>)> = HashMap::new();
+
+        for row in self.all_transfers() {
+            if row.from == row.to {
+                continue;
+            }
+            let low = felt_to_u128(&row.value_low);
+            let high = felt_to_u128(&row.value_high);
+
+            // from-side: sent grows
+            {
+                let entry = per_addr.entry(row.from).or_insert_with(|| {
+                    addr_order.push(row.from);
+                    (Vec::new(), HashMap::new())
+                });
+                if !entry.1.contains_key(&row.token) {
+                    entry.0.push(row.token);
+                }
+                entry.1.entry(row.token).or_default().add_sent(low, high);
+            }
+
+            // to-side: received grows
+            {
+                let entry = per_addr.entry(row.to).or_insert_with(|| {
+                    addr_order.push(row.to);
+                    (Vec::new(), HashMap::new())
+                });
+                if !entry.1.contains_key(&row.token) {
+                    entry.0.push(row.token);
+                }
+                entry
+                    .1
+                    .entry(row.token)
+                    .or_default()
+                    .add_received(low, high);
+            }
+        }
+
+        let mut out = Vec::with_capacity(addr_order.len());
+        for addr in addr_order {
+            let (token_order, mut accum_map) =
+                per_addr.remove(&addr).expect("address tracked in order");
+            let mut tokens = Vec::with_capacity(token_order.len());
+            for tk in token_order {
+                let accum = accum_map.remove(&tk).expect("token tracked in order");
+                let (net, overflow) = accum.finalize();
+                if matches!(net, Some(0)) && !overflow {
+                    continue;
+                }
+                tokens.push(TokenDelta {
+                    token: tk,
+                    net,
+                    overflow,
+                    received_low: accum.received_low,
+                    received_high: accum.received_high,
+                    sent_low: accum.sent_low,
+                    sent_high: accum.sent_high,
+                });
+            }
+            if tokens.is_empty() {
+                continue;
+            }
+            out.push(AddressDelta {
+                address: addr,
+                tokens,
+            });
+        }
+        out
+    }
 }
 
 /// Pre-order walk of one invocation's subtree, appending every Transfer event
@@ -725,5 +900,171 @@ mod tests {
         let groups = trace.collect_transfers();
         assert_eq!(groups.execute_top.len(), 1);
         assert_eq!(groups.total, 1);
+    }
+
+    /// A two-leg swap: alice sends token1 to avnu and receives token2 back.
+    /// Expect both addresses with two-token deltas, opposite signs.
+    #[test]
+    fn balance_changes_pairs_swap_legs() {
+        let token1 = felt(ETH);
+        let token2 = felt(SEQ);
+        let alice = felt(ALICE);
+        let avnu = felt(AVNU);
+
+        let execute = leaf_call(
+            alice,
+            "__execute__",
+            vec![
+                transfer_event(token1, alice, avnu, 1_000),
+                transfer_event(token2, avnu, alice, 950),
+            ],
+        );
+        let trace = DecodedTrace {
+            execute: Some(execute),
+            ..DecodedTrace::default()
+        };
+        let deltas = trace.collect_transfers().balance_changes();
+
+        assert_eq!(deltas.len(), 2, "expected two participating addresses");
+        let by_addr: std::collections::HashMap<Felt, &AddressDelta> =
+            deltas.iter().map(|d| (d.address, d)).collect();
+
+        let a = by_addr[&alice];
+        assert_eq!(a.tokens.len(), 2);
+        let a_t1 = a.tokens.iter().find(|t| t.token == token1).unwrap();
+        let a_t2 = a.tokens.iter().find(|t| t.token == token2).unwrap();
+        assert_eq!(a_t1.net, Some(-1_000));
+        assert_eq!(a_t2.net, Some(950));
+
+        let b = by_addr[&avnu];
+        let b_t1 = b.tokens.iter().find(|t| t.token == token1).unwrap();
+        let b_t2 = b.tokens.iter().find(|t| t.token == token2).unwrap();
+        assert_eq!(b_t1.net, Some(1_000));
+        assert_eq!(b_t2.net, Some(-950));
+    }
+
+    /// A round-trip transfer (A → B then B → A, same token, same amount)
+    /// nets to zero on both sides and should drop from the summary entirely.
+    #[test]
+    fn balance_changes_drops_round_trip_to_zero() {
+        let token = felt(ETH);
+        let alice = felt(ALICE);
+        let avnu = felt(AVNU);
+
+        let execute = leaf_call(
+            alice,
+            "__execute__",
+            vec![
+                transfer_event(token, alice, avnu, 500),
+                transfer_event(token, avnu, alice, 500),
+            ],
+        );
+        let trace = DecodedTrace {
+            execute: Some(execute),
+            ..DecodedTrace::default()
+        };
+        let deltas = trace.collect_transfers().balance_changes();
+        assert!(deltas.is_empty(), "expected no addresses; got {:?}", deltas);
+    }
+
+    /// A mint from the zero address shows up as +X on the recipient and −X
+    /// on 0x0 — the renderer relabels 0x0 as mint/burn.
+    #[test]
+    fn balance_changes_records_mint_from_zero_address() {
+        let token = felt(ETH);
+        let alice = felt(ALICE);
+        let zero = Felt::ZERO;
+
+        let execute = leaf_call(
+            alice,
+            "__execute__",
+            vec![transfer_event(token, zero, alice, 7_777)],
+        );
+        let trace = DecodedTrace {
+            execute: Some(execute),
+            ..DecodedTrace::default()
+        };
+        let deltas = trace.collect_transfers().balance_changes();
+        let by_addr: std::collections::HashMap<Felt, &AddressDelta> =
+            deltas.iter().map(|d| (d.address, d)).collect();
+
+        assert_eq!(by_addr[&alice].tokens[0].net, Some(7_777));
+        assert_eq!(by_addr[&zero].tokens[0].net, Some(-7_777));
+    }
+
+    /// Fee transfers must be included in the per-address net deltas.
+    #[test]
+    fn balance_changes_includes_fee_phase() {
+        let token = felt(ETH);
+        let alice = felt(ALICE);
+        let seq = felt(SEQ);
+
+        let fee = leaf_call(
+            token,
+            "transfer",
+            vec![transfer_event(token, alice, seq, 42)],
+        );
+        let trace = DecodedTrace {
+            fee_transfer: Some(fee),
+            ..DecodedTrace::default()
+        };
+        let deltas = trace.collect_transfers().balance_changes();
+        let by_addr: std::collections::HashMap<Felt, &AddressDelta> =
+            deltas.iter().map(|d| (d.address, d)).collect();
+        assert_eq!(by_addr[&alice].tokens[0].net, Some(-42));
+        assert_eq!(by_addr[&seq].tokens[0].net, Some(42));
+    }
+
+    /// A transfer whose value exceeds u128 (value_high != 0) must mark the
+    /// affected delta as `overflow` so the renderer falls back to raw display.
+    #[test]
+    fn balance_changes_flags_u256_overflow() {
+        let token = felt(ETH);
+        let alice = felt(ALICE);
+        let avnu = felt(AVNU);
+
+        // value_high = 1 → amount > 2^128
+        let ev = DecodedEvent {
+            contract_address: token,
+            event_name: Some("Transfer".into()),
+            decoded_keys: vec![
+                DecodedParam {
+                    name: Some("from".into()),
+                    type_name: Some("ContractAddress".into()),
+                    value: alice,
+                    value_high: None,
+                },
+                DecodedParam {
+                    name: Some("to".into()),
+                    type_name: Some("ContractAddress".into()),
+                    value: avnu,
+                    value_high: None,
+                },
+            ],
+            decoded_data: vec![DecodedParam {
+                name: Some("value".into()),
+                type_name: Some("u256".into()),
+                value: Felt::from(1u32),
+                value_high: Some(Felt::from(1u32)),
+            }],
+            raw: SnEvent {
+                from_address: token,
+                keys: Vec::new(),
+                data: Vec::new(),
+                transaction_hash: Felt::ZERO,
+                block_number: 0,
+                event_index: 0,
+            },
+        };
+        let execute = leaf_call(alice, "__execute__", vec![ev]);
+        let trace = DecodedTrace {
+            execute: Some(execute),
+            ..DecodedTrace::default()
+        };
+        let deltas = trace.collect_transfers().balance_changes();
+        for ad in &deltas {
+            assert!(ad.tokens[0].overflow, "expected overflow flag set");
+            assert!(ad.tokens[0].net.is_none());
+        }
     }
 }

--- a/src/decode/trace.rs
+++ b/src/decode/trace.rs
@@ -215,43 +215,59 @@ struct DeltaAccum {
     received_high: u128,
     sent_low: u128,
     sent_high: u128,
-    /// Any contributing row had `value_high != 0`, or a u128 sum saturated.
+    /// Set only when a running sum exceeds 2^256 — astronomically rare. Other
+    /// overflow conditions (u256 net not representable as i128) are detected
+    /// at `finalize()` time so the raw `received_*` / `sent_*` totals stay
+    /// faithful to the actual sum even in the fallback display path.
     overflow: bool,
+}
+
+/// In-place u256 add: `(dst_low, dst_high) += (add_low, add_high)` with
+/// proper carry from the low half into the high half. Sets `overflow_flag`
+/// only when the high half itself overflows (sum > 2^256).
+fn add_u256_inplace(
+    add_low: u128,
+    add_high: u128,
+    dst_low: &mut u128,
+    dst_high: &mut u128,
+    overflow_flag: &mut bool,
+) {
+    let (new_low, carry_low) = dst_low.overflowing_add(add_low);
+    *dst_low = new_low;
+    let (mid_high, c1) = dst_high.overflowing_add(add_high);
+    let (new_high, c2) = mid_high.overflowing_add(u128::from(carry_low));
+    *dst_high = new_high;
+    if c1 || c2 {
+        *overflow_flag = true;
+    }
 }
 
 impl DeltaAccum {
     fn add_received(&mut self, low: u128, high: u128) {
-        if high != 0 {
-            self.overflow = true;
-        }
-        match self.received_low.checked_add(low) {
-            Some(v) => self.received_low = v,
-            None => self.overflow = true,
-        }
-        match self.received_high.checked_add(high) {
-            Some(v) => self.received_high = v,
-            None => self.overflow = true,
-        }
+        add_u256_inplace(
+            low,
+            high,
+            &mut self.received_low,
+            &mut self.received_high,
+            &mut self.overflow,
+        );
     }
     fn add_sent(&mut self, low: u128, high: u128) {
-        if high != 0 {
-            self.overflow = true;
-        }
-        match self.sent_low.checked_add(low) {
-            Some(v) => self.sent_low = v,
-            None => self.overflow = true,
-        }
-        match self.sent_high.checked_add(high) {
-            Some(v) => self.sent_high = v,
-            None => self.overflow = true,
-        }
+        add_u256_inplace(
+            low,
+            high,
+            &mut self.sent_low,
+            &mut self.sent_high,
+            &mut self.overflow,
+        );
     }
     fn finalize(&self) -> (Option<i128>, bool) {
-        if self.overflow {
+        // Either side carrying a non-zero high half means the u256 difference
+        // can't be expressed cleanly as a low-128 signed delta — fall back to
+        // raw display. (The u256 totals are still accurate thanks to carry.)
+        if self.overflow || self.received_high != 0 || self.sent_high != 0 {
             return (None, true);
         }
-        // received_low and sent_low fit in u128; convert to i128 individually.
-        // Both must be ≤ i128::MAX for the subtraction to stay in range.
         let r = i128::try_from(self.received_low).ok();
         let s = i128::try_from(self.sent_low).ok();
         match (r, s) {
@@ -1013,6 +1029,50 @@ mod tests {
             deltas.iter().map(|d| (d.address, d)).collect();
         assert_eq!(by_addr[&alice].tokens[0].net, Some(-42));
         assert_eq!(by_addr[&seq].tokens[0].net, Some(42));
+    }
+
+    /// Sum of multiple in-range transfers can still exceed u128 on either
+    /// side. The carry must propagate cleanly into the high half so the raw
+    /// totals shown in the overflow-fallback row remain accurate.
+    #[test]
+    fn balance_changes_propagates_low_half_carry() {
+        let token = felt(ETH);
+        let alice = felt(ALICE);
+        let avnu = felt(AVNU);
+
+        let execute = leaf_call(
+            alice,
+            "__execute__",
+            vec![
+                transfer_event(token, avnu, alice, u128::MAX),
+                transfer_event(token, avnu, alice, 1),
+            ],
+        );
+        let trace = DecodedTrace {
+            execute: Some(execute),
+            ..DecodedTrace::default()
+        };
+        let deltas = trace.collect_transfers().balance_changes();
+        let by_addr: std::collections::HashMap<Felt, &AddressDelta> =
+            deltas.iter().map(|d| (d.address, d)).collect();
+
+        // Alice received u128::MAX + 1 = 2^128, so low wraps to 0 and high = 1.
+        let alice_td = &by_addr[&alice].tokens[0];
+        assert!(alice_td.overflow);
+        assert!(alice_td.net.is_none());
+        assert_eq!(alice_td.received_low, 0, "low half must wrap to 0");
+        assert_eq!(alice_td.received_high, 1, "carry must propagate into high");
+        assert_eq!(alice_td.sent_low, 0);
+        assert_eq!(alice_td.sent_high, 0);
+
+        // Mirrored on the sender side.
+        let avnu_td = &by_addr[&avnu].tokens[0];
+        assert!(avnu_td.overflow);
+        assert!(avnu_td.net.is_none());
+        assert_eq!(avnu_td.sent_low, 0);
+        assert_eq!(avnu_td.sent_high, 1);
+        assert_eq!(avnu_td.received_low, 0);
+        assert_eq!(avnu_td.received_high, 0);
     }
 
     /// A transfer whose value exceeds u128 (value_high != 0) must mark the

--- a/src/ui/views/tx_detail.rs
+++ b/src/ui/views/tx_detail.rs
@@ -2554,8 +2554,8 @@ fn push_balance_changes_section(
     }
 
     // USD magnitude for a token delta — used purely for sort order.
-    // Unpriced or unknown-decimals tokens get NEG_INFINITY so they sort
-    // after priced ones; overflow rows get 0 (drop to the end as well).
+    // Overflow rows, unpriced tokens, and tokens with unknown decimals all
+    // return NEG_INFINITY so they sort after priced ones.
     let ts = app.tx_detail.block_timestamp;
     let token_magnitude = |td: &TokenDelta| -> f64 {
         let Some(net) = td.net else {

--- a/src/ui/views/tx_detail.rs
+++ b/src/ui/views/tx_detail.rs
@@ -14,7 +14,9 @@ use crate::decode::events::{DecodedEvent, DecodedParam};
 use crate::decode::functions::RawCall;
 use crate::decode::outside_execution;
 use crate::decode::privacy::PrivacySummary;
-use crate::decode::trace::{DecodedTraceCall, MulticallGroup, TransferRow};
+use crate::decode::trace::{
+    AddressDelta, DecodedTraceCall, MulticallGroup, TokenDelta, TransferGroups, TransferRow,
+};
 use crate::ui::theme;
 use crate::ui::widgets::address_color::AddressColorMap;
 use crate::ui::widgets::hex_display::{format_commas, format_fri, format_strk_u128};
@@ -2367,6 +2369,10 @@ fn build_transfers_lines(
         );
     }
 
+    push_balance_changes_section(
+        app, color_map, registry, selected, line_map, &groups, &mut lines,
+    );
+
     lines
 }
 
@@ -2517,6 +2523,209 @@ fn push_transfer_row(
     {
         let amount_f64 = low as f64 / 10f64.powi(d as i32);
         let (today, historic) = price::token_prices(app, &row.token, app.tx_detail.block_timestamp);
+        if today.is_some() || historic.is_some() {
+            spans.push(Span::styled(
+                format_usd_pair(amount_f64, today, historic),
+                theme::SUGGESTION_STYLE,
+            ));
+        }
+    }
+
+    lines.push(Line::from(spans));
+}
+
+/// Append a Balance Changes summary under the per-transfer sections: one
+/// block per participating address with per-token net deltas (+ received,
+/// − sent) and USD pricing, reusing the same formatters as transfer rows.
+/// Skipped silently when there are no net deltas.
+#[allow(clippy::too_many_arguments)]
+fn push_balance_changes_section(
+    app: &App,
+    color_map: &AddressColorMap,
+    registry: Option<&crate::registry::AddressRegistry>,
+    selected: Option<&TxNavItem>,
+    line_map: &mut [Option<u16>],
+    groups: &TransferGroups,
+    lines: &mut Vec<Line<'static>>,
+) {
+    let deltas = groups.balance_changes();
+    if deltas.is_empty() {
+        return;
+    }
+
+    // USD magnitude for a token delta — used purely for sort order.
+    // Unpriced or unknown-decimals tokens get NEG_INFINITY so they sort
+    // after priced ones; overflow rows get 0 (drop to the end as well).
+    let ts = app.tx_detail.block_timestamp;
+    let token_magnitude = |td: &TokenDelta| -> f64 {
+        let Some(net) = td.net else {
+            return f64::NEG_INFINITY;
+        };
+        let Some(d) = registry.and_then(|r| r.get_decimals(&td.token)) else {
+            return f64::NEG_INFINITY;
+        };
+        let (today, historic) = price::token_prices(app, &td.token, ts);
+        let Some(p) = today.or(historic) else {
+            return f64::NEG_INFINITY;
+        };
+        let amount = net.unsigned_abs() as f64 / 10f64.powi(d as i32);
+        (amount * p).abs()
+    };
+
+    // Sort tokens within each address by |USD| desc; compute per-address
+    // total |USD| for the outer address sort, with first-appearance index
+    // as the tiebreak for fully-unpriced addresses.
+    let mut indexed: Vec<(usize, AddressDelta, f64)> = deltas
+        .into_iter()
+        .enumerate()
+        .map(|(idx, mut ad)| {
+            ad.tokens.sort_by(|a, b| {
+                token_magnitude(b)
+                    .partial_cmp(&token_magnitude(a))
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            let total: f64 = ad
+                .tokens
+                .iter()
+                .map(token_magnitude)
+                .filter(|m| m.is_finite())
+                .sum();
+            (idx, ad, total)
+        })
+        .collect();
+    indexed.sort_by(|a, b| {
+        b.2.partial_cmp(&a.2)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.0.cmp(&b.0))
+    });
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        " Balance Changes",
+        theme::TITLE_STYLE,
+    )));
+
+    for (_, ad, _) in indexed {
+        push_balance_address_header(&ad, app, color_map, selected, line_map, lines);
+        let n = ad.tokens.len();
+        for (i, td) in ad.tokens.iter().enumerate() {
+            let is_last = i == n - 1;
+            let branch = if is_last { "└─" } else { "├─" };
+            push_balance_token_row(
+                &ad.address,
+                td,
+                branch,
+                app,
+                color_map,
+                registry,
+                selected,
+                line_map,
+                lines,
+            );
+        }
+    }
+}
+
+/// Render the header line for one address in the Balance Changes block.
+fn push_balance_address_header(
+    ad: &AddressDelta,
+    app: &App,
+    color_map: &AddressColorMap,
+    selected: Option<&TxNavItem>,
+    line_map: &mut [Option<u16>],
+    lines: &mut Vec<Line<'static>>,
+) {
+    let label = fmt_addr(app, &ad.address);
+    let style = addr_style(&ad.address, color_map, selected);
+    record(
+        &TxNavItem::Address(ad.address),
+        lines.len(),
+        line_map,
+        &app.tx_detail.nav_items,
+        &app.tx_detail.nav_sections,
+        NavSection::Transfers,
+    );
+    let mut spans: Vec<Span<'static>> = vec![
+        addr_marker(&ad.address, selected),
+        Span::raw(" "),
+        Span::styled(label, style),
+    ];
+    if ad.address == Felt::ZERO {
+        spans.push(Span::styled(" (mint/burn)", theme::SUGGESTION_STYLE));
+    }
+    lines.push(Line::from(spans));
+}
+
+/// Render one token-delta row under an address in the Balance Changes block.
+#[allow(clippy::too_many_arguments)]
+fn push_balance_token_row(
+    addr: &Felt,
+    td: &TokenDelta,
+    branch: &str,
+    app: &App,
+    color_map: &AddressColorMap,
+    registry: Option<&crate::registry::AddressRegistry>,
+    selected: Option<&TxNavItem>,
+    line_map: &mut [Option<u16>],
+    lines: &mut Vec<Line<'static>>,
+) {
+    let token_label = fmt_addr(app, &td.token);
+    let token_style = addr_style(&td.token, color_map, selected);
+    let decimals = registry.and_then(|r| r.get_decimals(&td.token));
+
+    record(
+        &TxNavItem::Address(td.token),
+        lines.len(),
+        line_map,
+        &app.tx_detail.nav_items,
+        &app.tx_detail.nav_sections,
+        NavSection::Transfers,
+    );
+
+    let mut spans: Vec<Span<'static>> = vec![
+        addr_marker_any(&[&td.token, addr], selected),
+        Span::styled(format!(" {branch} "), theme::BORDER_STYLE),
+    ];
+
+    if td.overflow {
+        // Rare: u256 > 2^128 somewhere in the sum. Fall back to raw totals
+        // since signed arithmetic can't represent the difference cleanly.
+        spans.push(Span::styled("± ", theme::SUGGESTION_STYLE));
+        spans.push(Span::styled(
+            format!(
+                "received 0x{:x}{:032x}, sent 0x{:x}{:032x}",
+                td.received_high, td.received_low, td.sent_high, td.sent_low
+            ),
+            theme::TX_HASH_STYLE,
+        ));
+        spans.push(Span::raw("  "));
+        spans.push(Span::styled(token_label, token_style));
+        lines.push(Line::from(spans));
+        return;
+    }
+
+    let net = td.net.expect("non-overflow row carries a net delta");
+    let sign_style = if net >= 0 {
+        theme::STATUS_OK
+    } else {
+        theme::STATUS_ERROR
+    };
+    let sign = if net >= 0 { "+" } else { "-" };
+    let magnitude = net.unsigned_abs();
+    let amount_str = match decimals {
+        Some(d) => crate::ui::widgets::param_display::format_token_amount(magnitude, 0, d),
+        None => magnitude.to_string(),
+    };
+
+    spans.push(Span::styled(format!("{sign}{amount_str}"), sign_style));
+    spans.push(Span::raw("  "));
+    spans.push(Span::styled(token_label, token_style));
+
+    // USD pair shown unsigned — the +/− on the amount already conveys direction,
+    // and matches how per-transfer rows render USD (always positive magnitude).
+    if let Some(d) = decimals {
+        let amount_f64 = magnitude as f64 / 10f64.powi(d as i32);
+        let (today, historic) = price::token_prices(app, &td.token, app.tx_detail.block_timestamp);
         if today.is_some() || historic.is_some() {
             spans.push(Span::styled(
                 format_usd_pair(amount_f64, today, historic),


### PR DESCRIPTION
## Summary

- The Transfers tab currently shows a play-by-play of every ERC20 Transfer event — useful for tracing flow, less useful for *"how did each address end up?"*
- Adds a **Balance Changes** section below the existing sections: one block per participating address, one row per (address, token) with the signed net delta and the same USD pair we already show on per-transfer rows
- Aggregator lives on `TransferGroups::balance_changes()` in `src/decode/trace.rs` and reuses `format_token_amount` / `token_prices` / `format_usd_pair` from the renderer side so units stay consistent

## Behavior

- Sort: addresses by sum of |USD| desc; tokens within each address by |USD| desc; first-appearance breaks ties for unpriced tokens
- Fee transfers are included — the sender's STRK/ETH delta reflects the true end-of-tx balance
- `0x0` is rendered with a dim `(mint/burn)` annotation
- `+` colored green, `−` colored red (existing `STATUS_OK` / `STATUS_ERROR` styles)
- USD shown unsigned in the bracket since the colored sign already conveys direction (matches the per-transfer-row convention)
- u256 sums that exceed `i128` fall back to raw `received 0x… / sent 0x…` instead of a single net (rare path; correctness over prettiness)
- Zero net deltas and self-transfers (`from == to`) are dropped

## Test plan

- [x] `cargo build` and `cargo build --release` clean
- [x] `cargo fmt` + `cargo clippy --all-targets` clean
- [x] `cargo test --lib` — all 236 unit tests pass, including 5 new ones for the aggregator: two-leg swap, round-trip drops to empty, mint from `0x0`, fee-phase inclusion, u256 overflow flag
- [ ] Manual TUI check on a known multi-hop swap: confirm the Balance Changes section appears below the fee transfer, signs are correct, USD totals match the transfer rows above, `(mint/burn)` shows on the right tx, and visual mode `v` still highlights addresses through the summary block

🤖 Generated with [Claude Code](https://claude.com/claude-code)