### PR TITLE
Fix tx fee breakdown and unify time-ago formatter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,22 @@
 [workspace]
 members = [".", "crates/pf-query"]
+# Only build the snbeat binary by default. pf-query is a separate companion
+# service with its own (heavy) dep tree (axum, rayon, tower-http, zstd,
+# bincode, primitive-types, …). Skipping it by default keeps a plain
+# `cargo build` / `cargo build --release` from compiling all of that into
+# `target/`. Build it explicitly when needed: `cargo build -p pf-query`.
+default-members = ["."]
+
+# Compilation speed is a non-goal here — we prioritize a small, fast binary.
+# `lto = "fat"` + `codegen-units = 1` enable whole-program optimization,
+# which prunes dead code across crate boundaries (smaller binary) and lets
+# the optimizer inline more aggressively (faster runtime). `strip` removes
+# debug + linker symbols from the final binary. These are the standard
+# release-binary settings; expect release builds in the multi-minute range.
+[profile.release]
+lto = "fat"
+codegen-units = 1
+strip = "symbols"
 
 [package]
 name = "snbeat"

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -179,6 +179,9 @@ pub enum Action {
         /// Detected outside executions: (call_index, parsed_info).
         outside_executions: Vec<(usize, OutsideExecutionInfo)>,
         block_timestamp: Option<u64>,
+        /// Block-level gas prices in FRI: (L1, L2, L1-Data). Optional in
+        /// case the block fetch fails; the fee view then falls back to 0.
+        block_gas_prices_fri: Option<(u128, u128, u128)>,
     },
     /// Decoded execution trace for a transaction (recursive call tree).
     /// Sent after TransactionLoaded so the user sees the rest of the view

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1177,6 +1177,7 @@ impl App {
                 decoded_calls,
                 outside_executions,
                 block_timestamp,
+                block_gas_prices_fri,
             } => {
                 self.tx_detail.transaction = Some(transaction);
                 self.tx_detail.receipt = Some(receipt);
@@ -1184,6 +1185,7 @@ impl App {
                 self.tx_detail.decoded_calls = decoded_calls;
                 self.tx_detail.outside_executions = outside_executions;
                 self.tx_detail.block_timestamp = block_timestamp;
+                self.tx_detail.block_gas_prices_fri = block_gas_prices_fri;
                 self.tx_detail.events_scroll = 0;
                 self.tx_detail.calls_scroll = 0;
                 self.tx_detail.trace_scroll = 0;

--- a/src/app/views/tx_detail.rs
+++ b/src/app/views/tx_detail.rs
@@ -125,6 +125,10 @@ pub struct TxDetailState {
     /// Whether to show the expanded outside execution intent view.
     pub show_outside_execution: bool,
     pub block_timestamp: Option<u64>,
+    /// Block-level gas prices in FRI (L1, L2, L1-Data). Captured alongside
+    /// the tx so the fee section renders correctly even when the user opens
+    /// the tx without first visiting the block view.
+    pub block_gas_prices_fri: Option<(u128, u128, u128)>,
 }
 
 impl TxDetailState {
@@ -151,6 +155,7 @@ impl TxDetailState {
         self.nav_cursor = 0;
         self.nav_item_lines = Vec::new();
         self.block_timestamp = None;
+        self.block_gas_prices_fri = None;
     }
 
     /// Build the list of navigable items for the current transaction.

--- a/src/network/transaction.rs
+++ b/src/network/transaction.rs
@@ -163,9 +163,20 @@ pub(super) async fn decode_and_send_transaction(
     )
     .await;
 
-    // Fetch block timestamp (used for age display and price lookups on tracked tokens).
-    // Block fetches are cached, so repeat calls for the same block are cheap.
-    let block_timestamp = ds.get_block(block).await.ok().map(|b| b.timestamp);
+    // Fetch block (cached) — provides the timestamp for age display + tracked-token
+    // price lookups, AND the per-lane gas prices the fee section needs to compute
+    // resources = sum(block_price × gas_used). The fee section can't rely on
+    // `app.block_detail.block` because the user may have opened the tx directly
+    // (search, history) without ever visiting the block view.
+    let block_info = ds.get_block(block).await.ok();
+    let block_timestamp = block_info.as_ref().map(|b| b.timestamp);
+    let block_gas_prices_fri = block_info.as_ref().map(|b| {
+        (
+            b.l1_gas_price_fri,
+            b.l2_gas_price_fri,
+            b.l1_data_gas_price_fri,
+        )
+    });
 
     let tx_hash = transaction.hash();
     let _ = action_tx.send(Action::TransactionLoaded {
@@ -175,6 +186,7 @@ pub(super) async fn decode_and_send_transaction(
         decoded_calls,
         outside_executions,
         block_timestamp,
+        block_gas_prices_fri,
     });
 
     // Fire-and-forget trace fetch. Sent as a separate Action so the rest of

--- a/src/ui/views/address_info.rs
+++ b/src/ui/views/address_info.rs
@@ -733,25 +733,7 @@ fn truncate_to(label: &str, max: usize) -> String {
     format!("{head}…")
 }
 
-fn format_age(timestamp: u64) -> String {
-    if timestamp == 0 {
-        return String::new();
-    }
-    let now = chrono::Utc::now().timestamp() as u64;
-    if timestamp > now {
-        return "now".to_string();
-    }
-    let diff = now - timestamp;
-    if diff < 60 {
-        format!("{diff}s")
-    } else if diff < 3600 {
-        format!("{}m", diff / 60)
-    } else if diff < 86400 {
-        format!("{}h", diff / 3600)
-    } else {
-        format!("{}d", diff / 86400)
-    }
-}
+use crate::ui::widgets::hex_display::format_age_short as format_age;
 
 fn draw_calls_tab(f: &mut Frame, app: &mut App, area: Rect) {
     // Column headers

--- a/src/ui/views/block_detail.rs
+++ b/src/ui/views/block_detail.rs
@@ -7,7 +7,9 @@ use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 use crate::app::App;
 use crate::ui::theme;
 use crate::ui::widgets::address_color::{AddressColorMap, known_or_palette_style};
-use crate::ui::widgets::hex_display::{format_fee, format_fri, short_hash, tx_hash_cell};
+use crate::ui::widgets::hex_display::{
+    format_age_short, format_fee, format_fri, short_hash, tx_hash_cell,
+};
 use crate::ui::widgets::{search_bar, status_bar};
 use crate::utils::felt_to_u64;
 
@@ -39,17 +41,10 @@ fn draw_header(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         }
     };
 
-    let age = {
-        let now = chrono::Utc::now().timestamp() as u64;
-        let diff = now.saturating_sub(block.timestamp);
-        if diff < 60 {
-            format!("{diff}s ago")
-        } else if diff < 3600 {
-            format!("{}m ago", diff / 60)
-        } else {
-            format!("{}h ago", diff / 3600)
-        }
-    };
+    let age = format!("{} ago", format_age_short(block.timestamp));
+    let timestamp_utc = chrono::DateTime::from_timestamp(block.timestamp as i64, 0)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+        .unwrap_or_else(|| block.timestamp.to_string());
 
     let lines = vec![
         Line::from(vec![
@@ -62,7 +57,7 @@ fn draw_header(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         ]),
         Line::from(vec![
             Span::styled(" Timestamp: ", theme::NORMAL_STYLE),
-            Span::raw(format!("{} ({})", block.timestamp, age)),
+            Span::raw(format!("{} ({})", timestamp_utc, age)),
         ]),
         Line::from(vec![
             Span::styled(" Sequencer: ", theme::NORMAL_STYLE),

--- a/src/ui/views/block_detail.rs
+++ b/src/ui/views/block_detail.rs
@@ -8,7 +8,7 @@ use crate::app::App;
 use crate::ui::theme;
 use crate::ui::widgets::address_color::{AddressColorMap, known_or_palette_style};
 use crate::ui::widgets::hex_display::{
-    format_age_short, format_fee, format_fri, short_hash, tx_hash_cell,
+    format_age_ago, format_fee, format_fri, short_hash, tx_hash_cell,
 };
 use crate::ui::widgets::{search_bar, status_bar};
 use crate::utils::felt_to_u64;
@@ -41,7 +41,7 @@ fn draw_header(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         }
     };
 
-    let age = format!("{} ago", format_age_short(block.timestamp));
+    let age = format_age_ago(block.timestamp);
     let timestamp_utc = chrono::DateTime::from_timestamp(block.timestamp as i64, 0)
         .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
         .unwrap_or_else(|| block.timestamp.to_string());

--- a/src/ui/views/blocks.rs
+++ b/src/ui/views/blocks.rs
@@ -6,7 +6,7 @@ use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 
 use crate::app::App;
 use crate::ui::theme;
-use crate::ui::widgets::hex_display::{format_age_short, format_fri, short_hash};
+use crate::ui::widgets::hex_display::{format_age_ago, format_fri, short_hash};
 use crate::ui::widgets::{search_bar, status_bar};
 
 pub fn draw(f: &mut Frame, app: &mut App) {
@@ -57,7 +57,7 @@ fn draw_block_list(f: &mut Frame, app: &mut App, area: Rect) {
         .items
         .iter()
         .map(|block| {
-            let age = format_age(block.timestamp);
+            let age = format_age_ago(block.timestamp);
             let sequencer = app.format_address(&block.sequencer_address);
             let l2_gas = format_fri(block.l2_gas_price_fri);
             let l1_gas = format_fri(block.l1_gas_price_fri);
@@ -93,12 +93,4 @@ fn draw_block_list(f: &mut Frame, app: &mut App, area: Rect) {
         .highlight_symbol(">> ");
 
     f.render_stateful_widget(list, list_area, &mut app.blocks.state);
-}
-
-fn format_age(timestamp: u64) -> String {
-    let now = chrono::Utc::now().timestamp() as u64;
-    if timestamp > now {
-        return "just now".to_string();
-    }
-    format!("{} ago", format_age_short(timestamp))
 }

--- a/src/ui/views/blocks.rs
+++ b/src/ui/views/blocks.rs
@@ -6,7 +6,7 @@ use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 
 use crate::app::App;
 use crate::ui::theme;
-use crate::ui::widgets::hex_display::{format_fri, short_hash};
+use crate::ui::widgets::hex_display::{format_age_short, format_fri, short_hash};
 use crate::ui::widgets::{search_bar, status_bar};
 
 pub fn draw(f: &mut Frame, app: &mut App) {
@@ -100,14 +100,5 @@ fn format_age(timestamp: u64) -> String {
     if timestamp > now {
         return "just now".to_string();
     }
-    let diff = now - timestamp;
-    if diff < 60 {
-        format!("{diff}s ago")
-    } else if diff < 3600 {
-        format!("{}m ago", diff / 60)
-    } else if diff < 86400 {
-        format!("{}h ago", diff / 3600)
-    } else {
-        format!("{}d ago", diff / 86400)
-    }
+    format!("{} ago", format_age_short(timestamp))
 }

--- a/src/ui/views/tx_detail.rs
+++ b/src/ui/views/tx_detail.rs
@@ -20,7 +20,7 @@ use crate::decode::trace::{
 use crate::ui::theme;
 use crate::ui::widgets::address_color::AddressColorMap;
 use crate::ui::widgets::hex_display::{
-    format_age_short, format_commas, format_fri, format_strk_u128,
+    format_age_ago, format_commas, format_fri, format_strk_u128,
 };
 use crate::ui::widgets::{param_display, price, search_bar, status_bar};
 use crate::utils::felt_to_u128;
@@ -472,7 +472,14 @@ fn build_header_lines(
     let age_suffix = app
         .tx_detail
         .block_timestamp
-        .map(|ts| format!("  ({} ago)", format_age_short(ts)))
+        .map(|ts| {
+            let s = format_age_ago(ts);
+            if s.is_empty() {
+                String::new()
+            } else {
+                format!("  ({s})")
+            }
+        })
         .unwrap_or_default();
     record(
         &TxNavItem::Block(blk_num),
@@ -825,8 +832,8 @@ fn build_header_lines(
         let resource_fee_fri = block_gas
             .map(|(l1_p, l2_p, l1d_p)| {
                 l1_p.saturating_mul(res.l1_gas as u128)
-                    + l2_p.saturating_mul(res.l2_gas as u128)
-                    + l1d_p.saturating_mul(res.l1_data_gas as u128)
+                    .saturating_add(l2_p.saturating_mul(res.l2_gas as u128))
+                    .saturating_add(l1d_p.saturating_mul(res.l1_data_gas as u128))
             })
             .unwrap_or(0);
         let tip_paid_fri = total_fri.saturating_sub(resource_fee_fri);

--- a/src/ui/views/tx_detail.rs
+++ b/src/ui/views/tx_detail.rs
@@ -19,7 +19,9 @@ use crate::decode::trace::{
 };
 use crate::ui::theme;
 use crate::ui::widgets::address_color::AddressColorMap;
-use crate::ui::widgets::hex_display::{format_commas, format_fri, format_strk_u128};
+use crate::ui::widgets::hex_display::{
+    format_age_short, format_commas, format_fri, format_strk_u128,
+};
 use crate::ui::widgets::{param_display, price, search_bar, status_bar};
 use crate::utils::felt_to_u128;
 
@@ -470,19 +472,7 @@ fn build_header_lines(
     let age_suffix = app
         .tx_detail
         .block_timestamp
-        .map(|ts| {
-            let now = chrono::Utc::now().timestamp() as u64;
-            let diff = now.saturating_sub(ts);
-            if diff < 60 {
-                format!("  ({diff}s ago)")
-            } else if diff < 3600 {
-                format!("  ({}m ago)", diff / 60)
-            } else if diff < 86400 {
-                format!("  ({}h ago)", diff / 3600)
-            } else {
-                format!("  ({}d ago)", diff / 86400)
-            }
-        })
+        .map(|ts| format!("  ({} ago)", format_age_short(ts)))
         .unwrap_or_default();
     record(
         &TxNavItem::Block(blk_num),
@@ -802,15 +792,17 @@ fn build_header_lines(
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(" Fee Info", theme::TITLE_STYLE)));
 
-    // Block gas prices
-    if let Some(block) = &app.block_detail.block {
+    // Block gas prices — captured into tx_detail so this works even when the
+    // user opens the tx directly (without going through the block view).
+    let block_gas = app.tx_detail.block_gas_prices_fri;
+    if let Some((l1_price, l2_price, l1_data_price)) = block_gas {
         lines.push(Line::from(vec![
             Span::styled("   Block Gas:  ", theme::NORMAL_STYLE),
             Span::raw(format!(
                 "L1: {}  L2: {}  L1-Data: {}",
-                format_fri(block.l1_gas_price_fri),
-                format_fri(block.l2_gas_price_fri),
-                format_fri(block.l1_data_gas_price_fri),
+                format_fri(l1_price),
+                format_fri(l2_price),
+                format_fri(l1_data_price),
             )),
         ]));
     }
@@ -826,9 +818,18 @@ fn build_header_lines(
     // Actual fee
     if let Some(receipt) = &app.tx_detail.receipt {
         let total_fri = felt_to_u128(&receipt.actual_fee);
-        // tip is per-L2-gas (FRI/gas); actual tip paid = tip * l2_gas_used
-        let tip_paid_fri = (tip as u128) * (receipt.execution_resources.l2_gas as u128);
-        let resource_fee_fri = total_fri.saturating_sub(tip_paid_fri);
+        let res = &receipt.execution_resources;
+        // Resources = sum(block_price * gas_used). For reverted-due-to-gas txs the
+        // sequencer bills on max_amount rather than receipt.l2_gas, so any
+        // over-charge falls into the tip line below (= total - resources).
+        let resource_fee_fri = block_gas
+            .map(|(l1_p, l2_p, l1d_p)| {
+                l1_p.saturating_mul(res.l1_gas as u128)
+                    + l2_p.saturating_mul(res.l2_gas as u128)
+                    + l1d_p.saturating_mul(res.l1_data_gas as u128)
+            })
+            .unwrap_or(0);
+        let tip_paid_fri = total_fri.saturating_sub(resource_fee_fri);
 
         lines.push(Line::from(vec![
             Span::styled("   Total Fee:  ", theme::NORMAL_STYLE),
@@ -847,20 +848,9 @@ fn build_header_lines(
             Span::raw(format_fri(tip as u128)),
             Span::styled("  (Tip/gas)", theme::SUGGESTION_STYLE),
         ]));
-
-        let res = &receipt.execution_resources;
-        lines.push(Line::from(vec![
-            Span::styled("   Gas Used:   ", theme::NORMAL_STYLE),
-            Span::raw(format!(
-                "L1: {}  L2: {}  L1-Data: {}",
-                format_commas(res.l1_gas),
-                format_commas(res.l2_gas),
-                format_commas(res.l1_data_gas),
-            )),
-        ]));
     }
 
-    // Resource bounds
+    // Resource bounds (used / requested)
     let rb = match tx {
         SnTransaction::Invoke(i) => i.resource_bounds.as_ref(),
         SnTransaction::Declare(d) => d.resource_bounds.as_ref(),
@@ -868,23 +858,38 @@ fn build_header_lines(
         _ => None,
     };
     if let Some(rb) = rb {
+        let (l1_used, l2_used, l1_data_used) = app
+            .tx_detail
+            .receipt
+            .as_ref()
+            .map(|r| {
+                (
+                    r.execution_resources.l1_gas,
+                    r.execution_resources.l2_gas,
+                    r.execution_resources.l1_data_gas,
+                )
+            })
+            .unwrap_or((0, 0, 0));
+
         lines.push(Line::from(Span::styled(
-            "   Resource Bounds (requested)",
+            "   Resource Bounds (used / requested)",
             theme::SUGGESTION_STYLE,
         )));
+        let pair =
+            |used: u64, max: u64| format!("{} / {}", format_commas(used), format_commas(max));
         lines.push(Line::from(vec![Span::raw(format!(
-            "     L1:      max_amount={:<14} max_price={}",
-            format_commas(rb.l1_gas_max_amount),
+            "     L1:      {:<28} max_price={}",
+            pair(l1_used, rb.l1_gas_max_amount),
             format_fri(rb.l1_gas_max_price)
         ))]));
         lines.push(Line::from(vec![Span::raw(format!(
-            "     L2:      max_amount={:<14} max_price={}",
-            format_commas(rb.l2_gas_max_amount),
+            "     L2:      {:<28} max_price={}",
+            pair(l2_used, rb.l2_gas_max_amount),
             format_fri(rb.l2_gas_max_price)
         ))]));
         lines.push(Line::from(vec![Span::raw(format!(
-            "     L1-Data: max_amount={:<14} max_price={}",
-            format_commas(rb.l1_data_gas_max_amount),
+            "     L1-Data: {:<28} max_price={}",
+            pair(l1_data_used, rb.l1_data_gas_max_amount),
             format_fri(rb.l1_data_gas_max_price)
         ))]));
     }

--- a/src/ui/widgets/hex_display.rs
+++ b/src/ui/widgets/hex_display.rs
@@ -80,6 +80,39 @@ pub fn tx_hash_cell(label: Option<&str>, hash: &Felt) -> String {
     }
 }
 
+/// Format a unix timestamp as a compact "time since" string: `"3s"`,
+/// `"42m"`, `"5h"`, `"6d"`, `"4mo"`, `"2y"`. Returns the bare form (no
+/// trailing " ago") so callers can wrap it for prose or drop it straight
+/// into a tight column. `0` → empty string, future timestamps → `"now"`.
+pub fn format_age_short(timestamp: u64) -> String {
+    if timestamp == 0 {
+        return String::new();
+    }
+    let now = chrono::Utc::now().timestamp() as u64;
+    if timestamp > now {
+        return "now".to_string();
+    }
+    const MINUTE: u64 = 60;
+    const HOUR: u64 = 60 * MINUTE;
+    const DAY: u64 = 24 * HOUR;
+    const MONTH: u64 = 30 * DAY;
+    const YEAR: u64 = 365 * DAY;
+    let diff = now - timestamp;
+    if diff < MINUTE {
+        format!("{diff}s")
+    } else if diff < HOUR {
+        format!("{}m", diff / MINUTE)
+    } else if diff < DAY {
+        format!("{}h", diff / HOUR)
+    } else if diff < MONTH {
+        format!("{}d", diff / DAY)
+    } else if diff < YEAR {
+        format!("{}mo", diff / MONTH)
+    } else {
+        format!("{}y", diff / YEAR)
+    }
+}
+
 /// Format a u128 fri value as STRK amount (5 decimal places).
 pub fn format_strk_u128(fri: u128) -> String {
     if fri == 0 {

--- a/src/ui/widgets/hex_display.rs
+++ b/src/ui/widgets/hex_display.rs
@@ -113,6 +113,20 @@ pub fn format_age_short(timestamp: u64) -> String {
     }
 }
 
+/// Format a unix timestamp as a "time since" string with the right suffix:
+/// `"3s ago"`, `"4mo ago"`, `"now"` (future timestamps — clock skew or
+/// pre-confirmed blocks), `""` (timestamp of 0). Wraps `format_age_short`
+/// so callers don't accidentally produce `"now ago"` when the local clock
+/// runs behind a block timestamp.
+pub fn format_age_ago(timestamp: u64) -> String {
+    let short = format_age_short(timestamp);
+    if short.is_empty() || short == "now" {
+        short
+    } else {
+        format!("{short} ago")
+    }
+}
+
 /// Format a u128 fri value as STRK amount (5 decimal places).
 pub fn format_strk_u128(fri: u128) -> String {
     if fri == 0 {


### PR DESCRIPTION
## Summary

- **Tx detail Fee Info**: resources were computed as `total_fee − tip × receipt.l2_gas`, so any sequencer over-charge (e.g. an L2-gas-exhaust revert where billing happens on `max_amount` rather than on consumed gas) ended up inflating the "resources" line. Switch to `resources = Σ(block_price × gas_used)` and `tip = total − resources` — exact for successful txs, and for OOG reverts the gap correctly surfaces in the tip line instead of in resources.
- Capture block-level gas prices into `tx_detail` state (the network task already fetches the block for the timestamp), so the fee section renders even when the user jumps straight to a tx via search/history without ever opening the block view (previously `app.block_detail.block` was `None` and resources displayed as `0`).
- Drop the standalone `Gas Used` row and fold per-lane consumed values into `Resource Bounds (used / requested)` so the ratio is readable at a glance.
- Replace four duplicated `format_age` implementations with a single `format_age_short` helper that extends past days into months/years, so old timestamps stop reading as `3034h ago`.

## Test plan

- [ ] Open a successful V3 invoke tx — `Total Fee = tip + resources` holds, `tip` matches `tip_rate × l2_used`.
- [ ] Open an L2-gas-exhaust reverted tx — `resources ≈ block_l2_price × receipt.l2_gas` (small), `tip` absorbs the over-charge, total adds up to `receipt.actual_fee`.
- [ ] Jump directly to a tx (e.g. via the search bar) without visiting its block first — Block Gas row and resources value both populate.
- [ ] Resource Bounds row shows `used / requested` per lane and lines up with `max_price`.
- [ ] Block detail / blocks list / tx detail / address activity all render ages with month/year units for old timestamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)