### PR TITLE
perf(dune): poll execution results immediately with backoff

### DIFF
--- a/src/network/dune.rs
+++ b/src/network/dune.rs
@@ -631,10 +631,16 @@ impl DuneClient {
                     break Err(format!("Dune query {} failed: {}", query_id, status.state));
                 }
                 _ => {
-                    if tokio::time::Instant::now() >= deadline {
+                    let now = tokio::time::Instant::now();
+                    if now >= deadline {
                         break Err("Dune query timed out (120s)".into());
                     }
-                    tokio::time::sleep(delay).await;
+                    // Cap the sleep to the remaining budget so a final
+                    // pre-sleep deadline check just under the cap can't
+                    // push wall-clock past 120s by up to a full `delay`
+                    // window (~2s at steady state).
+                    let remaining = deadline.duration_since(now);
+                    tokio::time::sleep(delay.min(remaining)).await;
                     delay = (delay * 2).min(Duration::from_secs(2));
                 }
             }

--- a/src/network/dune.rs
+++ b/src/network/dune.rs
@@ -597,14 +597,16 @@ impl DuneClient {
             .map_err(|e| format!("Dune execute parse failed: {e}"))?;
 
         let execution_id = &exec_resp.execution_id;
-        let mut attempts = 0;
+        // Poll immediately, then back off exponentially (250ms → 2s cap).
+        // Light queries (COUNT probes) complete in well under a second, so a
+        // fixed pre-poll sleep put a hard ~2s latency floor on every Dune
+        // fetch. The 120s overall deadline is unchanged.
         // Archive runs from `_archive_guard`'s Drop impl so the query is
         // cleaned up on every exit path (success, polling failure, future
         // cancellation, error early-return).
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(120);
+        let mut delay = Duration::from_millis(250);
         loop {
-            tokio::time::sleep(Duration::from_secs(2)).await;
-            attempts += 1;
-
             let status: ExecutionStatusResponse = self
                 .client
                 .get(format!(
@@ -629,9 +631,11 @@ impl DuneClient {
                     break Err(format!("Dune query {} failed: {}", query_id, status.state));
                 }
                 _ => {
-                    if attempts > 60 {
+                    if tokio::time::Instant::now() >= deadline {
                         break Err("Dune query timed out (120s)".into());
                     }
+                    tokio::time::sleep(delay).await;
+                    delay = (delay * 2).min(Duration::from_secs(2));
                 }
             }
         }


### PR DESCRIPTION
## Summary
- `execute_sql` slept a fixed 2s before the first results poll, putting a hard ~2s latency floor on every Dune fetch.
- Poll immediately, then back off exponentially (250ms → 500ms → 1s → 2s cap). Overall 120s deadline preserved.

Closes #52

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo clippy` clean
- [ ] Manual: open a cold address in snbeat and confirm the activity-probe + windowed queries return noticeably faster than before