### PR TITLE
perf(http): add timeouts to Dune, Voyager, and prices HTTP clients

### DIFF
--- a/src/network/dune.rs
+++ b/src/network/dune.rs
@@ -132,8 +132,18 @@ impl AddressActivityProbe {
 
 impl DuneClient {
     pub fn new(api_key: String, is_private: bool) -> Self {
+        // Without timeouts, a hung connection wedges the poll loop
+        // indefinitely — the overall 120s deadline in `execute_sql` only
+        // counts *completed* polls. Match PF's posture: cap each request
+        // at 60s (enough for result fetches on large windows), 10s to
+        // even open a connection.
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(60))
+            .build()
+            .expect("Failed to build Dune reqwest client");
         Self {
-            client: reqwest::Client::new(),
+            client,
             api_key,
             is_private,
         }

--- a/src/network/prices.rs
+++ b/src/network/prices.rs
@@ -7,7 +7,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::{LazyLock, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use chrono::{DateTime, NaiveDate, Utc};
 use rusqlite::{Connection, params};
@@ -81,8 +81,16 @@ impl PriceClient {
         )
         .map_err(|e| format!("Failed to init token_prices table: {e}"))?;
 
+        // Bound HTTP latency so a hung DefiLlama call can't stall the
+        // price-fetch path. DefiLlama is usually sub-second; 20s is
+        // generous enough for spikes.
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(20))
+            .build()
+            .map_err(|e| format!("Failed to build price reqwest client: {e}"))?;
         Ok(Self {
-            client: reqwest::Client::new(),
+            client,
             db: Mutex::new(db),
         })
     }

--- a/src/network/voyager.rs
+++ b/src/network/voyager.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use rusqlite::{Connection, params};
 use serde::Deserialize;
@@ -158,8 +158,15 @@ impl VoyagerClient {
         )
         .map_err(|e| format!("Failed to init voyager_labels table: {e}"))?;
 
+        // Bound HTTP latency: without these a hung connection holds a
+        // semaphore permit forever and starves every other label fetch.
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|e| format!("Failed to build Voyager reqwest client: {e}"))?;
         Ok(Self {
-            client: reqwest::Client::new(),
+            client,
             api_key,
             db: Mutex::new(db),
             sem: Semaphore::new(MAX_CONCURRENT_FETCHES),


### PR DESCRIPTION
## Summary
- All three external HTTP clients were built with `reqwest::Client::new()` — no connect or request timeout. A hung connection stalls the owning task indefinitely.
- Match the PF client's posture (already 30s timeout): 10s connect on all three; per-request 60s for Dune (large result fetches), 30s for Voyager, 20s for prices (DefiLlama is sub-second).

Closes #54

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo clippy --all-targets` clean
- [ ] Manual smoke: app starts, Dune/Voyager/prices fetches succeed against live endpoints