### PR TITLE
perf(address): run endpoint-enrichment chunks concurrently while streaming

### DIFF
--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -2721,17 +2721,36 @@ async fn enrich_all_empty_endpoints(
         missing.len()
     );
 
-    // Process in batches of 20 for streaming UI updates.
-    for (i, chunk) in missing.chunks(20).enumerate() {
-        info!(
-            batch = i + 1,
-            size = chunk.len(),
-            "Sanity check endpoints: enriching batch {}/{}",
-            i + 1,
-            missing.len().div_ceil(20)
-        );
-        enrich_address_txs(address, chunk.to_vec(), ds, pf, abi_reg, action_tx).await;
-    }
+    // Process in batches of 20 for streaming UI updates. Run up to 3
+    // chunks concurrently so the second batch's pf-query fetch is
+    // already in flight by the time the first finishes — chunks were
+    // previously fully serialised, so 60 missing txs paid 3 back-to-back
+    // round trips. Per-chunk emits still happen (each future calls
+    // `enrich_address_txs` which dispatches its own `AddressTxsEnriched`
+    // action on completion), so progressive rendering is preserved;
+    // ordering across chunks is moot because the UI merges by tx hash.
+    use futures::stream::StreamExt;
+    const MAX_PARALLEL_CHUNKS: usize = 3;
+    let total_batches = missing.len().div_ceil(20);
+    let chunks: Vec<_> = missing
+        .chunks(20)
+        .enumerate()
+        .map(|(i, c)| (i, c.to_vec()))
+        .collect();
+    futures::stream::iter(chunks)
+        .map(|(i, chunk)| async move {
+            info!(
+                batch = i + 1,
+                size = chunk.len(),
+                "Sanity check endpoints: enriching batch {}/{}",
+                i + 1,
+                total_batches
+            );
+            enrich_address_txs(address, chunk, ds, pf, abi_reg, action_tx).await;
+        })
+        .buffer_unordered(MAX_PARALLEL_CHUNKS)
+        .collect::<Vec<_>>()
+        .await;
 }
 
 /// Fetch all txs sent by `address` from specific blocks, skipping any already in `known_txs`.


### PR DESCRIPTION
## Summary
- `enrich_all_empty_endpoints` processed missing-endpoint txs in chunks of 20, awaiting each chunk before the next. With `ENRICH_BUFFER=200` that's up to 10 sequential round trips.
- Switch to `futures::stream::buffer_unordered(3)`: up to 3 chunks in flight at once, so the next chunk's pf-query is already started before the previous completes.
- Per-chunk progressive emits preserved — each `enrich_address_txs` still dispatches its own `AddressTxsEnriched` action — and cross-chunk ordering is moot because the UI merges by tx hash.

Closes #62

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo clippy --all-targets` clean
- [ ] Manual: open an address with many INVOKE txs missing endpoint names; confirm the Txs tab fills in faster while still streaming progressively