### PR TITLE
perf(address): recent contract calls first, backfill lifetime history in background

### DIFF
--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -3958,8 +3958,8 @@ pub(super) async fn fetch_address_contract_calls(
     // the `block_number BETWEEN` range and fails with QUERY_STATE_FAILED on
     // dense contracts. A 1-day UTC cushion guards against the cached row
     // sitting right before a day boundary.
-    let cached_calls = ds.load_cached_address_calls(&address);
-    let newest_cached_pair = cached_calls
+    let newest_cached_pair = ds
+        .load_cached_address_calls(&address)
         .iter()
         .filter(|c| c.block_number > 0)
         .max_by_key(|c| c.block_number)
@@ -4038,7 +4038,76 @@ pub(super) async fn fetch_address_contract_calls(
         None => None,
     };
 
-    let plan = pick_calls_dune_query(newest_cached_pair, deploy_floor, deploy_floor_ts);
+    // Warm cache: only fetch blocks newer than the highest cached row
+    // (TopDelta), reusing the cached row's date as a partition hint. One query,
+    // then emit.
+    if newest_cached_pair.is_some() {
+        let plan = pick_calls_dune_query(newest_cached_pair, deploy_floor, deploy_floor_ts);
+        match run_calls_dune_plan(&plan, dune_client, address, CONTRACT_CALL_LIMIT).await {
+            Ok(dune_calls) => {
+                persist_and_emit_calls(
+                    address, dune_calls, abi_reg, ds, pf, action_tx, nonce, class_hash,
+                )
+                .await
+            }
+            Err(e) => {
+                warn!(addr = %format!("{:#x}", address), error = %e, "Calls: Dune contract calls fetch failed")
+            }
+        }
+        return;
+    }
+
+    // Cold cache: show the recent tail FIRST. `starknet.calls` is partitioned by
+    // `block_date`, so a recent date floor prunes to a handful of partitions and
+    // returns in a few seconds — versus the deploy-scoped query below, which
+    // scans the contract's entire lifetime (deploy..tip) and can take 30s+ on a
+    // long-lived contract. Render recent calls immediately, then backfill older
+    // history only if the recent window didn't already fill a page (active
+    // contracts skip the expensive scan; older calls load via pagination).
+    const RECENT_CALLS_DAYS: i64 = 14;
+    let recent_min_date =
+        chrono::Utc::now().date_naive() - chrono::Duration::days(RECENT_CALLS_DAYS);
+    let recent_from = deploy_floor.unwrap_or(0);
+    let recent_filled = match dune_client
+        .query_contract_calls_windowed(
+            address,
+            recent_from,
+            u64::MAX,
+            CONTRACT_CALL_LIMIT,
+            Some(recent_min_date),
+        )
+        .await
+    {
+        Ok(recent) => {
+            let filled = recent.len() as u32 >= CONTRACT_CALL_LIMIT;
+            info!(
+                addr = %format!("{:#x}", address),
+                recent_calls = recent.len(),
+                recent_days = RECENT_CALLS_DAYS,
+                "Calls: recent-window first paint"
+            );
+            persist_and_emit_calls(
+                address, recent, abi_reg, ds, pf, action_tx, nonce, class_hash,
+            )
+            .await;
+            filled
+        }
+        Err(e) => {
+            warn!(addr = %format!("{:#x}", address), error = %e, "Calls: recent-window query failed; falling back to full backfill");
+            false
+        }
+    };
+
+    // Recent window already filled a page → older calls load via pagination;
+    // skip the expensive lifetime scan.
+    if recent_filled {
+        return;
+    }
+
+    // Backfill older history: deploy-scoped (deploy..tip with the deploy date as
+    // partition hint) or, if the deploy block/date is unknown, the legacy
+    // unwindowed query.
+    let plan = pick_calls_dune_query(None, deploy_floor, deploy_floor_ts);
     if let CallsDuneQuery::DeployScoped {
         from_block,
         min_date,
@@ -4048,22 +4117,43 @@ pub(super) async fn fetch_address_contract_calls(
             addr = %format!("{:#x}", address),
             from_block,
             ?min_date,
-            "Calls: cold-cache windowed Dune query (deploy-scoped)"
+            "Calls: cold-cache backfill Dune query (deploy-scoped)"
         );
     }
-    let dune_calls_result = match plan {
+    match run_calls_dune_plan(&plan, dune_client, address, CONTRACT_CALL_LIMIT).await {
+        Ok(dune_calls) => {
+            info!(
+                addr = %format!("{:#x}", address),
+                calls = dune_calls.len(),
+                "Calls: Dune contract calls backfill complete"
+            );
+            persist_and_emit_calls(
+                address, dune_calls, abi_reg, ds, pf, action_tx, nonce, class_hash,
+            )
+            .await
+        }
+        Err(e) => {
+            warn!(addr = %format!("{:#x}", address), error = %e, "Calls: Dune contract calls backfill failed")
+        }
+    }
+}
+
+/// Execute the chosen [`CallsDuneQuery`] variant against Dune and return the
+/// raw rows. Shared by the warm-cache TopDelta path and the cold-cache
+/// deploy-scoped backfill.
+async fn run_calls_dune_plan(
+    plan: &CallsDuneQuery,
+    dune_client: &Arc<dune::DuneClient>,
+    address: starknet::core::types::Felt,
+    limit: u32,
+) -> Result<Vec<crate::data::types::ContractCallSummary>, String> {
+    match plan {
         CallsDuneQuery::TopDelta {
             from_block,
             min_date,
         } => {
             dune_client
-                .query_contract_calls_windowed(
-                    address,
-                    from_block,
-                    u64::MAX,
-                    CONTRACT_CALL_LIMIT,
-                    min_date,
-                )
+                .query_contract_calls_windowed(address, *from_block, u64::MAX, limit, *min_date)
                 .await
         }
         CallsDuneQuery::DeployScoped {
@@ -4073,47 +4163,44 @@ pub(super) async fn fetch_address_contract_calls(
             dune_client
                 .query_contract_calls_windowed(
                     address,
-                    from_block,
+                    *from_block,
                     u64::MAX,
-                    CONTRACT_CALL_LIMIT,
-                    Some(min_date),
+                    limit,
+                    Some(*min_date),
                 )
                 .await
         }
-        CallsDuneQuery::Unwindowed => {
-            dune_client
-                .query_contract_calls(address, CONTRACT_CALL_LIMIT)
-                .await
-        }
-    };
+        CallsDuneQuery::Unwindowed => dune_client.query_contract_calls(address, limit).await,
+    }
+}
 
-    let dune_calls = match dune_calls_result {
-        Ok(v) => v,
-        Err(e) => {
-            warn!(addr = %format!("{:#x}", address), error = %e, "Calls: Dune contract calls fetch failed");
-            return;
-        }
-    };
-
+/// Enrich raw Dune contract calls, merge with the current cache, persist, and
+/// emit them to the UI. Shared by the recent-window first paint and the
+/// deploy-scoped backfill so each phase streams as soon as it lands. Reloads
+/// the cache on each call so a later phase merges on top of an earlier one.
+#[allow(clippy::too_many_arguments)]
+async fn persist_and_emit_calls(
+    address: starknet::core::types::Felt,
+    dune_calls: Vec<crate::data::types::ContractCallSummary>,
+    abi_reg: &Arc<AbiRegistry>,
+    ds: &Arc<dyn crate::data::DataSource>,
+    pf: Option<&Arc<crate::data::pathfinder::PathfinderClient>>,
+    action_tx: &mpsc::UnboundedSender<Action>,
+    nonce: starknet::core::types::Felt,
+    class_hash: Option<starknet::core::types::Felt>,
+) {
     // Resolve selectors, dedupe, and backfill real sender + fee + timestamp.
     // Dune's `starknet.calls.caller_address` is the immediate caller (often a
     // router like Ekubo), not the outer tx sender; `enrich_dune_calls` replaces
     // it with `fetched_tx.sender()` and fills in fee/timestamp from the receipt.
     let calls = enrich_dune_calls(address, dune_calls, abi_reg, ds, pf, action_tx).await;
 
-    info!(
-        addr = %format!("{:#x}", address),
-        calls = calls.len(),
-        "Calls: Dune contract calls complete"
-    );
-
-    // Merge the freshly fetched rows with whatever we already had cached before
-    // persisting. The windowed TopDelta path only returns rows newer than the
-    // previously seen tip, so writing just `calls` would clobber the bulk of
-    // the cache. Cold-cache path still works: `cached_calls` is empty there,
-    // and `deduplicate_contract_calls` returns the full 500-row set unchanged.
+    // Merge with whatever is already cached before persisting — a windowed
+    // fetch only returns part of the history, so writing just `calls` would
+    // clobber the rest. `deduplicate_contract_calls` collapses overlap between
+    // the recent-window and backfill phases.
     if !calls.is_empty() {
-        let mut merged = cached_calls;
+        let mut merged = ds.load_cached_address_calls(&address);
         merged.extend(calls.iter().cloned());
         let merged = crate::data::types::deduplicate_contract_calls(merged);
         ds.save_address_calls(&address, &merged);

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -3965,84 +3965,12 @@ pub(super) async fn fetch_address_contract_calls(
         .max_by_key(|c| c.block_number)
         .map(|c| (c.block_number, c.timestamp));
 
-    // Cold-cache path: resolve a deploy-block floor before deciding the Dune
-    // query variant. Sources, in order: cached deploy_info → cached
-    // class_history → pf class-history (~500ms) → Voyager label (~600ms).
-    // Either pf or voyager unblocks the deploy-scoped query; the cold path
-    // works against RPC + Voyager alone when pf isn't wired up.
-    let mut deploy_floor: Option<u64> = None;
-    if newest_cached_pair.is_none() {
-        deploy_floor = ds
-            .load_cached_deploy_info(&address)
-            .map(|(_, block, _)| block)
-            .or_else(|| {
-                ds.load_cached_class_history(&address)
-                    .iter()
-                    .map(|e| e.block_number)
-                    .min()
-            });
-
-        // PF and Voyager are independent network calls (~500ms and ~600ms
-        // respectively). Run them concurrently rather than awaiting PF and
-        // only then awaiting Voyager on miss — the cold-cache path takes
-        // ~max(pf, voyager) instead of pf+voyager. PF is still preferred:
-        // we use Voyager's deploy_block only when PF returned nothing.
-        if deploy_floor.is_none() {
-            let pf_fut = async {
-                if let Some(pf_client) = pf {
-                    Some(pf_client.get_class_history(address).await)
-                } else {
-                    None
-                }
-            };
-            let voyager_fut = async {
-                if let Some(vc) = voyager_c {
-                    Some(vc.get_label(address).await)
-                } else {
-                    None
-                }
-            };
-            let (pf_result, voyager_result) = tokio::join!(pf_fut, voyager_fut);
-
-            if let Some(Ok(entries)) = &pf_result {
-                if !entries.is_empty() {
-                    ds.save_class_history(&address, entries);
-                }
-                deploy_floor = entries.iter().map(|e| e.block_number).min();
-            } else if let Some(Err(e)) = &pf_result {
-                debug!(
-                    addr = %format!("{:#x}", address),
-                    error = %e,
-                    "Calls: pf class-history fetch failed; trying Voyager"
-                );
-            }
-
-            if deploy_floor.is_none() {
-                match voyager_result {
-                    Some(Ok(label)) => deploy_floor = label.deploy_block,
-                    Some(Err(e)) => debug!(
-                        addr = %format!("{:#x}", address),
-                        error = %e,
-                        "Calls: Voyager label fetch failed"
-                    ),
-                    None => {}
-                }
-            }
-        }
-    }
-
-    // Block timestamp for the deploy floor. `ds.get_block` serves from cache
-    // or falls back to RPC, so this works without pf.
-    let deploy_floor_ts = match deploy_floor {
-        Some(b) => ds.get_block(b).await.ok().map(|blk| blk.timestamp),
-        None => None,
-    };
-
     // Warm cache: only fetch blocks newer than the highest cached row
     // (TopDelta), reusing the cached row's date as a partition hint. One query,
-    // then emit.
+    // then emit. TopDelta needs neither the deploy floor nor a recent probe, so
+    // none is resolved on this path.
     if newest_cached_pair.is_some() {
-        let plan = pick_calls_dune_query(newest_cached_pair, deploy_floor, deploy_floor_ts);
+        let plan = pick_calls_dune_query(newest_cached_pair, None, None);
         match run_calls_dune_plan(&plan, dune_client, address, CONTRACT_CALL_LIMIT).await {
             Ok(dune_calls) => {
                 persist_and_emit_calls(
@@ -4064,14 +3992,19 @@ pub(super) async fn fetch_address_contract_calls(
     // long-lived contract. Render recent calls immediately, then backfill older
     // history only if the recent window didn't already fill a page (active
     // contracts skip the expensive scan; older calls load via pagination).
+    //
+    // This query needs no deploy floor — the recent `block_date` floor does the
+    // pruning and `from_block = 0` is a harmless lower bound — so deploy-floor
+    // resolution (PF/Voyager + block timestamp) is deferred to the backfill
+    // below, keeping first paint off those round-trips and skipping them
+    // entirely when the recent window fills the page.
     const RECENT_CALLS_DAYS: i64 = 14;
     let recent_min_date =
         chrono::Utc::now().date_naive() - chrono::Duration::days(RECENT_CALLS_DAYS);
-    let recent_from = deploy_floor.unwrap_or(0);
     let recent_filled = match dune_client
         .query_contract_calls_windowed(
             address,
-            recent_from,
+            0,
             u64::MAX,
             CONTRACT_CALL_LIMIT,
             Some(recent_min_date),
@@ -4106,7 +4039,10 @@ pub(super) async fn fetch_address_contract_calls(
 
     // Backfill older history: deploy-scoped (deploy..tip with the deploy date as
     // partition hint) or, if the deploy block/date is unknown, the legacy
-    // unwindowed query.
+    // unwindowed query. The deploy floor is resolved here (not before the recent
+    // paint), so its PF/Voyager + block-timestamp round-trips only run when a
+    // backfill is actually needed.
+    let (deploy_floor, deploy_floor_ts) = resolve_deploy_floor(address, ds, pf, voyager_c).await;
     let plan = pick_calls_dune_query(None, deploy_floor, deploy_floor_ts);
     if let CallsDuneQuery::DeployScoped {
         from_block,
@@ -4136,6 +4072,82 @@ pub(super) async fn fetch_address_contract_calls(
             warn!(addr = %format!("{:#x}", address), error = %e, "Calls: Dune contract calls backfill failed")
         }
     }
+}
+
+/// Resolve a contract's deploy-block floor and that block's timestamp — the
+/// partition hint for the deploy-scoped calls backfill. Sources, in order:
+/// cached deploy_info → cached class_history → pf class-history (~500ms) →
+/// Voyager label (~600ms), then the floor block's timestamp (cache or RPC).
+/// PF and Voyager are independent so they run concurrently (`~max` not sum);
+/// PF wins, Voyager's `deploy_block` is the fallback. Only called on the cold
+/// backfill path — the recent-window first paint doesn't need it.
+async fn resolve_deploy_floor(
+    address: starknet::core::types::Felt,
+    ds: &Arc<dyn crate::data::DataSource>,
+    pf: Option<&Arc<crate::data::pathfinder::PathfinderClient>>,
+    voyager_c: Option<&Arc<voyager::VoyagerClient>>,
+) -> (Option<u64>, Option<u64>) {
+    let mut deploy_floor: Option<u64> = ds
+        .load_cached_deploy_info(&address)
+        .map(|(_, block, _)| block)
+        .or_else(|| {
+            ds.load_cached_class_history(&address)
+                .iter()
+                .map(|e| e.block_number)
+                .min()
+        });
+
+    if deploy_floor.is_none() {
+        let pf_fut = async {
+            if let Some(pf_client) = pf {
+                Some(pf_client.get_class_history(address).await)
+            } else {
+                None
+            }
+        };
+        let voyager_fut = async {
+            if let Some(vc) = voyager_c {
+                Some(vc.get_label(address).await)
+            } else {
+                None
+            }
+        };
+        let (pf_result, voyager_result) = tokio::join!(pf_fut, voyager_fut);
+
+        if let Some(Ok(entries)) = &pf_result {
+            if !entries.is_empty() {
+                ds.save_class_history(&address, entries);
+            }
+            deploy_floor = entries.iter().map(|e| e.block_number).min();
+        } else if let Some(Err(e)) = &pf_result {
+            debug!(
+                addr = %format!("{:#x}", address),
+                error = %e,
+                "Calls: pf class-history fetch failed; trying Voyager"
+            );
+        }
+
+        if deploy_floor.is_none() {
+            match voyager_result {
+                Some(Ok(label)) => deploy_floor = label.deploy_block,
+                Some(Err(e)) => debug!(
+                    addr = %format!("{:#x}", address),
+                    error = %e,
+                    "Calls: Voyager label fetch failed"
+                ),
+                None => {}
+            }
+        }
+    }
+
+    // `ds.get_block` serves from cache or falls back to RPC, so this works
+    // without pf.
+    let deploy_floor_ts = match deploy_floor {
+        Some(b) => ds.get_block(b).await.ok().map(|blk| blk.timestamp),
+        None => None,
+    };
+
+    (deploy_floor, deploy_floor_ts)
 }
 
 /// Execute the chosen [`CallsDuneQuery`] variant against Dune and return the

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -4022,7 +4022,7 @@ pub(super) async fn fetch_address_contract_calls(
         .await
     {
         Ok(recent) => {
-            let filled = recent.len() as u32 >= CONTRACT_CALL_LIMIT;
+            let filled = recent.len() >= CONTRACT_CALL_LIMIT as usize;
             info!(
                 addr = %format!("{:#x}", address),
                 recent_calls = recent.len(),

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -3958,8 +3958,8 @@ pub(super) async fn fetch_address_contract_calls(
     // the `block_number BETWEEN` range and fails with QUERY_STATE_FAILED on
     // dense contracts. A 1-day UTC cushion guards against the cached row
     // sitting right before a day boundary.
-    let newest_cached_pair = ds
-        .load_cached_address_calls(&address)
+    let cached_calls = ds.load_cached_address_calls(&address);
+    let newest_cached_pair = cached_calls
         .iter()
         .filter(|c| c.block_number > 0)
         .max_by_key(|c| c.block_number)
@@ -3973,8 +3973,18 @@ pub(super) async fn fetch_address_contract_calls(
         let plan = pick_calls_dune_query(newest_cached_pair, None, None);
         match run_calls_dune_plan(&plan, dune_client, address, CONTRACT_CALL_LIMIT).await {
             Ok(dune_calls) => {
+                // Warm path already loaded the cache for `newest_cached_pair`;
+                // hand it over so the merge doesn't re-read SQLite.
                 persist_and_emit_calls(
-                    address, dune_calls, abi_reg, ds, pf, action_tx, nonce, class_hash,
+                    address,
+                    dune_calls,
+                    Some(cached_calls),
+                    abi_reg,
+                    ds,
+                    pf,
+                    action_tx,
+                    nonce,
+                    class_hash,
                 )
                 .await
             }
@@ -4020,7 +4030,7 @@ pub(super) async fn fetch_address_contract_calls(
                 "Calls: recent-window first paint"
             );
             persist_and_emit_calls(
-                address, recent, abi_reg, ds, pf, action_tx, nonce, class_hash,
+                address, recent, None, abi_reg, ds, pf, action_tx, nonce, class_hash,
             )
             .await;
             filled
@@ -4064,7 +4074,7 @@ pub(super) async fn fetch_address_contract_calls(
                 "Calls: Dune contract calls backfill complete"
             );
             persist_and_emit_calls(
-                address, dune_calls, abi_reg, ds, pf, action_tx, nonce, class_hash,
+                address, dune_calls, None, abi_reg, ds, pf, action_tx, nonce, class_hash,
             )
             .await
         }
@@ -4186,14 +4196,18 @@ async fn run_calls_dune_plan(
     }
 }
 
-/// Enrich raw Dune contract calls, merge with the current cache, persist, and
-/// emit them to the UI. Shared by the recent-window first paint and the
-/// deploy-scoped backfill so each phase streams as soon as it lands. Reloads
-/// the cache on each call so a later phase merges on top of an earlier one.
+/// Enrich raw Dune contract calls, merge with the cache, persist, and emit them
+/// to the UI. Shared by the recent-window first paint and the deploy-scoped
+/// backfill so each phase streams as soon as it lands. `preloaded_cache` lets a
+/// caller that already read the cache (the warm/TopDelta path) skip a redundant
+/// read; pass `None` to reload from the data source — which the cold
+/// recent→backfill phases do, so each merges on top of the previous phase's
+/// saved rows.
 #[allow(clippy::too_many_arguments)]
 async fn persist_and_emit_calls(
     address: starknet::core::types::Felt,
     dune_calls: Vec<crate::data::types::ContractCallSummary>,
+    preloaded_cache: Option<Vec<crate::data::types::ContractCallSummary>>,
     abi_reg: &Arc<AbiRegistry>,
     ds: &Arc<dyn crate::data::DataSource>,
     pf: Option<&Arc<crate::data::pathfinder::PathfinderClient>>,
@@ -4212,7 +4226,7 @@ async fn persist_and_emit_calls(
     // clobber the rest. `deduplicate_contract_calls` collapses overlap between
     // the recent-window and backfill phases.
     if !calls.is_empty() {
-        let mut merged = ds.load_cached_address_calls(&address);
+        let mut merged = preloaded_cache.unwrap_or_else(|| ds.load_cached_address_calls(&address));
         merged.extend(calls.iter().cloned());
         let merged = crate::data::types::deduplicate_contract_calls(merged);
         ds.save_address_calls(&address, &merged);


### PR DESCRIPTION
## What

Cold-cache contract **Calls** loads were blocking for ~30s+ before showing anything. A cold-read log of a long-lived contract (deployed at block 982340) showed the Dune contract-calls query dominating **~37s** of wall time — because the cold path went straight to a **deploy→tip lifetime scan** (`query_contract_calls_windowed(deploy_block, ∞)`) just to return the 500 most-recent calls.

`starknet.calls` is partitioned by `block_date`, so a recent date floor prunes to a handful of partitions and returns in seconds.

## Change (`src/network/address.rs`, `fetch_address_contract_calls`)

Cold-cache path is now recent-window-first:
1. **Query the recent tail first** — last 14 days via a `block_date` floor — and emit immediately. Freshest calls paint in ~2–3s.
2. **Backfill** the deploy-scoped lifetime history only if the recent window did **not** fill a page (active contracts skip the expensive scan; older calls load via the existing pagination).

Warm-cache (TopDelta) path is unchanged. Extracted `run_calls_dune_plan` + `persist_and_emit_calls` so the recent-paint and backfill phases share enrich/merge/cache/emit without duplication.

## Verification

- `cargo build --release` ✓ · `cargo clippy --lib` — no new warnings ✓ · `cargo test --lib network::address` — 13 pass incl. the `pick_calls_dune_query` suite ✓
- **Live Dune** (public ETH token, calls table, medium tier): recent-14d window **2.83s** (500 rows) vs full-history deploy-scoped **12.69s** (500 rows). On a long-lived contract the deploy-scoped scan was ~37s, so the recent window lands in ~2–3s.

## Follow-up

The events **probe** itself (`probe_address_activity` full-history, ~36s) and the `probe_address_activity_delta` / `query_account_txs_windowed` queries still lack `block_date` floors — tracked separately in #80 (Part 2). This PR is the contract-calls (Part 1) piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)