### PR TITLE
perf(address): recent-first MetaTxs fast path via Dune (mirror of Calls)

### DIFF
--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -3667,6 +3667,7 @@ pub(super) async fn fetch_address_meta_txs(
     window_size: u64,
     _limit: u32,
     ds: &Arc<dyn crate::data::DataSource>,
+    dune: Option<&Arc<dune::DuneClient>>,
     pf: &Arc<crate::data::pathfinder::PathfinderClient>,
     abi_reg: &Arc<AbiRegistry>,
     action_tx: &mpsc::UnboundedSender<Action>,
@@ -3740,7 +3741,20 @@ pub(super) async fn fetch_address_meta_txs(
         pf,
         abi_reg,
     );
-    let (outcome_res, private_outcome) = tokio::join!(account_fut, private_fut);
+    // Cold tab entry: paint the most-recent PUBLIC meta-txs via Dune in
+    // parallel with the pf scans (mirrors the Calls fast path). It emits
+    // through the cursor-neutral `AddressMetaTxsStreamed`, so it never disturbs
+    // the pf account/pool pagination this function drives below. On ExtendDown
+    // pages (`continuation_token` = Some) the pf walk already covers older
+    // history, so Dune is not re-run.
+    let dune_fut = async {
+        if continuation_token.is_none() {
+            if let Some(d) = dune {
+                emit_recent_meta_txs_via_dune(address, d, pf, abi_reg, &ds_dyn, action_tx).await;
+            }
+        }
+    };
+    let (outcome_res, private_outcome, _) = tokio::join!(account_fut, private_fut, dune_fut);
     let PrivateDiscoveryOutcome {
         summaries: mut private_summaries,
         pool_min_searched,
@@ -3912,6 +3926,171 @@ pub(super) async fn fetch_address_meta_txs(
         next_token: combined_next_token,
         next_window_size: combined_next_window,
     });
+}
+
+/// Recent-first fast paint of PUBLIC meta-txs via Dune — the MetaTxs analogue
+/// of the Calls progressive window ladder (`fetch_address_contract_calls`).
+///
+/// A meta-tx where `address` is the intender is an `execute_from_outside*`
+/// CALL to `address`, so Dune's trace-indexed `starknet.calls` (selector-
+/// filtered, `ORDER BY block_number DESC`) jumps straight to the most-recent
+/// ones — no pf-query block-walk. Without this the cold MetaTxs tab scans the
+/// 5k-block tip and then walks `ExtendDown` backward one window at a time,
+/// which is slow and surfaces *old* meta-txs first on accounts whose meta-tx
+/// activity sits deep in history.
+///
+/// Runs a narrow (90d) and a wide (365d, hedged) window concurrently, paints
+/// each as it lands, cancels on a full page, then bulk-fetches the matching
+/// outer txs and classifies them. Emits via the cursor-neutral
+/// `AddressMetaTxsStreamed`, so the rows merge into the tab newest-first
+/// WITHOUT touching the pf scan's pagination cursor — the pf account scan +
+/// private-pool discovery still own lifetime backfill and catch what Dune's
+/// selector filter can't see (privacy-sponsored meta-txs; component-based
+/// account selectors that don't equal `starknet_keccak(name)`).
+async fn emit_recent_meta_txs_via_dune(
+    address: starknet::core::types::Felt,
+    dune_client: &Arc<dune::DuneClient>,
+    pf: &Arc<crate::data::pathfinder::PathfinderClient>,
+    abi_reg: &Arc<AbiRegistry>,
+    ds: &Arc<dyn crate::data::DataSource>,
+    action_tx: &mpsc::UnboundedSender<Action>,
+) {
+    use futures::FutureExt;
+    use futures::stream::{FuturesUnordered, StreamExt};
+    use starknet::core::types::Felt;
+
+    // Page size for the recent-first window. Comfortably above the UI's
+    // `AUTO_FILL_TARGET` (50) so a full page also halts the pf auto-fill
+    // walk-down on dense accounts, while staying cheap to fetch + classify.
+    const META_TX_LIMIT: u32 = 100;
+    const RECENT_DAYS: i64 = 90;
+    const WIDE_DAYS: i64 = 365;
+    const WIDE_HEDGE_DELAY: std::time::Duration = std::time::Duration::from_secs(15);
+
+    let today = chrono::Utc::now().date_naive();
+    let recent_min_date = today - chrono::Duration::days(RECENT_DAYS);
+    let wide_min_date = today - chrono::Duration::days(WIDE_DAYS);
+
+    let mut rungs = FuturesUnordered::new();
+    // Narrow recent window: one execution, returns fast → partial first paint.
+    {
+        let d = dune_client.clone();
+        rungs.push(
+            async move {
+                let rows = d
+                    .query_meta_tx_calls_windowed(
+                        address,
+                        0,
+                        u64::MAX,
+                        META_TX_LIMIT,
+                        Some(recent_min_date),
+                    )
+                    .await;
+                (RECENT_DAYS, rows)
+            }
+            .boxed(),
+        );
+    }
+    // Wide window: hedged against Dune's tail latency, fills the page.
+    {
+        let d = dune_client.clone();
+        rungs.push(
+            async move {
+                let rows = hedged_query(
+                    || {
+                        d.query_meta_tx_calls_windowed(
+                            address,
+                            0,
+                            u64::MAX,
+                            META_TX_LIMIT,
+                            Some(wide_min_date),
+                        )
+                    },
+                    WIDE_HEDGE_DELAY,
+                )
+                .await;
+                (WIDE_DAYS, rows)
+            }
+            .boxed(),
+        );
+    }
+
+    // Paint each rung as it lands (the narrow window usually finishes first).
+    // Dedup tx hashes across rungs (365d ⊇ 90d) so the wide rung only fetches
+    // what the narrow one didn't already paint. A full page means we have the
+    // most-recent META_TX_LIMIT meta-txs, so the wider rung can only re-return
+    // the same hashes — cancel it.
+    let mut seen: std::collections::HashSet<Felt> = std::collections::HashSet::new();
+    while let Some((days, result)) = rungs.next().await {
+        match result {
+            Ok(rows) => {
+                let n = rows.len();
+                let fresh: Vec<Felt> = rows
+                    .iter()
+                    .map(|c| c.tx_hash)
+                    .filter(|h| *h != Felt::ZERO && seen.insert(*h))
+                    .collect();
+                info!(
+                    addr = %format!("{:#x}", address),
+                    rung_days = days,
+                    meta_tx_calls = n,
+                    fresh = fresh.len(),
+                    "MetaTxs: Dune ladder rung paint"
+                );
+                paint_meta_tx_hashes(address, &fresh, pf, abi_reg, ds, action_tx).await;
+                if n >= META_TX_LIMIT as usize {
+                    break;
+                }
+            }
+            Err(e) => {
+                warn!(
+                    addr = %format!("{:#x}", address),
+                    rung_days = days,
+                    error = %e,
+                    "MetaTxs: Dune ladder rung query failed"
+                );
+            }
+        }
+    }
+    drop(rungs);
+}
+
+/// Bulk-fetch `hashes` via pf-query, classify each as a meta-tx where
+/// `address` is the intender, then persist + stream the survivors to the UI.
+/// Shared tail of the Dune meta-tx fast-paint ladder; a no-op when `hashes` is
+/// empty or nothing classifies. Persists here (we hold `ds`) because
+/// `AddressMetaTxsStreamed` is a cursor-neutral merge the reducer does not
+/// persist.
+async fn paint_meta_tx_hashes(
+    address: starknet::core::types::Felt,
+    hashes: &[starknet::core::types::Felt],
+    pf: &Arc<crate::data::pathfinder::PathfinderClient>,
+    abi_reg: &Arc<AbiRegistry>,
+    ds: &Arc<dyn crate::data::DataSource>,
+    action_tx: &mpsc::UnboundedSender<Action>,
+) {
+    if hashes.is_empty() {
+        return;
+    }
+    let rows = match pf.get_txs_by_hash(hashes).await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(addr = %format!("{:#x}", address), error = %e, "MetaTxs: pf txs-by-hash fetch failed");
+            return;
+        }
+    };
+    let mut summaries = Vec::new();
+    for row in &rows {
+        if let Some(s) = classify_meta_tx_candidate(address, row, abi_reg).await {
+            summaries.push(s);
+        }
+    }
+    if summaries.is_empty() {
+        return;
+    }
+    sort_meta_txs_recency(&mut summaries);
+    ds.save_meta_txs(&address, &summaries);
+    let _ = action_tx.send(Action::AddressMetaTxsStreamed { address, summaries });
 }
 
 /// Which Dune query variant the calls fetch should issue.
@@ -4383,21 +4562,39 @@ async fn hedged_contract_calls_window(
     limit: u32,
     hedge_delay: std::time::Duration,
 ) -> Result<Vec<crate::data::types::ContractCallSummary>, String> {
-    let first =
-        dune_client.query_contract_calls_windowed(address, 0, u64::MAX, limit, Some(min_date));
-    tokio::pin!(first);
+    hedged_query(
+        || dune_client.query_contract_calls_windowed(address, 0, u64::MAX, limit, Some(min_date)),
+        hedge_delay,
+    )
+    .await
+}
 
+/// Generic tail-latency hedge: run `make_attempt()`, and if it hasn't returned
+/// within `hedge_delay`, fire a second identical attempt and take whichever
+/// finishes first. Dune execution time has a heavy random tail that is
+/// independent per execution, so the odds of both attempts tailing are low —
+/// this collapses the worst case to roughly `hedge_delay` plus a median run,
+/// paying one extra attempt only when the first is already slow. The loser's
+/// poll loop simply stops; safe for side-effect-free reads (a `SELECT`).
+/// `make_attempt` only *builds* the future, so it is cheap to call twice.
+async fn hedged_query<F, Fut, T>(
+    make_attempt: F,
+    hedge_delay: std::time::Duration,
+) -> Result<T, String>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = Result<T, String>>,
+{
+    let first = make_attempt();
+    tokio::pin!(first);
     tokio::select! {
         r = &mut first => r,
         _ = tokio::time::sleep(hedge_delay) => {
             debug!(
-                addr = %format!("{:#x}", address),
-                ?min_date,
                 hedge_delay_s = hedge_delay.as_secs(),
-                "Calls: wide window slow, firing hedged second execution"
+                "hedged_query: first attempt slow, firing hedged second execution"
             );
-            let second = dune_client
-                .query_contract_calls_windowed(address, 0, u64::MAX, limit, Some(min_date));
+            let second = make_attempt();
             tokio::pin!(second);
             tokio::select! {
                 r = &mut first => r,

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -3671,6 +3671,7 @@ pub(super) async fn fetch_address_meta_txs(
     pf: &Arc<crate::data::pathfinder::PathfinderClient>,
     abi_reg: &Arc<AbiRegistry>,
     action_tx: &mpsc::UnboundedSender<Action>,
+    cancel: CancellationToken,
 ) {
     use crate::network::event_window::{
         EXTEND_DOWN_INITIAL_WINDOW, EventWindowPolicy, ensure_address_events_window,
@@ -3741,20 +3742,42 @@ pub(super) async fn fetch_address_meta_txs(
         pf,
         abi_reg,
     );
-    // Cold tab entry: paint the most-recent PUBLIC meta-txs via Dune in
-    // parallel with the pf scans (mirrors the Calls fast path). It emits
-    // through the cursor-neutral `AddressMetaTxsStreamed`, so it never disturbs
-    // the pf account/pool pagination this function drives below. On ExtendDown
-    // pages (`continuation_token` = Some) the pf walk already covers older
-    // history, so Dune is not re-run.
-    let dune_fut = async {
-        if continuation_token.is_none() {
-            if let Some(d) = dune {
-                emit_recent_meta_txs_via_dune(address, d, pf, abi_reg, &ds_dyn, action_tx).await;
-            }
+    // Cold tab entry: paint the most-recent PUBLIC meta-txs via Dune (mirrors
+    // the Calls fast path). It runs CONCURRENTLY with the pf scans for latency
+    // overlap, but as a DETACHED best-effort task — deliberately NOT inside the
+    // `join!` below — so a slow/tailing Dune window (the wide rung can hedge up
+    // to ~15s + a second execution) can't delay the terminal
+    // `AddressMetaTxsLoaded` (spinner-clear / next_token / auto-fill) once the
+    // pf scans have finished. It streams via the cursor-neutral
+    // `AddressMetaTxsStreamed`, so painting rows after the pf merge has already
+    // emitted is harmless. Guarded by the session token so navigating away
+    // cancels it just like it cancels this task. On ExtendDown pages
+    // (`continuation_token` = Some) the pf walk already covers older history, so
+    // Dune is not re-run.
+    if continuation_token.is_none() {
+        if let Some(d) = dune {
+            let d = d.clone();
+            let pf = pf.clone();
+            let abi_reg = abi_reg.clone();
+            let ds_spawn = ds_dyn.clone();
+            let tx_spawn = action_tx.clone();
+            let cancel = cancel.clone();
+            tokio::spawn(async move {
+                tokio::select! {
+                    _ = emit_recent_meta_txs_via_dune(
+                        address, &d, &pf, &abi_reg, &ds_spawn, &tx_spawn,
+                    ) => {}
+                    _ = cancel.cancelled() => {
+                        debug!(
+                            addr = %format!("{:#x}", address),
+                            "MetaTxs: Dune fast-paint cancelled on navigation"
+                        );
+                    }
+                }
+            });
         }
-    };
-    let (outcome_res, private_outcome, _) = tokio::join!(account_fut, private_fut, dune_fut);
+    }
+    let (outcome_res, private_outcome) = tokio::join!(account_fut, private_fut);
     let PrivateDiscoveryOutcome {
         summaries: mut private_summaries,
         pool_min_searched,
@@ -3996,6 +4019,9 @@ async fn emit_recent_meta_txs_via_dune(
         let d = dune_client.clone();
         rungs.push(
             async move {
+                use tracing::Instrument;
+                // Span keeps the generic `hedged_query`'s slow-attempt log
+                // attributable to this address/window (see Calls equivalent).
                 let rows = hedged_query(
                     || {
                         d.query_meta_tx_calls_windowed(
@@ -4008,6 +4034,11 @@ async fn emit_recent_meta_txs_via_dune(
                     },
                     WIDE_HEDGE_DELAY,
                 )
+                .instrument(tracing::debug_span!(
+                    "hedged_meta_tx",
+                    addr = %format!("{:#x}", address),
+                    min_date = %wide_min_date,
+                ))
                 .await;
                 (WIDE_DAYS, rows)
             }
@@ -4025,11 +4056,7 @@ async fn emit_recent_meta_txs_via_dune(
         match result {
             Ok(rows) => {
                 let n = rows.len();
-                let fresh: Vec<Felt> = rows
-                    .iter()
-                    .map(|c| c.tx_hash)
-                    .filter(|h| *h != Felt::ZERO && seen.insert(*h))
-                    .collect();
+                let fresh = fresh_meta_tx_hashes(&rows, &mut seen);
                 info!(
                     addr = %format!("{:#x}", address),
                     rung_days = days,
@@ -4053,6 +4080,25 @@ async fn emit_recent_meta_txs_via_dune(
         }
     }
     drop(rungs);
+}
+
+/// Filter one Dune ladder rung's rows down to the tx hashes not yet painted by
+/// an earlier rung, dropping the zero sentinel. The wide window (365d) is a
+/// superset of the narrow one (90d), so without this cross-rung dedup the wide
+/// rung would re-fetch + re-paint every hash the narrow rung already covered.
+/// `seen` accumulates across rungs and is mutated in place with the hashes this
+/// call returns. Pulled out of `emit_recent_meta_txs_via_dune`'s rung loop as a
+/// pure function so the dedup can be unit-tested without driving live Dune/pf
+/// I/O (see `fresh_meta_tx_hashes_dedups_across_rungs`).
+fn fresh_meta_tx_hashes(
+    rows: &[crate::data::types::ContractCallSummary],
+    seen: &mut std::collections::HashSet<starknet::core::types::Felt>,
+) -> Vec<starknet::core::types::Felt> {
+    use starknet::core::types::Felt;
+    rows.iter()
+        .map(|c| c.tx_hash)
+        .filter(|h| *h != Felt::ZERO && seen.insert(*h))
+        .collect()
 }
 
 /// Bulk-fetch `hashes` via pf-query, classify each as a meta-tx where
@@ -4562,10 +4608,16 @@ async fn hedged_contract_calls_window(
     limit: u32,
     hedge_delay: std::time::Duration,
 ) -> Result<Vec<crate::data::types::ContractCallSummary>, String> {
+    use tracing::Instrument;
+    // Re-scope the hedge to this address/window: `hedged_query` is generic and
+    // logs the "firing hedged second execution" line without any context, so
+    // attach `addr`/`min_date` via a span to keep slow Dune executions
+    // attributable when investigating latency.
     hedged_query(
         || dune_client.query_contract_calls_windowed(address, 0, u64::MAX, limit, Some(min_date)),
         hedge_delay,
     )
+    .instrument(tracing::debug_span!("hedged_calls", addr = %format!("{:#x}", address), ?min_date))
     .await
 }
 
@@ -5749,6 +5801,45 @@ mod tests {
     use super::*;
     use crate::data::rpc::RpcDataSource;
     use starknet::core::types::Felt;
+
+    /// The Dune meta-tx fast paint runs a narrow (90d) and a wide (365d)
+    /// window; the wide window is a superset of the narrow one, so
+    /// `fresh_meta_tx_hashes` must return only the hashes an earlier rung
+    /// hasn't already painted and must drop the zero sentinel. Guards the
+    /// cross-rung dedup pulled out of `emit_recent_meta_txs_via_dune`'s loop.
+    #[test]
+    fn fresh_meta_tx_hashes_dedups_across_rungs() {
+        fn row(h: Felt) -> crate::data::types::ContractCallSummary {
+            crate::data::types::ContractCallSummary {
+                tx_hash: h,
+                sender: Felt::ZERO,
+                function_name: String::new(),
+                block_number: 0,
+                timestamp: 0,
+                total_fee_fri: 0,
+                status: "OK".into(),
+                nonce: None,
+                tip: 0,
+                inner_targets: Vec::new(),
+            }
+        }
+
+        let (a, b, c) = (Felt::from(1u32), Felt::from(2u32), Felt::from(3u32));
+        let mut seen = std::collections::HashSet::new();
+
+        // Narrow rung lands first: returns its unique non-zero hashes in
+        // first-seen order, dropping the zero sentinel and an in-page dup.
+        let narrow = vec![row(a), row(b), row(Felt::ZERO), row(a)];
+        assert_eq!(fresh_meta_tx_hashes(&narrow, &mut seen), vec![a, b]);
+
+        // Wide rung (365d ⊇ 90d) re-returns the narrow hashes plus one new
+        // one; only the genuinely new hash survives the shared `seen` set.
+        let wide = vec![row(a), row(b), row(c)];
+        assert_eq!(fresh_meta_tx_hashes(&wide, &mut seen), vec![c]);
+
+        // `seen` now holds exactly the three distinct non-zero hashes.
+        assert_eq!(seen.len(), 3);
+    }
 
     fn rpc_ds() -> Arc<dyn DataSource> {
         dotenvy::dotenv().ok();

--- a/src/network/dune.rs
+++ b/src/network/dune.rs
@@ -217,6 +217,39 @@ fn min_date_floor(min_block_date: Option<chrono::NaiveDate>) -> String {
         .to_string()
 }
 
+/// Build the fallback (non-persistent) SQL for the windowed meta-tx calls
+/// query — used by `run_shape` whenever the persisted `query_id` is stale or
+/// missing. Mirror of the persisted `QueryShape::ContractMetaTxCallsWindowed`
+/// shape, narrowing `starknet.calls` to the three `execute_from_outside`
+/// selectors. The selector literals MUST stay identical to the persisted copy;
+/// both are pinned against `starknet_keccak` by `meta_tx_sql_has_correct_selectors`
+/// so a drift in either path fails the build.
+fn meta_tx_calls_windowed_sql(
+    contract_hex: &str,
+    min_date: &str,
+    from_block: u64,
+    to_block: u64,
+    limit: u32,
+) -> String {
+    format!(
+        "SELECT transaction_hash, caller_address, entry_point_selector, \
+         block_number, block_time, revert_reason \
+         FROM starknet.calls \
+         WHERE contract_address = {} \
+         AND block_date >= date '{}' \
+         AND block_number BETWEEN {} AND {} \
+         AND call_type = 'CALL' \
+         AND entry_point_selector IN ( \
+           0x007ec457cd7ed1630225a8328f826a29a327b19486f6b2882b4176545ebdbe3d, \
+           0x034cc13b274446654ca3233ed2c1620d4c5d1d32fd20b47146a3371064bdc57d, \
+           0x03dbc508ba4afd040c8dc4ff8a61113a7bcaf5eae88a6ba27b3c50578b3587e3 \
+         ) \
+         ORDER BY block_number DESC \
+         LIMIT {}",
+        contract_hex, min_date, from_block, to_block, limit
+    )
+}
+
 /// Parse Dune `starknet.calls` result rows into [`ContractCallSummary`]s.
 ///
 /// Shared by [`DuneClient::query_contract_calls_windowed`] and its meta-tx
@@ -1014,26 +1047,13 @@ impl DuneClient {
             "to_block": to_capped.to_string(),
             "limit": limit.to_string(),
         });
-        // Mirror of the persisted `ContractMetaTxCallsWindowed` SQL (the literal
-        // selector list must stay identical — `meta_tx_sql_has_correct_selectors`
-        // guards the persisted copy).
-        let sql = format!(
-            "SELECT transaction_hash, caller_address, entry_point_selector, \
-             block_number, block_time, revert_reason \
-             FROM starknet.calls \
-             WHERE contract_address = {} \
-             AND block_date >= date '{}' \
-             AND block_number BETWEEN {} AND {} \
-             AND call_type = 'CALL' \
-             AND entry_point_selector IN ( \
-               0x007ec457cd7ed1630225a8328f826a29a327b19486f6b2882b4176545ebdbe3d, \
-               0x034cc13b274446654ca3233ed2c1620d4c5d1d32fd20b47146a3371064bdc57d, \
-               0x03dbc508ba4afd040c8dc4ff8a61113a7bcaf5eae88a6ba27b3c50578b3587e3 \
-             ) \
-             ORDER BY block_number DESC \
-             LIMIT {}",
-            contract_hex, min_date_str, from_capped, to_capped, limit
-        );
+        // Mirror of the persisted `ContractMetaTxCallsWindowed` SQL. Built via
+        // the shared `meta_tx_calls_windowed_sql` so the selector list lives in
+        // a single place that `meta_tx_sql_has_correct_selectors` pins against
+        // `starknet_keccak` — alongside the persisted copy — preventing the two
+        // from drifting.
+        let sql =
+            meta_tx_calls_windowed_sql(&contract_hex, &min_date_str, from_capped, to_capped, limit);
 
         debug!(contract = %contract_hex, from_block, to_block, from_capped, to_capped, ?min_block_date, "Querying Dune for meta-tx calls (windowed)");
         let rows = self
@@ -1485,10 +1505,17 @@ mod tests {
     /// from the recent-first fast path, so pin each against `starknet_keccak`
     /// of the entry-point name. `{:#066x}` matches the 32-byte (64-hex) form
     /// Dune stores `entry_point_selector` as — and the form the SQL must use.
+    ///
+    /// The literals live in TWO copies — the persisted `sql()` template and the
+    /// `meta_tx_calls_windowed_sql` fallback that `run_shape` uses when the
+    /// persisted `query_id` is stale/missing — so assert BOTH. Checking only
+    /// the persisted copy would let the fallback drift and silently filter on
+    /// the wrong selectors whenever the persistent query is unavailable.
     #[test]
     fn meta_tx_sql_has_correct_selectors() {
         use starknet::core::utils::get_selector_from_name;
-        let sql = QueryShape::ContractMetaTxCallsWindowed.sql();
+        let persisted = QueryShape::ContractMetaTxCallsWindowed.sql();
+        let fallback = meta_tx_calls_windowed_sql("0x0", "2024-01-01", 0, i64::MAX as u64, 100);
         for name in [
             "execute_from_outside",
             "execute_from_outside_v2",
@@ -1496,8 +1523,12 @@ mod tests {
         ] {
             let sel = format!("{:#066x}", get_selector_from_name(name).unwrap());
             assert!(
-                sql.contains(&sel),
-                "meta-tx SQL is missing the selector for {name} ({sel})"
+                persisted.contains(&sel),
+                "persisted meta-tx SQL is missing the selector for {name} ({sel})"
+            );
+            assert!(
+                fallback.contains(&sel),
+                "fallback meta-tx SQL is missing the selector for {name} ({sel})"
             );
         }
     }

--- a/src/network/dune.rs
+++ b/src/network/dune.rs
@@ -28,6 +28,12 @@ enum QueryShape {
     /// Calls TO a contract scoped to a range; also serves the non-windowed
     /// full-history case via an open-ended range (see `query_contract_calls`).
     ContractCallsWindowed,
+    /// Meta-tx calls TO a contract scoped to a range: the `ContractCallsWindowed`
+    /// shape narrowed to the `execute_from_outside*` entry-point selectors. A
+    /// meta-tx where the contract is the intender is exactly such a call to it,
+    /// so this jumps straight to the most-recent meta-txs (see
+    /// `query_meta_tx_calls_windowed`).
+    ContractMetaTxCallsWindowed,
     /// First DECLARE tx for a class hash.
     DeclareTx,
 }
@@ -40,6 +46,7 @@ impl QueryShape {
             QueryShape::AccountTxs => "account_txs",
             QueryShape::AccountTxsWindowed => "account_txs_windowed",
             QueryShape::ContractCallsWindowed => "contract_calls_windowed",
+            QueryShape::ContractMetaTxCallsWindowed => "contract_meta_tx_calls_windowed",
             QueryShape::DeclareTx => "declare_tx",
         }
     }
@@ -54,6 +61,7 @@ impl QueryShape {
             "account_txs" => QueryShape::AccountTxs,
             "account_txs_windowed" => QueryShape::AccountTxsWindowed,
             "contract_calls_windowed" => QueryShape::ContractCallsWindowed,
+            "contract_meta_tx_calls_windowed" => QueryShape::ContractMetaTxCallsWindowed,
             "declare_tx" => QueryShape::DeclareTx,
             _ => return None,
         })
@@ -118,6 +126,31 @@ impl QueryShape {
                  ORDER BY block_number DESC \
                  LIMIT {{limit}}"
             }
+            QueryShape::ContractMetaTxCallsWindowed => {
+                // `ContractCallsWindowed` narrowed to the three
+                // `execute_from_outside` selectors (v1/v2/v3) — a meta-tx where
+                // `contract` is the intender is exactly such a call TO it. The
+                // selector literals are the 32-byte `starknet_keccak` of the
+                // entry-point names; `meta_tx_sql_has_correct_selectors` guards
+                // them against drift. AVNU's `execute_private_sponsored` is NOT
+                // here: it targets the forwarder, not the intender, so it never
+                // matches `contract_address = {{contract}}` (the private-pool
+                // discovery path covers those).
+                "SELECT transaction_hash, caller_address, entry_point_selector, \
+                   block_number, block_time, revert_reason \
+                 FROM starknet.calls \
+                 WHERE contract_address = {{contract}} \
+                 AND block_date >= date '{{min_date}}' \
+                 AND block_number BETWEEN {{from_block}} AND {{to_block}} \
+                 AND call_type = 'CALL' \
+                 AND entry_point_selector IN ( \
+                   0x007ec457cd7ed1630225a8328f826a29a327b19486f6b2882b4176545ebdbe3d, \
+                   0x034cc13b274446654ca3233ed2c1620d4c5d1d32fd20b47146a3371064bdc57d, \
+                   0x03dbc508ba4afd040c8dc4ff8a61113a7bcaf5eae88a6ba27b3c50578b3587e3 \
+                 ) \
+                 ORDER BY block_number DESC \
+                 LIMIT {{limit}}"
+            }
             QueryShape::DeclareTx => {
                 "SELECT hash, sender_address, block_number, block_time \
                  FROM starknet.transactions \
@@ -136,6 +169,7 @@ impl QueryShape {
             QueryShape::AccountTxs => "snbeat_account_txs",
             QueryShape::AccountTxsWindowed => "snbeat_account_txs_windowed",
             QueryShape::ContractCallsWindowed => "snbeat_contract_calls_windowed",
+            QueryShape::ContractMetaTxCallsWindowed => "snbeat_contract_meta_tx_calls_windowed",
             QueryShape::DeclareTx => "snbeat_declare_tx",
         }
     }
@@ -154,7 +188,7 @@ impl QueryShape {
             QueryShape::AccountTxsWindowed => {
                 &["sender", "min_date", "from_block", "to_block", "limit"]
             }
-            QueryShape::ContractCallsWindowed => {
+            QueryShape::ContractCallsWindowed | QueryShape::ContractMetaTxCallsWindowed => {
                 &["contract", "min_date", "from_block", "to_block", "limit"]
             }
             QueryShape::DeclareTx => &["class_hash"],
@@ -181,6 +215,55 @@ fn min_date_floor(min_block_date: Option<chrono::NaiveDate>) -> String {
         .unwrap_or_else(|| chrono::NaiveDate::from_ymd_opt(2021, 1, 1).expect("valid date"))
         .format("%Y-%m-%d")
         .to_string()
+}
+
+/// Parse Dune `starknet.calls` result rows into [`ContractCallSummary`]s.
+///
+/// Shared by [`DuneClient::query_contract_calls_windowed`] and its meta-tx
+/// variant — both SELECT the identical column set. `sender` is set from
+/// `caller_address` (the immediate on-chain caller, often a router); callers
+/// that need the true outer tx sender enrich it downstream.
+fn parse_contract_call_rows(rows: &[serde_json::Value]) -> Vec<ContractCallSummary> {
+    rows.iter()
+        .filter_map(|row| {
+            let tx_hash = Felt::from_hex(row.get("transaction_hash")?.as_str()?).ok()?;
+            let caller = Felt::from_hex(row.get("caller_address")?.as_str()?).ok()?;
+            let selector_hex = row.get("entry_point_selector")?.as_str().unwrap_or("");
+            let function_name = selector_hex.to_string();
+            let block_number = row
+                .get("block_number")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let block_time = row
+                .get("block_time")
+                .and_then(|v| v.as_str())
+                .and_then(|s| {
+                    chrono::DateTime::parse_from_rfc3339(s)
+                        .or_else(|_| chrono::DateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f %Z"))
+                        .ok()
+                })
+                .map(|dt| dt.timestamp() as u64)
+                .unwrap_or(0);
+            let revert = row
+                .get("revert_reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let status = if revert.is_empty() { "OK" } else { "REV" }.to_string();
+
+            Some(ContractCallSummary {
+                tx_hash,
+                sender: caller,
+                function_name,
+                block_number,
+                timestamp: block_time,
+                total_fee_fri: 0,
+                status,
+                nonce: None,
+                tip: 0,
+                inner_targets: Vec::new(),
+            })
+        })
+        .collect()
 }
 
 /// Dune Analytics API client for querying Starknet transaction history.
@@ -901,49 +984,66 @@ impl DuneClient {
             "Dune windowed contract calls query complete"
         );
 
-        Ok(rows
-            .iter()
-            .filter_map(|row| {
-                let tx_hash = Felt::from_hex(row.get("transaction_hash")?.as_str()?).ok()?;
-                let caller = Felt::from_hex(row.get("caller_address")?.as_str()?).ok()?;
-                let selector_hex = row.get("entry_point_selector")?.as_str().unwrap_or("");
-                let function_name = selector_hex.to_string();
-                let block_number = row
-                    .get("block_number")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-                let block_time = row
-                    .get("block_time")
-                    .and_then(|v| v.as_str())
-                    .and_then(|s| {
-                        chrono::DateTime::parse_from_rfc3339(s)
-                            .or_else(|_| {
-                                chrono::DateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f %Z")
-                            })
-                            .ok()
-                    })
-                    .map(|dt| dt.timestamp() as u64)
-                    .unwrap_or(0);
-                let revert = row
-                    .get("revert_reason")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let status = if revert.is_empty() { "OK" } else { "REV" }.to_string();
+        Ok(parse_contract_call_rows(&rows))
+    }
 
-                Some(ContractCallSummary {
-                    tx_hash,
-                    sender: caller,
-                    function_name,
-                    block_number,
-                    timestamp: block_time,
-                    total_fee_fri: 0,
-                    status,
-                    nonce: None,
-                    tip: 0,
-                    inner_targets: Vec::new(),
-                })
-            })
-            .collect())
+    /// Meta-tx variant of [`Self::query_contract_calls_windowed`]: identical
+    /// window/partition handling, but the persisted SQL also filters
+    /// `entry_point_selector` to the three `execute_from_outside` selectors. A
+    /// meta-tx where `contract` is the intender is exactly such a call TO it,
+    /// so this returns the most-recent meta-txs (newest-first) in one indexed
+    /// scan — the recent-first fast path the MetaTxs tab paints before the
+    /// pf-query block-walk backfills the rest. Returns the *outer* tx hashes
+    /// (in `tx_hash`); the caller fetches + classifies them.
+    pub async fn query_meta_tx_calls_windowed(
+        &self,
+        contract: Felt,
+        from_block: u64,
+        to_block: u64,
+        limit: u32,
+        min_block_date: Option<chrono::NaiveDate>,
+    ) -> Result<Vec<ContractCallSummary>, String> {
+        let contract_hex = format!("{:#066x}", contract);
+        let min_date_str = min_date_floor(min_block_date);
+        let from_capped = from_block.min(i64::MAX as u64);
+        let to_capped = to_block.min(i64::MAX as u64);
+        let params = serde_json::json!({
+            "contract": contract_hex,
+            "min_date": min_date_str,
+            "from_block": from_capped.to_string(),
+            "to_block": to_capped.to_string(),
+            "limit": limit.to_string(),
+        });
+        // Mirror of the persisted `ContractMetaTxCallsWindowed` SQL (the literal
+        // selector list must stay identical — `meta_tx_sql_has_correct_selectors`
+        // guards the persisted copy).
+        let sql = format!(
+            "SELECT transaction_hash, caller_address, entry_point_selector, \
+             block_number, block_time, revert_reason \
+             FROM starknet.calls \
+             WHERE contract_address = {} \
+             AND block_date >= date '{}' \
+             AND block_number BETWEEN {} AND {} \
+             AND call_type = 'CALL' \
+             AND entry_point_selector IN ( \
+               0x007ec457cd7ed1630225a8328f826a29a327b19486f6b2882b4176545ebdbe3d, \
+               0x034cc13b274446654ca3233ed2c1620d4c5d1d32fd20b47146a3371064bdc57d, \
+               0x03dbc508ba4afd040c8dc4ff8a61113a7bcaf5eae88a6ba27b3c50578b3587e3 \
+             ) \
+             ORDER BY block_number DESC \
+             LIMIT {}",
+            contract_hex, min_date_str, from_capped, to_capped, limit
+        );
+
+        debug!(contract = %contract_hex, from_block, to_block, from_capped, to_capped, ?min_block_date, "Querying Dune for meta-tx calls (windowed)");
+        let rows = self
+            .run_shape(QueryShape::ContractMetaTxCallsWindowed, params, &sql)
+            .await?;
+        info!(
+            rows = rows.len(),
+            "Dune windowed meta-tx calls query complete"
+        );
+        Ok(parse_contract_call_rows(&rows))
     }
 
     /// Lightweight probe: returns the block range and count of activity for an address.
@@ -1356,6 +1456,7 @@ mod tests {
             QueryShape::AccountTxs,
             QueryShape::AccountTxsWindowed,
             QueryShape::ContractCallsWindowed,
+            QueryShape::ContractMetaTxCallsWindowed,
             QueryShape::DeclareTx,
         ] {
             // Extract every distinct `{{key}}` from the shape's SQL.
@@ -1374,6 +1475,29 @@ mod tests {
                 declared,
                 "shape {} param_keys() != its sql() placeholders",
                 shape.name()
+            );
+        }
+    }
+
+    /// The meta-tx shape hard-codes the three `execute_from_outside` selector
+    /// literals in its SQL (a persisted parameterized query can't compute them
+    /// at runtime). A wrong literal would silently drop a whole meta-tx version
+    /// from the recent-first fast path, so pin each against `starknet_keccak`
+    /// of the entry-point name. `{:#066x}` matches the 32-byte (64-hex) form
+    /// Dune stores `entry_point_selector` as — and the form the SQL must use.
+    #[test]
+    fn meta_tx_sql_has_correct_selectors() {
+        use starknet::core::utils::get_selector_from_name;
+        let sql = QueryShape::ContractMetaTxCallsWindowed.sql();
+        for name in [
+            "execute_from_outside",
+            "execute_from_outside_v2",
+            "execute_from_outside_v3",
+        ] {
+            let sel = format!("{:#066x}", get_selector_from_name(name).unwrap());
+            assert!(
+                sql.contains(&sel),
+                "meta-tx SQL is missing the selector for {name} ({sel})"
             );
         }
     }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -473,6 +473,7 @@ pub async fn run_network_task(
                                 pf,
                                 &abi_reg,
                                 &tx,
+                                cancel.clone(),
                             )
                             .await;
                         } else {

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -469,6 +469,7 @@ pub async fn run_network_task(
                                 window_size,
                                 limit,
                                 &ds,
+                                dune.as_ref(),
                                 pf,
                                 &abi_reg,
                                 &tx,


### PR DESCRIPTION
> Split out of #84 — this is pre-existing work that got bundled into the WS branch when it was cut from a local `master` that was one commit ahead of `origin/master`. It is independent (touches `address.rs` / `dune.rs` / `mod.rs`; no overlap with the WS change).

## Problem

The cold MetaTxs tab scanned the 5k-block tip then walked `ExtendDown` backward one
pf-query window at a time. On accounts whose meta-tx activity sits deep in history that
is slow and surfaces the **oldest** meta-txs first.

## Change

A meta-tx where the address is the intender is an `execute_from_outside*` **call** to the
address, so Dune's trace-indexed `starknet.calls` (selector-filtered, `ORDER BY block DESC`)
jumps straight to the most-recent ones. Adds a Dune fast-paint mirroring the Calls
progressive window ladder:

- **dune**: `QueryShape::ContractMetaTxCallsWindowed` = `ContractCallsWindowed` narrowed to
  the three `execute_from_outside` selectors; shared row parser extracted to avoid
  duplication. Selector literals pinned by a test.
- **address**: `emit_recent_meta_txs_via_dune` runs a 90d + hedged-365d window concurrently
  (cancel-on-fill), bulk-fetches the outer txs via pf, runs the shared classifier, and
  streams survivors via the cursor-neutral `AddressMetaTxsStreamed` so the pf scan still
  owns lifetime backfill and the private-pool / component-selector cases Dune can't see.
  Tail-latency hedge generalised and shared with Calls.

## Verification

- Windowed SQL verified against production Dune (recent-first rows).
- Both new dune guard tests pass; release build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)