### PR TITLE
perf(rpc): reuse provider connection pool in get_recent_blocks

### DIFF
--- a/src/data/rpc.rs
+++ b/src/data/rpc.rs
@@ -320,28 +320,20 @@ impl DataSource for RpcDataSource {
         let start = latest.saturating_sub(count as u64 - 1);
         let mut blocks = Vec::with_capacity(count);
 
-        // Fetch blocks in parallel batches
-        let mut handles = Vec::new();
-        for num in start..=latest {
-            let provider = JsonRpcClient::new(HttpTransport::new(
-                Url::parse(&self.rpc_url).expect("invalid RPC URL"),
-            ));
-            handles.push(tokio::spawn(async move {
-                let result = provider
+        // Fan out via `join_all` over `&self.provider` instead of building a
+        // fresh `JsonRpcClient<HttpTransport>` (and therefore a fresh reqwest
+        // connection pool) per block. With 30 blocks on a cold start the old
+        // form did 30 separate TCP+TLS handshakes; this reuses one keep-alive
+        // pool for all of them.
+        let futs = (start..=latest).map(|num| async move {
+            (
+                num,
+                self.provider
                     .get_block_with_txs(BlockId::Number(num), None)
-                    .await;
-                (num, result)
-            }));
-        }
-
-        let mut results = Vec::with_capacity(handles.len());
-        for handle in handles {
-            results.push(
-                handle
-                    .await
-                    .map_err(|e| SnbeatError::Other(e.to_string()))?,
-            );
-        }
+                    .await,
+            )
+        });
+        let mut results: Vec<_> = futures::future::join_all(futs).await;
 
         // Sort by block number descending (newest first)
         results.sort_by(|a, b| b.0.cmp(&a.0));

--- a/src/data/rpc.rs
+++ b/src/data/rpc.rs
@@ -315,9 +315,16 @@ impl DataSource for RpcDataSource {
     }
 
     async fn get_recent_blocks(&self, count: usize) -> Result<Vec<SnBlock>> {
+        if count == 0 {
+            return Ok(Vec::new());
+        }
         let latest = self.get_latest_block_number().await?;
         debug!(latest, count, "RPC: fetching recent blocks");
-        let start = latest.saturating_sub(count as u64 - 1);
+        // count >= 1 here, so the subtraction can't underflow. The
+        // previous `count as u64 - 1` wrapped when count==0 (silently
+        // producing u64::MAX and then a saturating_sub to 0, which
+        // tried to fetch every block from 0..=latest).
+        let start = latest.saturating_sub((count as u64).saturating_sub(1));
         let mut blocks = Vec::with_capacity(count);
 
         // Fan out via `join_all` over `&self.provider` instead of building a


### PR DESCRIPTION
## Summary
- `get_recent_blocks` built a fresh `JsonRpcClient<HttpTransport>` (and therefore a fresh `reqwest::Client` with an empty connection pool) per block. On a 30-block cold start that meant 30 separate TCP+TLS handshakes against the RPC host.
- Fan out via `futures::future::join_all` over `&self.provider`. reqwest's Client is internally Arc'd, so concurrent requests share its connection pool. Also drops the per-block `tokio::spawn` overhead.

Closes #56

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo clippy --all-targets` clean
- [ ] Manual: cold-start the binary and confirm initial 30-block fetch is faster than before